### PR TITLE
fix(hooks): scope stop-drift-guard to the toolkit repo via intrinsic marker

### DIFF
--- a/hooks/stop-drift-guard.py
+++ b/hooks/stop-drift-guard.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 """
 Stop-event drift guard (ADR: adr/stop-event-drift-guards.md)
 
@@ -8,6 +8,12 @@ regression the moment they're introduced — at Stop, not at CI. It computes the
 session's working-tree diff, decides which component classes changed, runs ONLY
 the relevant existing check script, and re-wakes the session ADVISORY- only (it
 never blocks) when a check actually REPORTS drift.
+
+Toolkit-repo identity gate:
+  - The whole hook no-ops unless the session cwd IS the toolkit repo itself,
+    identified intrinsically by cwd/pyproject.toml declaring [project] name ==
+    "vexjoy-agent" (clone-portable: not a path, remote, or env var). In any
+    other repo the hook silently exits 0 before any check runs.
 
 Relevance gate (diff file paths -> which check to run):
   - hooks/** changed                          -> smoke-test-hooks.py --ci
@@ -53,6 +59,7 @@ Module seams (patched by hooks/tests/test_stop_drift_guard.py):
 
 import json
 import os
+import re
 import subprocess
 import sys
 import traceback
@@ -247,6 +254,28 @@ def _target_is_trusted_root(cwd: str | None) -> bool:
         return False
 
 
+# Intrinsic toolkit-repo marker: pyproject.toml declaring [project] name.
+# A minimal line scan (Python 3.10 here — no tomllib, no 3rd-party toml lib).
+_TOOLKIT_NAME_RE = re.compile(r"""^\s*name\s*=\s*["']vexjoy-agent["']\s*$""", re.MULTILINE)
+
+
+def _is_toolkit_repo(cwd: str | None) -> bool:
+    """Is `cwd` the toolkit repo itself?
+
+    True IFF `cwd` is non-empty AND `cwd/pyproject.toml` exists AND that file
+    declares a project name of "vexjoy-agent". Clone-portable: keys on an
+    intrinsic committed marker, not a path/remote/env var. Fail-open: ANY
+    IOError / parse issue -> False (treated as "not the toolkit repo" -> no-op).
+    """
+    if not cwd:
+        return False
+    try:
+        text = (Path(cwd) / "pyproject.toml").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return _TOOLKIT_NAME_RE.search(text) is not None
+
+
 def _run_script(script: str, args: list[str], cwd: str | None, timeout: int = 30):
     """Run scripts/<script> with args; return CompletedProcess or None on failure."""
     path = _script_path(script)
@@ -391,6 +420,13 @@ def handle_stop(event: dict) -> None:
         sys.exit(0)
 
     cwd = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR")
+
+    # Toolkit-repo identity gate: run drift checks ONLY when the session's repo
+    # IS the toolkit itself. Any other repo (or an unreadable/absent marker)
+    # short-circuits before diff parsing or any check runs. Clone-portable.
+    if not _is_toolkit_repo(cwd):
+        sys.exit(0)
+
     diff = _working_tree_diff(cwd)
 
     # Front gate: nothing reviewable -> short-circuit before any check runs.

--- a/hooks/tests/test_stop_drift_guard.py
+++ b/hooks/tests/test_stop_drift_guard.py
@@ -118,7 +118,7 @@ def _clean_env(extra: dict | None = None) -> dict:
     return base
 
 
-def _run(stdin_payload: str, *, env: dict | None = None, diff=None, check_results=None):
+def _run(stdin_payload: str, *, env: dict | None = None, diff=None, check_results=None, toolkit_repo: bool = True):
     """Invoke mod.main() in-process.
 
     Returns (exit_code, stdout_str, stderr_str).
@@ -128,11 +128,15 @@ def _run(stdin_payload: str, *, env: dict | None = None, diff=None, check_result
                      - a dict mapping check-name -> result dict (per-check control), or
                      - a single result dict applied to whatever check is invoked, or
                      - a list capturing call order (see _CheckSpy below).
+    toolkit_repo:  patches _is_toolkit_repo to this value (default True) so the
+                   toolkit-repo identity gate lets the event through. Set False to
+                   exercise the non-toolkit no-op path.
     """
     out, err = io.StringIO(), io.StringIO()
     with ExitStack() as stack:
         stack.enter_context(patch.dict(os.environ, _clean_env(env), clear=True))
         stack.enter_context(patch.object(mod, "read_stdin", return_value=stdin_payload))
+        stack.enter_context(patch.object(mod, "_is_toolkit_repo", return_value=toolkit_repo))
         stack.enter_context(redirect_stdout(out))
         stack.enter_context(redirect_stderr(err))
         if diff is not None:
@@ -587,3 +591,108 @@ class TestReviewableContentGate:
         assert spy.calls == []
         assert code == 0
         assert _rewake_summary(out) is None
+
+
+# ---------------------------------------------------------------------------
+# Toolkit-repo identity gate: the hook runs ONLY when the session cwd IS the
+# toolkit repo (cwd/pyproject.toml declares [project] name == "vexjoy-agent").
+# In any other repo it silently no-ops. Clone-portable intrinsic marker.
+# ---------------------------------------------------------------------------
+
+
+def _write_pyproject(dir_path: Path, name: str = "vexjoy-agent") -> Path:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / "pyproject.toml").write_text(f'[project]\nname = "{name}"\nversion = "0.1.0"\n', encoding="utf-8")
+    return dir_path
+
+
+class TestIsToolkitRepo:
+    def test_true_when_pyproject_names_vexjoy_agent(self, tmp_path):
+        repo = _write_pyproject(tmp_path / "repo")
+        assert mod._is_toolkit_repo(str(repo)) is True
+
+    def test_false_when_pyproject_absent(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert mod._is_toolkit_repo(str(empty)) is False
+
+    def test_false_when_pyproject_names_other_project(self, tmp_path):
+        repo = _write_pyproject(tmp_path / "other", name="some-other-service")
+        assert mod._is_toolkit_repo(str(repo)) is False
+
+    def test_false_when_cwd_is_none(self):
+        assert mod._is_toolkit_repo(None) is False
+
+    def test_false_when_cwd_is_empty_string(self):
+        assert mod._is_toolkit_repo("") is False
+
+    def test_fail_open_on_unreadable_pyproject(self, tmp_path):
+        """A pyproject.toml that can't be read -> False (fail-open, no-op)."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        # pyproject.toml is a directory, so read_text raises OSError.
+        (repo / "pyproject.toml").mkdir()
+        assert mod._is_toolkit_repo(str(repo)) is False
+
+
+class TestToolkitRepoGate:
+    def test_non_toolkit_repo_no_ops_even_with_reviewable_drift(self):
+        """Regression for the false positive in unrelated repos (e.g. Hermez):
+        a reviewable diff in a NON-toolkit cwd exits 0 and never rewakes."""
+        spy = _CheckSpy(results={SMOKE: _drift()})
+        with patch.object(mod, "_run_check", side_effect=spy):
+            code, out, _ = _run(
+                _stop_event(),
+                diff=_diff_for("hooks/foo.py"),
+                toolkit_repo=False,
+            )
+        assert code == 0
+        assert _rewake_summary(out) is None
+        # Gated before any check ran.
+        assert spy.calls == []
+
+    def test_toolkit_repo_with_real_drift_still_rewakes(self):
+        """In a toolkit cwd, real drift preserves the existing rewake behavior."""
+        code, out, err = _run(
+            _stop_event(),
+            diff=_diff_for("hooks/foo.py"),
+            check_results={SMOKE: _drift("hook crashed", "python3 scripts/smoke-test-hooks.py --ci")},
+            toolkit_repo=True,
+        )
+        assert code == 2
+        assert _rewake_summary(out) is not None
+
+    def test_gate_consulted_with_real_pyproject_end_to_end(self, tmp_path):
+        """Unpatched _is_toolkit_repo: a tmp toolkit repo (real pyproject) with
+        drift rewakes; the same diff in a non-toolkit tmp dir stays silent."""
+        toolkit = _write_pyproject(tmp_path / "toolkit")
+        non_toolkit = tmp_path / "plain"
+        non_toolkit.mkdir()
+        results = {SMOKE: _drift()}
+
+        def fake(name, cwd, _map=results):
+            return _map.get(name, _clean())
+
+        def drive(cwd: str) -> tuple[int, str]:
+            out = io.StringIO()
+            with ExitStack() as stack:
+                stack.enter_context(patch.dict(os.environ, _clean_env(None), clear=True))
+                stack.enter_context(patch.object(mod, "read_stdin", return_value=_stop_event(cwd=cwd)))
+                stack.enter_context(patch.object(mod, "_working_tree_diff", return_value=_diff_for("hooks/foo.py")))
+                stack.enter_context(patch.object(mod, "_run_check", side_effect=fake))
+                stack.enter_context(redirect_stdout(out))
+                stack.enter_context(redirect_stderr(io.StringIO()))
+                code = 0
+                try:
+                    mod.main()
+                except SystemExit as e:
+                    code = int(e.code) if e.code is not None else 0
+            return code, out.getvalue()
+
+        code_t, out_t = drive(str(toolkit))
+        assert code_t == 2
+        assert _rewake_summary(out_t) is not None
+
+        code_n, out_n = drive(str(non_toolkit))
+        assert code_n == 0
+        assert _rewake_summary(out_n) is None

--- a/scripts/tests/test_codex_hooks_runtime_compat.py
+++ b/scripts/tests/test_codex_hooks_runtime_compat.py
@@ -470,6 +470,10 @@ def _prepare_case(
         scripts_dir = cwd / "scripts"
         hooks_dir.mkdir()
         scripts_dir.mkdir()
+        # The guard runs only when cwd is the toolkit repo, identified by the
+        # intrinsic pyproject.toml [project] name marker (hook 1.1.0+). Stamp it
+        # so the drift path is exercised instead of the non-toolkit no-op.
+        (cwd / "pyproject.toml").write_text('[project]\nname = "vexjoy-agent"\n', encoding="utf-8")
         changed_hook = hooks_dir / "runtime.py"
         changed_hook.write_text("VALUE = 'before'\n", encoding="utf-8")
         (scripts_dir / "smoke-test-hooks.py").write_text(


### PR DESCRIPTION
## Problem

The `stop-drift-guard.py` Stop-event hook is registered at **user scope**
(`~/.claude/settings.json`), so it fires in every repo the user opens. Two of
its three checks (`smoke-test-hooks`, `validate-doc-counts`) ran against the
session's own repo, so in unrelated repos they found no toolkit doc-count
claims and emitted false-positive drift — the `Toolkit drift guard found drift
to review` advisory rewake seen in e.g. the Hermez OpenStack repo (`?` / actual
`?` placeholders).

## Fix

Gate `handle_stop` on **repo identity**: run only when `cwd/pyproject.toml`
declares `name = "vexjoy-agent"`. Non-toolkit repos exit 0 before any check
runs.

The marker is intrinsic and committed, so it travels with any clone regardless
of checkout path, git remote, or machine:

| Candidate marker | Clone-portable? |
|---|---|
| Absolute path | No — breaks on clone elsewhere |
| Git remote | No — breaks on fork/mirror |
| Per-machine env var | No — not in the clone |
| `pyproject.toml [project].name` | **Yes** |

Python 3.10 has no `tomllib`; the name is read with a `MULTILINE` regex line
scan, fail-open on any `OSError`. The `VEXJOY_DRIFT_GUARD_DISABLE` kill switch,
`async_rewake` advisory/never-block behavior, and fail-open contracts are
unchanged. Hook version `1.0.0` -> `1.1.0`.

## Behavioral proof

| cwd | `_is_toolkit_repo` |
|---|---|
| vexjoy-agent | True (guard runs) |
| hermez | False (silent no-op) |
| /tmp, None, "" | False |

## Tests

+12 tests (`TestIsToolkitRepo`, `TestToolkitRepoGate` including the
false-positive regression test). Target suite: 40 pass. `ruff check` +
`ruff format --check`: clean.

Note: 3 unrelated pre-existing failures in `test_sync_to_user_claude.py` /
`test_posttool_bash_injection_scan.py` (env-specific `/tmp` path tests) fail
identically on `main` and touch neither changed file.