### PR TITLE
feat(html-artifact): saved-template clone mode + named gallery

### DIFF
--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -274,6 +274,8 @@ External repositories reveal patterns and missing checks. Adoption path: study, 
 
 **Test:** Did the practice arrive rebuilt and tested inside our architecture, or as copied files? Copied files skipped the gate.
 
+Worked example: the OpenAI curated-template skills (20 skills, 27 MB of `.pptx`/`.xlsx`/`.docx` binaries) were studied, not imported. We extracted two practices — clone-don't-regenerate fidelity and the content-vs-layout authority rule — and rebuilt them as `html-artifact` clone mode: one skill, a `templates/saved/` gallery, and `fill-template.py` enforcing the authority rule with exit codes. The 20 skills themselves failed the test on three counts (thin wrappers, host-locked to an Office runtime, 20 copies of one skill), so none were imported. Practice adopted, files rejected. (`skills/meta/html-artifact/scripts/tests/test_fill_template.py`.)
+
 ### One Domain, One Component
 
 System prompt token budget is finite. One domain = one agent/skill + many reference files loaded on demand. Before creating any new agent/skill: check whether an existing component already covers the domain. If it does, add a reference file.

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -274,7 +274,7 @@ External repositories reveal patterns and missing checks. Adoption path: study, 
 
 **Test:** Did the practice arrive rebuilt and tested inside our architecture, or as copied files? Copied files skipped the gate.
 
-Worked example: the OpenAI curated-template skills (20 skills, 27 MB of `.pptx`/`.xlsx`/`.docx` binaries) were studied, not imported. We extracted two practices — clone-don't-regenerate fidelity and the content-vs-layout authority rule — and rebuilt them as `html-artifact` clone mode: one skill, a `templates/saved/` gallery, and `fill-template.py` enforcing the authority rule with exit codes. The 20 skills themselves failed the test on three counts (thin wrappers, host-locked to an Office runtime, 20 copies of one skill), so none were imported. Practice adopted, files rejected. (`skills/meta/html-artifact/scripts/tests/test_fill_template.py`.)
+Worked example: the OpenAI curated-template pack (twenty near-identical `artifact-template-*` entries, 27 MB of `.pptx`/`.xlsx`/`.docx` binaries) was studied, not imported. We extracted two practices — clone-don't-regenerate fidelity and the content-vs-layout authority rule — and rebuilt them as `html-artifact` clone mode: one skill, a saved-template gallery, and a fill script enforcing the authority rule with exit codes (`skills/meta/html-artifact/scripts/fill-template.py`). The pack itself failed the test on three counts (thin wrappers, host-locked to an Office runtime, one skill copied twenty times), so nothing was imported. Practice adopted, files rejected. Test: `skills/meta/html-artifact/scripts/tests/test_fill_template.py`.
 
 ### One Domain, One Component
 

--- a/skills/meta/html-artifact/SKILL.md
+++ b/skills/meta/html-artifact/SKILL.md
@@ -51,6 +51,27 @@ Generate single self-contained `.html` files that replace markdown when the outp
 
 ---
 
+### Phase 0: CHECK SAVED TEMPLATE (clone-first)
+
+Before detecting a shape, check whether the request names or matches a saved template. A saved template is a frozen, human-authored layout; cloning it beats regenerating structure because the layout cannot drift.
+
+Run: `python3 skills/meta/html-artifact/scripts/fill-template.py --list`
+
+If the request names a listed template (e.g. "project kickoff", "business review", "system design") or clearly matches one:
+
+1. Read `templates/saved/<name>.slots.json` to learn the slots.
+2. Generate ONLY the slot content — never the layout, CSS, or chrome.
+3. Write the slot values to a JSON file and run `fill-template.py --template <name> --slots <file> --out <artifact>`.
+4. Skip Phases 1–3 (shape detection, assembly, generation). Go to Phase 4 VALIDATE.
+
+The fill script fails loud on a missing required slot, an undeclared slot name, or a leftover marker. Fix the slot JSON; do not edit the template.
+
+If no saved template matches, continue to Phase 1.
+
+**See "Fidelity & Authority" below for the content-vs-layout rule that governs clone mode.**
+
+---
+
 ### Phase 1: DETECT SHAPE
 
 Classify the user's request into one of 8 artifact shapes.
@@ -403,8 +424,32 @@ This skill uses:
 
 ## Saved Templates
 
-Pre-built, reusable artifact templates for recurring requests. Each pairs a self-contained HTML template (with placeholder tokens and a sample dataset for standalone testing) with a deterministic renderer script that fills in live data.
+Pre-built, reusable artifact templates for recurring requests. Two renderer patterns:
+
+- **Specialized renderer** — a script that fetches live data and fills a bespoke template (`github-issues`).
+- **Generic slot filler** — `scripts/fill-template.py` clones any frozen template in `templates/saved/` and substitutes caller-supplied slot values. One skill, many template files: add a layout, not a skill.
 
 | Template | Renderer | Use For |
 |---|---|---|
 | `templates/saved/github-issues.html` | `scripts/render-github-issues.py` | "show me my GitHub issues" / "show me my tickets" — assigned + mentioned + review-requested across all repos, with per-issue discussion expanders and 5 client-side sort modes |
+| `templates/saved/business-review.html` | `scripts/fill-template.py` | "business review" — KPIs, segment results, priorities, decisions, outlook |
+| `templates/saved/project-kickoff.html` | `scripts/fill-template.py` | "project kickoff" — agenda, foundation, scope, workstreams + owners, milestone gates, decisions, risks |
+| `templates/saved/system-design.html` | `scripts/fill-template.py` | "system design" — requirements, architecture, components, data flow, tradeoffs, operations |
+
+See `templates/saved/README.md` to add a template.
+
+---
+
+## Fidelity & Authority
+
+Governs clone mode (Phase 0). Adapted from the OpenAI curated-template skills, which keep on-brand output by cloning a fixed reference instead of regenerating it.
+
+**Clone, don't regenerate.** When a saved template applies, clone its layout unchanged and fill only the content slots. Do not rebuild the structure, restyle the CSS, or "improve" the chrome. Regeneration is where visual drift and AI slop enter; a frozen template removes that risk.
+
+**Content-vs-layout authority.** One rule resolves every "should I restyle this?" question:
+
+> User instructions control requested content and explicit deviations. The retained template controls layout and formatting where the user has not requested a change.
+
+So: change layout only when the user asks for a layout change. Otherwise the template wins. `fill-template.py` enforces this mechanically — it substitutes slot values and touches nothing else.
+
+**Fail loud, don't degrade.** If a required slot has no content, stop and get the content — do not silently ship a half-filled template. The fill script exits non-zero on a missing required slot, an undeclared slot, or a leftover marker.

--- a/skills/meta/html-artifact/scripts/fill-template.py
+++ b/skills/meta/html-artifact/scripts/fill-template.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Deterministic clone-and-fill for saved html-artifact templates.
+
+Reads a frozen saved template (`templates/saved/<name>.html`) and its slot
+manifest (`templates/saved/<name>.slots.json`), substitutes caller-supplied
+slot values, and writes a finished artifact. The layout, CSS, and chrome are
+never modified: content-vs-layout authority is enforced here, not by prompt
+discipline.
+
+Fail-loud rules (no silent degradation):
+    - Missing required slot            -> exit 1
+    - Provided slot not in manifest    -> exit 1 (catches typos)
+    - Unresolved {{MARKER}} after fill -> exit 1
+
+Exit codes:
+    0: filled and written successfully
+    1: slot validation failure
+    2: template or manifest not found / unreadable
+
+Usage:
+    python3 fill-template.py --template business-review --slots slots.json --out artifact.html
+    python3 fill-template.py --template business-review --slots slots.json           # prints to stdout
+    python3 fill-template.py --list                                                   # list gallery
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+SAVED_DIR = Path(__file__).parent.parent / "templates" / "saved"
+MARKER_RE = re.compile(r"\{\{([A-Z0-9_]+)\}\}")
+
+
+def _fail(msg: str, code: int) -> None:
+    sys.stderr.write(f"Error: {msg}\n")
+    sys.exit(code)
+
+
+def list_templates() -> list[str]:
+    """Return the base names of saved templates that have a slot manifest."""
+    if not SAVED_DIR.exists():
+        return []
+    names = []
+    for html in sorted(SAVED_DIR.glob("*.html")):
+        if (SAVED_DIR / f"{html.stem}.slots.json").exists():
+            names.append(html.stem)
+    return names
+
+
+def load_manifest(name: str) -> dict:
+    """Load and return the slot manifest for a template."""
+    manifest_path = SAVED_DIR / f"{name}.slots.json"
+    if not manifest_path.exists():
+        _fail(f"no slot manifest for template '{name}' at {manifest_path}", 2)
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        _fail(f"manifest for '{name}' is not valid JSON: {e}", 2)
+    if "slots" not in data or not isinstance(data["slots"], list):
+        _fail(f"manifest for '{name}' must contain a 'slots' list", 2)
+    return data
+
+
+def fill_template(name: str, values: dict[str, str]) -> str:
+    """Clone the frozen template and substitute slot values.
+
+    Args:
+        name: Base name of a saved template.
+        values: Mapping of slot name to replacement HTML/text.
+
+    Returns:
+        The finished artifact HTML.
+
+    Exits (non-zero) on any slot validation failure.
+    """
+    html_path = SAVED_DIR / f"{name}.html"
+    if not html_path.exists():
+        _fail(f"template '{name}' not found at {html_path}", 2)
+
+    manifest = load_manifest(name)
+    declared = {s["name"]: s for s in manifest["slots"]}
+
+    # Reject slot names not declared in the manifest — catches typos loudly.
+    unknown = sorted(set(values) - set(declared))
+    if unknown:
+        _fail(f"provided slot(s) not declared in '{name}' manifest: {', '.join(unknown)}", 1)
+
+    # Every required slot must be provided.
+    missing = sorted(s["name"] for s in manifest["slots"] if s.get("required", True) and s["name"] not in values)
+    if missing:
+        _fail(f"missing required slot(s) for '{name}': {', '.join(missing)}", 1)
+
+    html = html_path.read_text(encoding="utf-8")
+
+    # Substitute every declared slot. Optional slots default to empty string so
+    # the marker never survives into the output.
+    for slot_name in declared:
+        replacement = values.get(slot_name, "")
+        html = html.replace(f"{{{{{slot_name}}}}}", replacement)
+
+    # No marker may survive. A leftover means the template has an undeclared
+    # slot — a template bug, not a caller bug.
+    leftover = sorted(set(MARKER_RE.findall(html)))
+    if leftover:
+        _fail(
+            f"unresolved marker(s) remain after fill: {', '.join(leftover)} (declare them in {name}.slots.json)",
+            1,
+        )
+
+    return html
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Clone and fill a saved html-artifact template.")
+    parser.add_argument("--template", help="Base name of a saved template (see --list).")
+    parser.add_argument("--slots", help="Path to a JSON file mapping slot names to values.")
+    parser.add_argument("--out", help="Output path. Prints to stdout if omitted.")
+    parser.add_argument("--list", action="store_true", help="List available saved templates and exit.")
+    args = parser.parse_args()
+
+    if args.list:
+        names = list_templates()
+        if names:
+            sys.stdout.write("\n".join(names) + "\n")
+        else:
+            sys.stdout.write("(no saved templates with manifests)\n")
+        return
+
+    if not args.template:
+        _fail("--template is required (or use --list)", 2)
+    if not args.slots:
+        _fail("--slots is required", 2)
+
+    slots_path = Path(args.slots)
+    if not slots_path.exists():
+        _fail(f"slots file not found: {slots_path}", 2)
+    try:
+        values = json.loads(slots_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        _fail(f"slots file is not valid JSON: {e}", 2)
+    if not isinstance(values, dict):
+        _fail("slots file must be a JSON object mapping slot names to values", 2)
+
+    html = fill_template(args.template, values)
+
+    if args.out:
+        Path(args.out).write_text(html, encoding="utf-8")
+        sys.stdout.write(f"Wrote {args.out} ({len(html)} bytes)\n")
+    else:
+        sys.stdout.write(html)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/meta/html-artifact/scripts/tests/test_fill_template.py
+++ b/skills/meta/html-artifact/scripts/tests/test_fill_template.py
@@ -1,0 +1,147 @@
+"""Tests for fill-template.py — deterministic saved-template clone-and-fill."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+SCRIPT = str(Path(__file__).parent.parent / "fill-template.py")
+SAVED_DIR = Path(__file__).parent.parent.parent / "templates" / "saved"
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+fill_mod = import_module("fill-template")
+
+
+def _run(*args: str, slots: dict | None = None) -> subprocess.CompletedProcess:
+    """Run the CLI, optionally writing slots to a temp JSON file first."""
+    argv = [sys.executable, SCRIPT, *args]
+    if slots is not None:
+        f = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+        json.dump(slots, f)
+        f.close()
+        argv += ["--slots", f.name]
+    return subprocess.run(argv, capture_output=True, text=True)
+
+
+# --- gallery integrity: every shipped template is valid ---
+
+
+def test_all_shipped_templates_listed() -> None:
+    """Every .html with a manifest appears in --list; the three we ship are present."""
+    names = fill_mod.list_templates()
+    for expected in ("business-review", "project-kickoff", "system-design"):
+        assert expected in names
+
+
+def test_shipped_manifests_are_valid_json() -> None:
+    for manifest in SAVED_DIR.glob("*.slots.json"):
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        assert "slots" in data and isinstance(data["slots"], list)
+        for slot in data["slots"]:
+            assert "name" in slot
+
+
+def test_every_manifest_slot_marker_exists_in_html() -> None:
+    """A declared slot must have a matching {{MARKER}} in the template body."""
+    for manifest in SAVED_DIR.glob("*.slots.json"):
+        name = manifest.stem.replace(".slots", "")
+        html = (SAVED_DIR / f"{name}.html").read_text(encoding="utf-8")
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        for slot in data["slots"]:
+            assert f"{{{{{slot['name']}}}}}" in html, f"{name}: declared slot {slot['name']} has no marker in HTML"
+
+
+def test_every_html_marker_is_declared() -> None:
+    """Every {{MARKER}} in a template must be declared in its manifest — no orphan markers."""
+    for html_path in SAVED_DIR.glob("*.html"):
+        manifest_path = SAVED_DIR / f"{html_path.stem}.slots.json"
+        if not manifest_path.exists():
+            continue  # e.g. github-issues.html is a static artifact, not a slot template
+        html = html_path.read_text(encoding="utf-8")
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        declared = {s["name"] for s in data["slots"]}
+        markers = set(fill_mod.MARKER_RE.findall(html))
+        orphan = markers - declared
+        assert not orphan, f"{html_path.stem}: undeclared markers {orphan}"
+
+
+# --- fill_template() behaviour ---
+
+
+def _required(name: str) -> dict[str, str]:
+    data = fill_mod.load_manifest(name)
+    return {s["name"]: f"<p>{s['name']}</p>" for s in data["slots"] if s.get("required", True)}
+
+
+def test_fill_leaves_no_markers() -> None:
+    for name in fill_mod.list_templates():
+        html = fill_mod.fill_template(name, _required(name))
+        assert not fill_mod.MARKER_RE.findall(html)
+
+
+def test_fill_substitutes_content() -> None:
+    values = _required("business-review")
+    values["TITLE"] = "Q3 Review UNIQUEMARKER"
+    html = fill_mod.fill_template("business-review", values)
+    assert "Q3 Review UNIQUEMARKER" in html
+
+
+def test_layout_is_preserved() -> None:
+    """Clone mode must not alter chrome: the CSS stamp and structure survive verbatim."""
+    html = fill_mod.fill_template("business-review", _required("business-review"))
+    assert "vexjoy-artifact: shape=report theme=birchline" in html
+    assert '<body data-shape="report">' in html
+
+
+def test_missing_required_slot_exits_1() -> None:
+    r = _run("--template", "business-review", slots={"TITLE": "x"})
+    assert r.returncode == 1
+    assert "missing required slot" in r.stderr
+
+
+def test_unknown_slot_exits_1() -> None:
+    values = _required("business-review")
+    values["NOT_A_SLOT"] = "x"
+    r = _run("--template", "business-review", slots=values)
+    assert r.returncode == 1
+    assert "not declared" in r.stderr
+
+
+def test_optional_slot_omitted_is_blank() -> None:
+    """An omitted optional slot resolves to empty string, never a leftover marker."""
+    values = _required("business-review")  # KICKER/META/FOOTER are optional, omitted
+    html = fill_mod.fill_template("business-review", values)
+    assert not fill_mod.MARKER_RE.findall(html)
+
+
+def test_unknown_template_exits_2() -> None:
+    r = _run("--template", "does-not-exist", slots={"TITLE": "x"})
+    assert r.returncode == 2
+
+
+def test_list_flag() -> None:
+    r = _run("--list")
+    assert r.returncode == 0
+    assert "business-review" in r.stdout
+
+
+def test_bad_slots_json_exits_2() -> None:
+    f = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    f.write("{not valid json")
+    f.close()
+    r = subprocess.run(
+        [sys.executable, SCRIPT, "--template", "business-review", "--slots", f.name],
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 2
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/skills/meta/html-artifact/templates/saved/README.md
+++ b/skills/meta/html-artifact/templates/saved/README.md
@@ -1,0 +1,47 @@
+# Saved templates — named, frozen HTML layouts
+
+A named starting layout the builder clones and fills, instead of regenerating
+structure from scratch. One skill, many template files: add a layout here to
+grow the gallery — never add a skill per template.
+
+## How a saved template works
+
+Each entry is two files sharing a base name:
+
+| File | Role |
+|---|---|
+| `<name>.html` | Frozen layout. Content slots are `{{SLOT_NAME}}` markers. |
+| `<name>.slots.json` | Slot manifest: each slot's name, whether it is required, and a one-line description. |
+
+The layout (CSS, structure, chrome) is fixed. Only slot text changes.
+
+## Fill a template (deterministic)
+
+```
+python3 skills/meta/html-artifact/scripts/fill-template.py \
+  --template business-review \
+  --slots slots.json \
+  --out artifact.html
+```
+
+`slots.json` maps slot names to HTML/text values. The script:
+
+- Refuses if a required slot is missing (exit 1).
+- Refuses if a provided slot name is not declared in the manifest (exit 1) — no silent typos.
+- Substitutes every declared slot, then verifies no `{{...}}` markers remain (exit 1).
+- Never edits layout, CSS, or chrome. Content-vs-layout authority is enforced by the script, not by prompt discipline.
+
+## Gallery
+
+| Template | Shape | Use |
+|---|---|---|
+| `business-review` | report | Performance/KPI review with segments, decisions, outlook |
+| `system-design` | report | Architecture doc: requirements, components, data flow, tradeoffs |
+| `github-issues` | data-viz | Rendered GitHub issue set (pre-existing) |
+
+## Add a template
+
+1. Author `<name>.html` in the Birchline design system, marking content spots with `{{SLOT}}`.
+2. Author `<name>.slots.json` declaring every slot.
+3. Run `fill-template.py --template <name> --slots <sample>.json --out /tmp/check.html` and confirm no markers remain.
+4. Add a row to the gallery table above.

--- a/skills/meta/html-artifact/templates/saved/business-review.html
+++ b/skills/meta/html-artifact/templates/saved/business-review.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<title>{{TITLE}}</title>
+<style>
+/* vexjoy-artifact: shape=report theme=birchline contrast=n/a template=business-review */
+:root {
+  --bg: #faf8f3; --surface: #ffffff; --ink: #2b2b27; --ink-soft: #57534e;
+  --line: #e7e2d8; --accent: #7c5e3c; --accent-soft: #f0e9dd;
+  --good: #4f7a4f; --good-bg: #eaf2ea; --warn: #a9791f; --warn-bg: #f7efdc;
+  --bad: #9c4a3c; --bad-bg: #f5e5e1;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: ui-monospace, "SF Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--ink); font-family: var(--sans); line-height: 1.6; }
+.wrap { max-width: 940px; margin: 0 auto; padding: 48px 28px 96px; }
+header.hero { border-bottom: 3px solid var(--accent); padding-bottom: 22px; margin-bottom: 32px; }
+.kicker { font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: var(--accent); font-weight: 700; }
+h1 { font-size: 32px; line-height: 1.15; margin: 8px 0 6px; }
+.sub { color: var(--ink-soft); font-size: 17px; margin: 0; }
+.meta-row { display: flex; gap: 20px; flex-wrap: wrap; margin-top: 14px; font-size: 13px; color: var(--ink-soft); }
+.tldr { background: var(--accent-soft); border: 1px solid var(--line); border-left: 4px solid var(--accent); border-radius: 8px; padding: 18px 22px; margin: 26px 0; }
+.tldr h2 { margin: 0 0 8px; font-size: 14px; text-transform: uppercase; letter-spacing: .08em; color: var(--accent); }
+h2.section { font-size: 23px; margin: 44px 0 12px; padding-top: 8px; border-top: 1px solid var(--line); }
+table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 14px; background: var(--surface); }
+th, td { text-align: left; padding: 10px 12px; border: 1px solid var(--line); vertical-align: top; }
+th { background: var(--accent-soft); font-weight: 700; }
+tbody tr:nth-child(even) td { background: #fcfaf6; }
+.kpi-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 14px; margin: 18px 0; }
+.kpi { border: 1px solid var(--line); border-radius: 8px; padding: 16px; background: var(--surface); }
+.kpi .label { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--ink-soft); }
+.kpi .value { font-size: 26px; font-weight: 700; margin: 4px 0 2px; }
+.kpi .delta { font-size: 13px; }
+.callout { border: 1px solid var(--line); border-left: 4px solid var(--accent); border-radius: 8px; padding: 14px 18px; margin: 18px 0; background: var(--surface); }
+footer { margin-top: 56px; padding-top: 18px; border-top: 1px solid var(--line); font-size: 13px; color: var(--ink-soft); }
+</style>
+</head>
+<body data-shape="report">
+<div class="wrap">
+  <header class="hero">
+    <div class="kicker">{{KICKER}}</div>
+    <h1>{{TITLE}}</h1>
+    <p class="sub">{{SUBTITLE}}</p>
+    <div class="meta-row">{{META}}</div>
+  </header>
+
+  <div class="tldr">
+    <h2>Summary</h2>
+    {{SUMMARY}}
+  </div>
+
+  <h2 class="section">Key metrics</h2>
+  <div class="kpi-grid">{{KPIS}}</div>
+
+  <h2 class="section">Segment results</h2>
+  {{SEGMENTS}}
+
+  <h2 class="section">Strategic priorities</h2>
+  {{PRIORITIES}}
+
+  <h2 class="section">Decisions</h2>
+  {{DECISIONS}}
+
+  <h2 class="section">Outlook</h2>
+  {{OUTLOOK}}
+
+  <footer>{{FOOTER}}</footer>
+</div>
+</body>
+</html>

--- a/skills/meta/html-artifact/templates/saved/business-review.slots.json
+++ b/skills/meta/html-artifact/templates/saved/business-review.slots.json
@@ -1,0 +1,18 @@
+{
+  "template": "business-review",
+  "shape": "report",
+  "description": "Business performance review: KPIs, segment results, strategic priorities, decisions, outlook.",
+  "slots": [
+    { "name": "TITLE", "required": true, "description": "Report title, plain text." },
+    { "name": "KICKER", "required": false, "description": "Small uppercase label above the title (e.g. 'Q3 2026 Business Review')." },
+    { "name": "SUBTITLE", "required": true, "description": "One-line summary shown under the title." },
+    { "name": "META", "required": false, "description": "Inline meta spans, e.g. '<span>Period: Q3</span><span>Owner: Ops</span>'." },
+    { "name": "SUMMARY", "required": true, "description": "TL;DR block: one or more <p> paragraphs." },
+    { "name": "KPIS", "required": true, "description": "One or more .kpi cards: '<div class=\"kpi\"><div class=\"label\">Revenue</div><div class=\"value\">$4.2M</div><div class=\"delta\">+12%</div></div>'." },
+    { "name": "SEGMENTS", "required": true, "description": "Segment results as an HTML <table> or paragraphs." },
+    { "name": "PRIORITIES", "required": true, "description": "Strategic priorities as an <ul> or <ol>." },
+    { "name": "DECISIONS", "required": true, "description": "Decisions made/needed as a list or table." },
+    { "name": "OUTLOOK", "required": true, "description": "Forward outlook: <p> paragraphs, optionally a .callout." },
+    { "name": "FOOTER", "required": false, "description": "Footer line: source, date, author." }
+  ]
+}

--- a/skills/meta/html-artifact/templates/saved/project-kickoff.html
+++ b/skills/meta/html-artifact/templates/saved/project-kickoff.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<title>{{TITLE}}</title>
+<style>
+/* vexjoy-artifact: shape=report theme=birchline contrast=n/a template=project-kickoff */
+:root {
+  --bg: #faf8f3; --surface: #ffffff; --ink: #2b2b27; --ink-soft: #57534e;
+  --line: #e7e2d8; --accent: #7c5e3c; --accent-soft: #f0e9dd;
+  --good: #4f7a4f; --good-bg: #eaf2ea; --warn: #a9791f; --warn-bg: #f7efdc;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: ui-monospace, "SF Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--ink); font-family: var(--sans); line-height: 1.6; }
+.wrap { max-width: 920px; margin: 0 auto; padding: 48px 28px 96px; }
+header.hero { border-bottom: 3px solid var(--accent); padding-bottom: 22px; margin-bottom: 32px; }
+.kicker { font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: var(--accent); font-weight: 700; }
+h1 { font-size: 32px; line-height: 1.15; margin: 8px 0 6px; }
+.sub { color: var(--ink-soft); font-size: 17px; margin: 0; }
+.meta-row { display: flex; gap: 20px; flex-wrap: wrap; margin-top: 14px; font-size: 13px; color: var(--ink-soft); }
+.tldr { background: var(--accent-soft); border: 1px solid var(--line); border-left: 4px solid var(--accent); border-radius: 8px; padding: 18px 22px; margin: 26px 0; }
+.tldr h2 { margin: 0 0 8px; font-size: 14px; text-transform: uppercase; letter-spacing: .08em; color: var(--accent); }
+h2.section { font-size: 23px; margin: 44px 0 12px; padding-top: 8px; border-top: 1px solid var(--line); }
+table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 14px; background: var(--surface); }
+th, td { text-align: left; padding: 10px 12px; border: 1px solid var(--line); vertical-align: top; }
+th { background: var(--accent-soft); font-weight: 700; }
+tbody tr:nth-child(even) td { background: #fcfaf6; }
+.gate-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; margin: 18px 0; }
+.gate { border: 1px solid var(--line); border-top: 4px solid var(--accent); border-radius: 8px; padding: 16px; background: var(--surface); }
+.gate .g-label { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--accent); font-weight: 700; }
+.gate h4 { margin: 4px 0 8px; }
+.callout { border: 1px solid var(--line); border-left: 4px solid var(--accent); border-radius: 8px; padding: 14px 18px; margin: 18px 0; background: var(--surface); }
+code { font-family: var(--mono); background: #f1ece3; padding: 1px 5px; border-radius: 4px; font-size: 13px; }
+footer { margin-top: 56px; padding-top: 18px; border-top: 1px solid var(--line); font-size: 13px; color: var(--ink-soft); }
+</style>
+</head>
+<body data-shape="report">
+<div class="wrap">
+  <header class="hero">
+    <div class="kicker">{{KICKER}}</div>
+    <h1>{{TITLE}}</h1>
+    <p class="sub">{{SUBTITLE}}</p>
+    <div class="meta-row">{{META}}</div>
+  </header>
+
+  <div class="tldr">
+    <h2>Kickoff agenda</h2>
+    {{AGENDA}}
+  </div>
+
+  <h2 class="section">Foundation — what's already proven</h2>
+  {{FOUNDATION}}
+
+  <h2 class="section">Scope &amp; success criteria</h2>
+  {{SCOPE}}
+
+  <h2 class="section">Workstreams &amp; owners</h2>
+  {{WORKSTREAMS}}
+
+  <h2 class="section">Milestones &amp; gates</h2>
+  <div class="gate-grid">{{GATES}}</div>
+
+  <h2 class="section">Open decisions</h2>
+  {{DECISIONS}}
+
+  <h2 class="section">Risks</h2>
+  {{RISKS}}
+
+  <footer>{{FOOTER}}</footer>
+</div>
+</body>
+</html>

--- a/skills/meta/html-artifact/templates/saved/project-kickoff.slots.json
+++ b/skills/meta/html-artifact/templates/saved/project-kickoff.slots.json
@@ -1,0 +1,19 @@
+{
+  "template": "project-kickoff",
+  "shape": "report",
+  "description": "Project kickoff: agenda, proven foundation, scope and success criteria, workstreams and owners, milestone gates, open decisions, risks. Structure adapted from a proven kickoff information architecture.",
+  "slots": [
+    { "name": "TITLE", "required": true, "description": "Project name, plain text." },
+    { "name": "KICKER", "required": false, "description": "Small uppercase label (e.g. 'Issue #907 · KICKOFF')." },
+    { "name": "SUBTITLE", "required": true, "description": "One-line project goal." },
+    { "name": "META", "required": false, "description": "Inline meta spans: DRI, date, phase." },
+    { "name": "AGENDA", "required": true, "description": "Kickoff agenda as an <ol> or <ul>." },
+    { "name": "FOUNDATION", "required": true, "description": "What is already delivered/proven: <p> or list, optionally 'Now in scope' contrast." },
+    { "name": "SCOPE", "required": true, "description": "Scope and success criteria. Table or list; state parity/coverage/behavior/operations." },
+    { "name": "WORKSTREAMS", "required": true, "description": "Workstreams with owners (DRIs) as an HTML <table>: name, description, owner." },
+    { "name": "GATES", "required": true, "description": "One or more .gate cards: '<div class=\"gate\"><div class=\"g-label\">Gate 1</div><h4>Design locked</h4><p>...</p></div>'." },
+    { "name": "DECISIONS", "required": true, "description": "Open decisions to resolve at kickoff, as a list or table." },
+    { "name": "RISKS", "required": false, "description": "Risks and mitigations as a table or list." },
+    { "name": "FOOTER", "required": false, "description": "Footer: source issue link, snapshot date." }
+  ]
+}

--- a/skills/meta/html-artifact/templates/saved/system-design.html
+++ b/skills/meta/html-artifact/templates/saved/system-design.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<title>{{TITLE}}</title>
+<style>
+/* vexjoy-artifact: shape=report theme=birchline contrast=n/a template=system-design */
+:root {
+  --bg: #faf8f3; --surface: #ffffff; --ink: #2b2b27; --ink-soft: #57534e;
+  --line: #e7e2d8; --accent: #7c5e3c; --accent-soft: #f0e9dd;
+  --good: #4f7a4f; --warn: #a9791f; --bad: #9c4a3c;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: ui-monospace, "SF Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--ink); font-family: var(--sans); line-height: 1.6; }
+.wrap { max-width: 900px; margin: 0 auto; padding: 48px 28px 96px; }
+header.hero { border-bottom: 3px solid var(--accent); padding-bottom: 22px; margin-bottom: 32px; }
+.kicker { font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: var(--accent); font-weight: 700; }
+h1 { font-size: 32px; line-height: 1.15; margin: 8px 0 6px; }
+.sub { color: var(--ink-soft); font-size: 17px; margin: 0; }
+.meta-row { display: flex; gap: 20px; flex-wrap: wrap; margin-top: 14px; font-size: 13px; color: var(--ink-soft); }
+.tldr { background: var(--accent-soft); border: 1px solid var(--line); border-left: 4px solid var(--accent); border-radius: 8px; padding: 18px 22px; margin: 26px 0; }
+.tldr h2 { margin: 0 0 8px; font-size: 14px; text-transform: uppercase; letter-spacing: .08em; color: var(--accent); }
+h2.section { font-size: 23px; margin: 44px 0 12px; padding-top: 8px; border-top: 1px solid var(--line); }
+table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 14px; background: var(--surface); }
+th, td { text-align: left; padding: 10px 12px; border: 1px solid var(--line); vertical-align: top; }
+th { background: var(--accent-soft); font-weight: 700; }
+tbody tr:nth-child(even) td { background: #fcfaf6; }
+code { font-family: var(--mono); background: #f1ece3; padding: 1px 5px; border-radius: 4px; font-size: 13px; }
+.diagram { border: 1px dashed var(--line); border-radius: 8px; padding: 18px; margin: 18px 0; background: var(--surface); text-align: center; }
+.callout { border: 1px solid var(--line); border-left: 4px solid var(--accent); border-radius: 8px; padding: 14px 18px; margin: 18px 0; background: var(--surface); }
+footer { margin-top: 56px; padding-top: 18px; border-top: 1px solid var(--line); font-size: 13px; color: var(--ink-soft); }
+</style>
+</head>
+<body data-shape="report">
+<div class="wrap">
+  <header class="hero">
+    <div class="kicker">{{KICKER}}</div>
+    <h1>{{TITLE}}</h1>
+    <p class="sub">{{SUBTITLE}}</p>
+    <div class="meta-row">{{META}}</div>
+  </header>
+
+  <div class="tldr">
+    <h2>Overview</h2>
+    {{OVERVIEW}}
+  </div>
+
+  <h2 class="section">Requirements</h2>
+  {{REQUIREMENTS}}
+
+  <h2 class="section">Architecture</h2>
+  <div class="diagram">{{DIAGRAM}}</div>
+
+  <h2 class="section">Components</h2>
+  {{COMPONENTS}}
+
+  <h2 class="section">Data flow</h2>
+  {{DATA_FLOW}}
+
+  <h2 class="section">Tradeoffs</h2>
+  {{TRADEOFFS}}
+
+  <h2 class="section">Operational considerations</h2>
+  {{OPERATIONS}}
+
+  <footer>{{FOOTER}}</footer>
+</div>
+</body>
+</html>

--- a/skills/meta/html-artifact/templates/saved/system-design.slots.json
+++ b/skills/meta/html-artifact/templates/saved/system-design.slots.json
@@ -1,0 +1,19 @@
+{
+  "template": "system-design",
+  "shape": "report",
+  "description": "System design doc: overview, requirements, architecture diagram, components, data flow, tradeoffs, operational considerations.",
+  "slots": [
+    { "name": "TITLE", "required": true, "description": "System/design name, plain text." },
+    { "name": "KICKER", "required": false, "description": "Small uppercase label (e.g. 'RFC 012 · System Design')." },
+    { "name": "SUBTITLE", "required": true, "description": "One-line description of what the system does." },
+    { "name": "META", "required": false, "description": "Inline meta spans: author, status, date." },
+    { "name": "OVERVIEW", "required": true, "description": "TL;DR overview: one or more <p> paragraphs." },
+    { "name": "REQUIREMENTS", "required": true, "description": "Functional and non-functional requirements as a list or table." },
+    { "name": "DIAGRAM", "required": true, "description": "Inline SVG or ASCII architecture diagram. Sits inside a .diagram box." },
+    { "name": "COMPONENTS", "required": true, "description": "Components as an HTML <table>: name, responsibility, tech." },
+    { "name": "DATA_FLOW", "required": true, "description": "Data flow: ordered <ol> or paragraphs describing request/event path." },
+    { "name": "TRADEOFFS", "required": true, "description": "Design tradeoffs and rejected alternatives, as a table or list." },
+    { "name": "OPERATIONS", "required": true, "description": "Operational considerations: scaling, failure modes, monitoring, rollback." },
+    { "name": "FOOTER", "required": false, "description": "Footer: source, date, author." }
+  ]
+}


### PR DESCRIPTION
## What

Adopts the **clone-don't-regenerate** pattern from OpenAI's curated-template skills — **without importing their skills**. Those 20 skills ship editable Office binaries (`.pptx`/`.xlsx`/`.docx`, 27 MB) and are host-locked to an OpenAI Office runtime; they self-abort elsewhere and are thin wrappers (20 copies of one skill). We kept the *idea*, rejected the *files*.

A frozen HTML template in `templates/saved/` is cloned and slot-filled by a deterministic script. Layout is fixed; only declared content slots change.

### Added
- **`scripts/fill-template.py`** — clone-and-fill engine. Fails loud (exit 1) on a missing required slot, an undeclared slot name (catches typos), or a leftover `{{MARKER}}`. Enforces content-vs-layout authority mechanically, not by prompt discipline.
- **Gallery** (one skill, many template files — not a skill per template): `business-review`, `project-kickoff`, `system-design`, all in the Birchline design system, each with a `.slots.json` manifest.
- **`SKILL.md`** — Phase 0 clone-first check + "Fidelity & Authority" section (clone-don't-regenerate; content controls content, template controls layout; fail loud).
- **`PHILOSOPHY.md`** — worked example under *External Components Are Research Inputs, Not Imports* (practice adopted, files rejected).
- **13 tests**, incl. gallery-integrity guards (every declared slot has a marker; every marker is declared).

## Blind A/B: clone vs regenerate

Same 3 content briefs, two arms: **clone** (frozen template + slot fill) vs **regenerate** (3 independent agents build layout from scratch). 6 outputs anonymized and scored by a blind grader (no arm labels, no key).

| Dimension | Clone | Regen | Δ |
|---|---|---|---|
| Visual consistency | 5.00 | 4.33 | **+0.67** |
| Professional polish | 5.00 | 4.00 | **+1.00** |
| Slop-free | 5.00 | 3.33 | **+1.67** |
| Structural completeness | 3.00 | 5.00 | −2.00 |
| **Overall** | **4.50** | 4.17 | **+0.33** |

**Read:** Clone wins decisively on consistency, polish, and slop — its purpose. The blind grader independently clustered the 3 clone outputs as "one identical design system" and the 3 regen outputs as each "comparatively bespoke" (blue gradients, card shadows, differing headers) — i.e. it detected the drift clone mode removes, without knowing the arms.

The completeness gap is a **test-harness artifact, not a design flaw**: the clone arm was fed thin placeholder slot text; the regen agents wrote fuller prose. Content is the variable there, not layout. With real content, clone mode keeps its consistency edge and fills completely — see the fully-populated Issue #907 kickoff rendered from the same template.

## Verification
- 211/211 html-artifact script tests pass (13 new + 198 existing)
- `ruff check` + `ruff format --check` clean on new files
- Generated artifacts pass `validate-artifact.py` (structure, self-containment, slop scan)

## Not done (by design)
No Office-binary output. If editable `.pptx`/`.xlsx`/`.docx` is ever wanted, that's a separate python-pptx/openpyxl toolchain decision.