### PR TITLE
fix(sync): remove orphaned category dirs from Codex skills mirror

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -643,6 +643,75 @@ def _is_support_dir(item: Path) -> bool:
     return has_md and not has_skill_subdir
 
 
+def _copy_if_changed(item: Path, target: Path) -> bool:
+    """Copy item to target when the two differ. Robust to broken symlinks.
+
+    Skips items whose symlink target is missing (a dangling source link, e.g. a
+    private-voices reference not present on this machine). Treats a dangling
+    destination symlink as "needs copy". Returns True when a copy happened.
+    """
+    # Dangling source symlink — nothing real to copy.
+    if item.is_symlink() and not item.exists():
+        return False
+    target_ok = target.exists() and not (target.is_symlink() and not target.exists())
+    if target_ok and filecmp.cmp(item, target, shallow=False):
+        return False
+    # Replace a dangling destination symlink before copying onto it.
+    if target.is_symlink() and not target.exists():
+        target.unlink()
+    shutil.copy2(item, target)
+    return True
+
+
+def _clean_codex_orphan_categories(repo_skills: Path, codex_skills_dst: Path) -> int:
+    """Remove orphaned category directories from a flat skills mirror.
+
+    The mirror flattens repo skills: repo/skills/content/create-voice/ →
+    <mirror>/create-voice/. An earlier strategy copied the nested category
+    structure verbatim (<mirror>/content/create-voice/), then the strategy
+    switched to flat. Because the mirror is additive-only (never deletes), the
+    old nested copies persist. Codex scans the mirror recursively, so it
+    discovers every skill twice — once flat, once nested.
+
+    Fix uses a structural invariant, not a name list: the flat strategy never
+    creates a top-level directory that itself contains skill subdirectories
+    (child dirs with SKILL.md). So any top-level real dir holding nested
+    SKILL.md is an orphan from the old strategy — including categories that were
+    renamed or removed from the repo (e.g. a former opensearch/ or .system/).
+
+    Preserved, so the additive-only contract holds for anything we do not own:
+      - flat skills (a dir whose own SKILL.md is at the top level)
+      - support dirs (shared-patterns, workflow, kb — reference material)
+      - symlinks (never followed out of the mirror)
+      - dot-directories and Codex-owned trees (e.g. .system/, which carries a
+        .codex-system-skills.marker and holds Codex's native skills)
+      - foreign flat skills a user or Codex created
+
+    Returns the number of orphan category directories removed.
+    """
+    if not repo_skills.is_dir() or not codex_skills_dst.is_dir():
+        return 0
+    removed = 0
+    for entry in codex_skills_dst.iterdir():
+        if entry.is_symlink() or not entry.is_dir():
+            continue
+        if entry.name.startswith("."):
+            continue  # Codex-owned infra (.system/) or hidden — never ours
+        if (entry / "SKILL.md").exists():
+            continue  # a flat skill, not a category
+        if _is_support_dir(entry):
+            continue  # reference material, keep
+        # Never touch a tree a foreign tool marks as its own.
+        if any(m.name.endswith(".marker") for m in entry.iterdir() if m.is_file()):
+            continue
+        # Orphan only if it holds skill subdirectories (nested SKILL.md).
+        has_nested_skill = any(sub.is_dir() and (sub / "SKILL.md").exists() for sub in entry.iterdir())
+        if has_nested_skill:
+            shutil.rmtree(entry)
+            removed += 1
+    return removed
+
+
 def _sync_skills_flat_symlinks(src: Path, dst: Path, repo_root: "Path | list[Path] | None" = None) -> None:
     """Create flat per-skill symlinks from nested category structure.
 
@@ -748,6 +817,13 @@ def _sync_skills_flat_symlinks(src: Path, dst: Path, repo_root: "Path | list[Pat
                 if item.exists():
                     continue  # (b) live and outside all roots — foreign, preserve
             item.unlink()
+
+    # Remove orphaned category directories (real dirs, not symlinks) left by an
+    # earlier nested-copy strategy. The flat-symlink strategy never creates a
+    # category-named top-level dir, so any real one is an orphan. Harmless to
+    # Claude Code (it reads flat depth-1 only) but scoped removal keeps the
+    # mirror clean and prevents recursive scanners from seeing skills twice.
+    _clean_codex_orphan_categories(src, dst)
 
 
 def _is_git_worktree(path: Path) -> bool:
@@ -1248,10 +1324,8 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
                             rel = item.relative_to(repo_skills)
                             target = codex_skills_dst / rel
                             _tolerant_mkdir(target.parent)
-                            if target.exists() and filecmp.cmp(item, target, shallow=False):
-                                continue
-                            shutil.copy2(item, target)
-                            codex_count += 1
+                            if _copy_if_changed(item, target):
+                                codex_count += 1
                 elif child.is_dir() and not child.name.startswith("."):
                     # Category folder: copy each skill inside as a flat entry
                     for skill_dir in sorted(child.iterdir()):
@@ -1265,10 +1339,8 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
                                 rel = item.relative_to(skill_dir)
                                 target = codex_skills_dst / skill_dir.name / rel
                                 _tolerant_mkdir(target.parent)
-                                if target.exists() and filecmp.cmp(item, target, shallow=False):
-                                    continue
-                                shutil.copy2(item, target)
-                                codex_count += 1
+                                if _copy_if_changed(item, target):
+                                    codex_count += 1
         except Exception as e:
             errors.append(f"codex-skills: {e}")
     # Also sync private skills to Codex (same category pattern as ~/.claude/skills)
@@ -1300,9 +1372,17 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
                             codex_count += 1
                 except Exception as e:
                     errors.append(f"codex-private-{deploy_name}: {e}")
-    # No stale cleanup for Codex — additive only. Users or Codex itself may
-    # create skills in ~/.codex/skills/ that we don't own. We only copy ours in;
-    # we never delete theirs.
+    # No stale cleanup for user- or Codex-created skills — additive only. But
+    # remove orphaned category directories left by the previous nested mirror
+    # strategy: Codex scans recursively, so a stale ~/.codex/skills/content/
+    # would list every skill inside it a second time. Scoped to repo category
+    # names only, so foreign skills are never touched.
+    try:
+        orphans = _clean_codex_orphan_categories(repo_skills, codex_skills_dst)
+        if orphans:
+            codex_count += orphans
+    except Exception as e:
+        errors.append(f"codex-skills-cleanup: {e}")
     if codex_count > 0:
         synced.append(f".codex/skills({codex_count} updated)")
     elif codex_skills_dst.is_dir():

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -1201,3 +1201,151 @@ class TestMainInnerWorktreeEndToEnd:
         support_link = user_claude / "skills" / "support-notes"
         assert support_link.is_symlink(), "symlink into main repo must survive"
         assert (main / "skills" / "support-notes" / "pattern.md").exists()
+
+
+class TestCleanCodexOrphanCategories:
+    """Tests for _clean_codex_orphan_categories.
+
+    Reproduces the Codex duplicate-skill bug: an earlier mirror strategy copied
+    the nested category structure (a category dir holding each skill), then the
+    strategy switched to a flat layout (one dir per skill at the top level).
+    Codex scans recursively, so both copies list the skill twice. Cleanup must
+    remove the orphaned category dir while preserving flat skills and foreign
+    entries.
+    """
+
+    def _make_repo_skills(self, root: Path) -> Path:
+        """Repo skills tree: one category (content) holding one skill."""
+        repo_skills = root / "skills"
+        skill = repo_skills / "content" / "create-voice"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: create-voice\n---\nbody\n")
+        return repo_skills
+
+    def test_removes_orphan_category_dir(self, tmp_path: Path) -> None:
+        repo_skills = self._make_repo_skills(tmp_path)
+        codex = tmp_path / "codex-skills"
+        # Flat (current strategy) — must survive.
+        flat = codex / "create-voice"
+        flat.mkdir(parents=True)
+        (flat / "SKILL.md").write_text("flat")
+        # Orphan nested category dir (old strategy) — must be removed.
+        orphan = codex / "content" / "create-voice"
+        orphan.mkdir(parents=True)
+        (orphan / "SKILL.md").write_text("nested")
+
+        removed = sync_mod._clean_codex_orphan_categories(repo_skills, codex)
+
+        assert removed == 1
+        assert not (codex / "content").exists(), "orphan category dir must be removed"
+        assert flat.exists(), "flat skill must be preserved"
+        assert (flat / "SKILL.md").exists()
+
+    def test_preserves_foreign_skill(self, tmp_path: Path) -> None:
+        repo_skills = self._make_repo_skills(tmp_path)
+        codex = tmp_path / "codex-skills"
+        # A user/Codex-created skill whose name is NOT a repo category.
+        foreign = codex / "my-own-skill"
+        foreign.mkdir(parents=True)
+        (foreign / "SKILL.md").write_text("mine")
+
+        removed = sync_mod._clean_codex_orphan_categories(repo_skills, codex)
+
+        assert removed == 0
+        assert foreign.exists(), "foreign skill must never be removed"
+
+    def test_ignores_category_symlink(self, tmp_path: Path) -> None:
+        repo_skills = self._make_repo_skills(tmp_path)
+        codex = tmp_path / "codex-skills"
+        codex.mkdir(parents=True)
+        # A symlink named like a category must not be followed or removed.
+        real = tmp_path / "elsewhere"
+        real.mkdir()
+        (codex / "content").symlink_to(real)
+
+        removed = sync_mod._clean_codex_orphan_categories(repo_skills, codex)
+
+        assert removed == 0
+        assert (codex / "content").is_symlink(), "symlink must be left untouched"
+
+    def test_noop_when_clean(self, tmp_path: Path) -> None:
+        repo_skills = self._make_repo_skills(tmp_path)
+        codex = tmp_path / "codex-skills"
+        flat = codex / "create-voice"
+        flat.mkdir(parents=True)
+        (flat / "SKILL.md").write_text("flat")
+
+        removed = sync_mod._clean_codex_orphan_categories(repo_skills, codex)
+
+        assert removed == 0
+        assert flat.exists()
+
+    def test_missing_dirs_return_zero(self, tmp_path: Path) -> None:
+        assert sync_mod._clean_codex_orphan_categories(tmp_path / "nope", tmp_path / "gone") == 0
+
+    def test_removes_renamed_or_removed_category(self, tmp_path: Path) -> None:
+        # A category the repo no longer has (e.g. opensearch/ folded into
+        # engineering/). Structural rule must still remove it.
+        repo_skills = self._make_repo_skills(tmp_path)
+        codex = tmp_path / "codex-skills"
+        orphan = codex / "opensearch" / "opensearch-detection-engineer"
+        orphan.mkdir(parents=True)
+        (orphan / "SKILL.md").write_text("stale")
+
+        removed = sync_mod._clean_codex_orphan_categories(repo_skills, codex)
+
+        assert removed == 1
+        assert not (codex / "opensearch").exists()
+
+    def test_preserves_marked_foreign_tree(self, tmp_path: Path) -> None:
+        # Codex's own .system/ tree (marker file + nested skills) must survive,
+        # even though it holds nested SKILL.md. Guarded by dot-prefix and marker.
+        repo_skills = self._make_repo_skills(tmp_path)
+        codex = tmp_path / "codex-skills"
+        system = codex / ".system" / "imagegen"
+        system.mkdir(parents=True)
+        (system / "SKILL.md").write_text("codex-native")
+        (codex / ".system" / ".codex-system-skills.marker").write_text("owned")
+
+        removed = sync_mod._clean_codex_orphan_categories(repo_skills, codex)
+
+        assert removed == 0
+        assert (codex / ".system" / "imagegen" / "SKILL.md").exists()
+
+
+class TestCopyIfChanged:
+    """Tests for _copy_if_changed — robust to broken symlinks on both ends."""
+
+    def test_copies_new_file(self, tmp_path: Path) -> None:
+        src = tmp_path / "a.md"
+        src.write_text("hello")
+        dst = tmp_path / "out" / "a.md"
+        dst.parent.mkdir()
+        assert sync_mod._copy_if_changed(src, dst) is True
+        assert dst.read_text() == "hello"
+
+    def test_skips_identical_file(self, tmp_path: Path) -> None:
+        src = tmp_path / "a.md"
+        src.write_text("same")
+        dst = tmp_path / "a-copy.md"
+        dst.write_text("same")
+        assert sync_mod._copy_if_changed(src, dst) is False
+
+    def test_skips_dangling_source_symlink(self, tmp_path: Path) -> None:
+        # Source is a symlink whose target is missing (e.g. a private-voices
+        # reference absent on this machine). Must skip without raising.
+        src = tmp_path / "link.md"
+        src.symlink_to(tmp_path / "missing-target.md")
+        dst = tmp_path / "out.md"
+        assert sync_mod._copy_if_changed(src, dst) is False
+        assert not dst.exists()
+
+    def test_replaces_dangling_dest_symlink(self, tmp_path: Path) -> None:
+        # Destination is a broken symlink from an earlier sync. Must replace it.
+        src = tmp_path / "a.md"
+        src.write_text("fresh")
+        dst = tmp_path / "out.md"
+        dst.symlink_to(tmp_path / "gone.md")
+        assert sync_mod._copy_if_changed(src, dst) is True
+        assert not dst.is_symlink()
+        assert dst.read_text() == "fresh"


### PR DESCRIPTION
## Problem

Codex CLI listed every skill **twice**. `~/.codex/skills` held 386 `SKILL.md` files for 247 real skills — 130 duplicate names.

**Root cause:** the Codex mirror flattens repo skills (`skills/content/create-voice/` → `~/.codex/skills/create-voice/`). An earlier strategy copied the **nested category** structure verbatim (`~/.codex/skills/content/create-voice/`), then switched to flat. The mirror is additive-only (never deletes), so the old nested copies persisted. Codex scans `~/.codex/skills` **recursively**, so it discovered each skill once flat and once nested.

Claude Code was unaffected because it only reads flat depth-1 `~/.claude/skills/*/SKILL.md`; the orphan category dirs were invisible to it. Agents were unaffected (single flat copy each).

## Fix

- **`_clean_codex_orphan_categories`** — removes any top-level dir holding nested `SKILL.md` (the orphan layout the flat strategy never emits). Structural rule, so it also catches renamed/removed categories (e.g. former `opensearch/`). Preserves flat skills, support dirs, symlinks, dot-dirs, and marker-owned trees (**Codex's own `.system/`**, which carries `.codex-system-skills.marker`). Wired into both the Codex mirror and the `.claude` flat-symlink sync, so it **self-heals on every SessionStart** — no manual cleanup for any user.
- **`_copy_if_changed`** — robust copy that skips dangling source symlinks and replaces dangling destination symlinks. Fixes a pre-existing sync error on a broken `private-voices` reference (also present on `main`).

## Validation

| Metric | Before | After |
|---|---|---|
| `~/.codex/skills` SKILL.md | 386 | 253 (247 ours + 6 Codex-native) |
| Duplicate skill names | 130 | 0 real (`skill-creator` = ours + Codex built-in) |
| Orphan category dirs | 14 | 0 |
| Sync errors | 1 | 0 |

- Ran the real syncer against a live `~/.codex`: dedup confirmed, Codex's `.system/` preserved, idempotent (second run reports 0 updates).
- 12 new tests (`TestCleanCodexOrphanCategories`, `TestCopyIfChanged`); 159 sync/codex tests pass.
- `ruff check` and `ruff format --check` clean.
- Verified in a fresh Codex CLI session: each skill lists once; Codex-native skills still work.

## Notes

Two pre-existing test failures (`test_rejects_tmp_path`, `test_blocks_tmp_source`) are environmental (macOS resolves `tmp_path` under `/private/var`, not `/tmp/`) and fail identically on `main` — unrelated to this change.