### PR TITLE
fix(telemetry): record the pipeline token and stop scoring unobservable instructions

### DIFF
--- a/docs/route-loop-validation.md
+++ b/docs/route-loop-validation.md
@@ -186,7 +186,9 @@ All Critical/High findings were fixed on the original branch before the split.
 ## Reproduce (sensor)
 
 ```bash
-# Signal check: expect exit 0 (NO-SIGNAL) today
+# Signal check: exits 3 (SIGNAL) today — 1 routing-relevant failure,
+# 81 decisions with health_at_decision, 0 would-demote. The re-propose
+# condition above is met; the actuator has not been re-proposed yet.
 python3 scripts/route-signal-check.py
 
 # Test suite

--- a/hooks/instruction-compliance.py
+++ b/hooks/instruction-compliance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 """PostToolUse Hook: Instruction Compliance Measurement
 
 Fires after Agent tool dispatches to check whether MANDATORY instructions
@@ -7,10 +7,18 @@ Fires after Agent tool dispatches to check whether MANDATORY instructions
 
 Records compliance observations to learning.db for skip-rate dashboard.
 
+SURFACE — what this hook can and cannot see. It scans two strings: the dispatch
+prompt (tool_input) and the subagent report (tool_result). Main-thread
+orchestrator output is in neither, so an instruction the orchestrator follows in
+its own reply is unmeasurable here and is declared `observable: False`. Those
+instructions are not recorded at all: a skip rate computed from a surface that
+structurally cannot show compliance measures the surface, not the behavior.
+
 Design Principles:
 - Informational only (always exits 0, never blocks)
 - Lightweight string-presence checks (<50ms)
 - Multiple signal patterns per instruction for reduced false negatives
+- Record only what this surface can observe
 """
 
 import json
@@ -30,9 +38,16 @@ EVENT_NAME = "PostToolUse"
 
 # ─── Instruction Definitions ─────────────────────────────────────
 
-INSTRUCTIONS: dict[str, dict[str, str | list[re.Pattern[str]]]] = {
+# `observable` declares whether THIS hook's surface (dispatch prompt + subagent
+# report) can show the signal. False => the patterns stay for reference, but no
+# observation is recorded, because a non-match proves nothing about behavior.
+INSTRUCTIONS: dict[str, dict[str, str | bool | list[re.Pattern[str]]]] = {
     "M01": {
         "name": "Phase Banners",
+        # Unobservable: phase banners are main-thread orchestrator output, absent
+        # from both the dispatch prompt and the subagent report. Measuring them
+        # needs a main-thread surface (a Stop-event transcript reader).
+        "observable": False,
         "patterns": [
             re.compile(r"##\s*Phase\s+\d", re.IGNORECASE),
             re.compile(r"Phase\s+\d\s*:", re.IGNORECASE),
@@ -40,6 +55,9 @@ INSTRUCTIONS: dict[str, dict[str, str | list[re.Pattern[str]]]] = {
     },
     "M03": {
         "name": "Routing Decision",
+        # Unobservable: the routing banner is main-thread orchestrator output,
+        # printed before dispatch. Same correct surface as M01.
+        "observable": False,
         "patterns": [
             re.compile(r"^={3,}\s*$", re.MULTILINE),
             re.compile(r"(?:^|\s)ROUTING\s*:", re.IGNORECASE | re.MULTILINE),
@@ -48,6 +66,9 @@ INSTRUCTIONS: dict[str, dict[str, str | list[re.Pattern[str]]]] = {
     },
     "M04": {
         "name": "Reference Loading",
+        # Observable: the reference-loading directive and an agent's own
+        # reference-table mentions both land in the scanned strings.
+        "observable": True,
         "patterns": [
             re.compile(r"Reference\s+Loading", re.IGNORECASE),
             re.compile(r"reference.*table", re.IGNORECASE),
@@ -56,7 +77,10 @@ INSTRUCTIONS: dict[str, dict[str, str | list[re.Pattern[str]]]] = {
         ],
     },
     "M05": {
-        "name": "Completeness",
+        # Measures whether the completeness directive reached the prompt, NOT
+        # whether the agent delivered a complete result. Renamed to say so.
+        "name": "Completeness Injected",
+        "observable": True,
         "patterns": [
             re.compile(r"deliver\s+the\s+finished\s+product", re.IGNORECASE),
             re.compile(r"ship\s+the\s+complete\s+thing", re.IGNORECASE),
@@ -65,7 +89,10 @@ INSTRUCTIONS: dict[str, dict[str, str | list[re.Pattern[str]]]] = {
         ],
     },
     "M06": {
-        "name": "Density Standard",
+        # Measures whether the density directive reached the prompt, NOT whether
+        # the output was written dense. Renamed to say so.
+        "name": "Density Injected",
+        "observable": True,
         "patterns": [
             re.compile(r"write\s+dense", re.IGNORECASE),
             re.compile(r"high\s+fidelity,?\s+minimum\s+words", re.IGNORECASE),
@@ -91,17 +118,29 @@ def check_compliance(text: str) -> dict[str, bool]:
     return results
 
 
+def is_observable(instr_id: str) -> bool:
+    """Report whether this hook's surface can observe the instruction.
+
+    Unknown IDs are unobservable: record nothing rather than record a reading
+    whose surface is undeclared.
+    """
+    return bool(INSTRUCTIONS.get(instr_id, {}).get("observable", False))
+
+
 def record_compliance_batch(
     results: dict[str, bool],
     session_id: str,
 ) -> None:
-    """Record all instruction compliance observations in one transaction.
+    """Record observable instruction compliance observations in one transaction.
+
+    Unobservable instructions are dropped here, so the skip-rate dashboard never
+    counts a non-match this surface could not have matched.
 
     Args:
         results: Dict mapping instruction ID to compliance boolean.
         session_id: Current session identifier.
     """
-    records = [(instr_id, compliant, session_id) for instr_id, compliant in results.items()]
+    records = [(instr_id, compliant, session_id) for instr_id, compliant in results.items() if is_observable(instr_id)]
     record_instruction_compliance_batch(records)
 
 

--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -211,6 +211,20 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
             "VALUES (7, 'add agent evidence event and route decision tables')"
         )
 
+    if current < 8:
+        # v7 -> v8: carry the router's ` pipeline=<name>` marker token. The
+        # column may already exist from an ad-hoc ALTER on a live DB; the
+        # duplicate-column error is the expected no-op there.
+        try:
+            conn.execute("ALTER TABLE evidence_route_decisions ADD COLUMN pipeline TEXT")
+        except sqlite3.OperationalError:
+            pass  # column already present
+        conn.execute("PRAGMA user_version = 8")
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, description) "
+            "VALUES (8, 'add pipeline column to evidence_route_decisions')"
+        )
+
     conn.commit()
 
 
@@ -420,6 +434,7 @@ CREATE TABLE IF NOT EXISTS evidence_route_decisions (
     outcome_basis        TEXT,
     request_snippet      TEXT,
     stack                TEXT,
+    pipeline             TEXT,
     alternates           TEXT,
     created_at           TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at           TEXT NOT NULL DEFAULT (datetime('now'))
@@ -1089,6 +1104,7 @@ def record_evidence_route_decision(
     model: str | None = None,
     request_snippet: str | None = None,
     stack: list[str] | tuple[str, ...] | str | None = None,
+    pipeline: str | None = None,
     health: float | None = None,
     n: int | None = None,
     failure: bool | None = None,
@@ -1122,10 +1138,10 @@ def record_evidence_route_decision(
             INSERT INTO evidence_route_decisions (
                 decision_id, session_id, route_key, agent, skill, complexity, model, action,
                 health, n, failure, gate_inputs_present, outcome, outcome_basis,
-                request_snippet, stack, alternates, created_at, updated_at
+                request_snippet, stack, pipeline, alternates, created_at, updated_at
             )
             VALUES (
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')
             )
             ON CONFLICT(decision_id) DO UPDATE SET
                 session_id = excluded.session_id,
@@ -1143,6 +1159,7 @@ def record_evidence_route_decision(
                 outcome_basis = excluded.outcome_basis,
                 request_snippet = excluded.request_snippet,
                 stack = excluded.stack,
+                pipeline = excluded.pipeline,
                 alternates = excluded.alternates,
                 updated_at = datetime('now')
             """,
@@ -1163,6 +1180,7 @@ def record_evidence_route_decision(
                 _bounded_text(outcome_basis, 120),
                 _bounded_text(request_snippet, 1000),
                 stack_text,
+                _bounded_text(pipeline, 160),
                 alternates_text,
             ),
         )

--- a/hooks/lib/route_events.py
+++ b/hooks/lib/route_events.py
@@ -71,6 +71,7 @@ def record_decision_event(
     complexity: str = "",
     complexity_invalid: str = "",
     stack: list[str] | None = None,
+    pipeline: str | None = None,
     model: str | None = None,
     health_at_decision: float | None = None,
     n: int | None = None,
@@ -101,6 +102,7 @@ def record_decision_event(
     (e.g. "Low") — written only when non-empty, so the bad value is kept for
     audit instead of dropped. stack is the parsed ` stack={s1,s2}` marker token;
     written only when present, so stack-free markers write unchanged events.
+    pipeline is the parsed ` pipeline=<name>` token, written on the same terms.
     """
     event: dict[str, Any] = {
         "type": "decision",
@@ -121,6 +123,8 @@ def record_decision_event(
         event["complexity_invalid"] = complexity_invalid
     if stack is not None:
         event["stack"] = stack
+    if pipeline is not None:
+        event["pipeline"] = pipeline
     if model is not None:
         event["model"] = model
     _append(event)

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.3.0
+# hook-version: 1.4.0
 """
 PostToolUse Hook: Routing Decision Recorder (action A, formerly /do Phase 5)
 
@@ -111,6 +111,13 @@ _VALID_COMPLEXITY = frozenset({"trivial", "simple", "medium", "complex"})
 # the router composed for this dispatch. Instrumentation only: parsed onto the
 # decision event as a list; absent token => no field. Same charset as alts=.
 _STACK_RE = re.compile(r"\bstack=\{([a-z0-9:_,-]*)\}", re.IGNORECASE)
+
+# Pipeline token on the marker line: ` pipeline=<name>` — the workflow pipeline
+# the router picked (build-dispatch.py resolve_pipeline, validated against
+# pipeline-index.json before it is emitted). Absent or `-` => None. Every
+# pipeline pick was invisible until this parser existed: the router emitted the
+# token, nothing read it, so evidence_route_decisions.pipeline stayed NULL.
+_PIPELINE_RE = re.compile(r"\bpipeline=([a-z0-9-]+)", re.IGNORECASE)
 
 # Model token on the marker line: `model=opus` or `model=-`. GPT-5.6 selections
 # carry an additional `effort=` token. Valid values match build-dispatch.py;
@@ -266,6 +273,21 @@ def parse_stack(marker_text: str) -> list[str] | None:
         return None
     items = [s for s in m.group(1).split(",") if s]
     return items or None
+
+
+def parse_pipeline(marker_text: str) -> str | None:
+    """Read the optional ` pipeline=<name>` token off the marker LINE, or None.
+
+    None when the token is absent (the majority of dispatches) or `pipeline=-`.
+    Scoped to the marker line (same rationale as parse_stack): task prose
+    mentioning `pipeline=` must never be read as the router's pick.
+    """
+    line = _marker_line(marker_text)
+    m = _PIPELINE_RE.search(line)
+    if not m:
+        return None
+    name = m.group(1).lower()
+    return None if name == "-" else name
 
 
 def parse_model(marker_text: str) -> str | None:
@@ -710,6 +732,7 @@ def main() -> None:
             # swallows write errors so the hook stays non-blocking.
             complexity, complexity_invalid = parse_marker_complexity(marker_text)
             stack = parse_stack(marker_text)
+            pipeline = parse_pipeline(marker_text)
             health = parse_health_inputs(marker_text)
             model = parse_model(marker_text)
             effort = parse_model_effort(marker_text)
@@ -735,6 +758,7 @@ def main() -> None:
                 complexity=complexity,
                 complexity_invalid=complexity_invalid,
                 stack=stack,
+                pipeline=pipeline,
                 model=recorded_model,
                 health_at_decision=health["health"],  # real gate inputs from the marker (Step 1.5)
                 n=health["n"],
@@ -778,6 +802,7 @@ def main() -> None:
                     model=recorded_model,
                     request_snippet=request_snippet,
                     stack=stack,
+                    pipeline=pipeline,
                     health=health["health"],
                     n=health["n"],
                     failure=bool(has_errors),

--- a/hooks/tests/test_instruction_observability.py
+++ b/hooks/tests/test_instruction_observability.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Tests for instruction observability declarations in instruction-compliance.
+
+The hook runs on PostToolUse:Agent and scans only the dispatch prompt plus the
+subagent report. Phase banners (M01) and the routing banner (M03) are
+main-thread orchestrator output, present in neither string — their recorded
+skip rates were an artifact of the measuring surface, not of behavior. Each
+instruction now declares whether this hook can observe it; unobservable ones
+are not recorded, and the skip-rate report never proposes a gate for them.
+
+Covers:
+- Every instruction declares `observable`; M01/M03 are False, M04-M06 True.
+- record_compliance_batch writes rows only for observable instructions.
+- Two-sample proof per recorded instruction: one text that matches, one that
+  does not.
+- skip-rate never flags an unobservable instruction for gate conversion, and
+  still flags an observable one.
+
+Uses a throwaway learning.db via CLAUDE_LEARNING_DIR — never the real DB.
+
+Run with: python3 -m pytest hooks/tests/test_instruction_observability.py -v
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = REPO_ROOT / "hooks" / "lib"
+HOOK_PATH = REPO_ROOT / "hooks" / "instruction-compliance.py"
+CLI_PATH = REPO_ROOT / "scripts" / "learning-db.py"
+
+sys.path.insert(0, str(LIB_DIR))
+
+_spec = importlib.util.spec_from_file_location("instruction_compliance", HOOK_PATH)
+assert _spec is not None and _spec.loader is not None
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+INSTRUCTIONS = mod.INSTRUCTIONS
+check_compliance = mod.check_compliance
+record_compliance_batch = mod.record_compliance_batch
+
+
+@pytest.fixture()
+def db_env(tmp_path, monkeypatch):
+    """Point the learning DB at a throwaway location."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    yield db_dir
+
+
+def _rows(instruction_id: str | None = None) -> list[dict]:
+    import learning_db_v2 as ldb
+
+    with ldb.get_connection() as conn:
+        if instruction_id:
+            cur = conn.execute(
+                "SELECT * FROM instruction_compliance WHERE instruction_id = ?",
+                (instruction_id,),
+            )
+        else:
+            cur = conn.execute("SELECT * FROM instruction_compliance")
+        return [dict(r) for r in cur.fetchall()]
+
+
+class TestObservabilityDeclarations:
+    """Every instruction states whether this hook's surface can see it."""
+
+    def test_every_instruction_declares_observable(self):
+        for instr_id, instr in INSTRUCTIONS.items():
+            assert isinstance(instr.get("observable"), bool), f"{instr_id} lacks an observable declaration"
+
+    def test_main_thread_instructions_are_unobservable(self):
+        assert INSTRUCTIONS["M01"]["observable"] is False
+        assert INSTRUCTIONS["M03"]["observable"] is False
+
+    def test_prompt_surface_instructions_stay_observable(self):
+        assert INSTRUCTIONS["M04"]["observable"] is True
+        assert INSTRUCTIONS["M05"]["observable"] is True
+        assert INSTRUCTIONS["M06"]["observable"] is True
+
+
+class TestUnobservableNotRecorded:
+    """Unobservable instructions produce no compliance rows."""
+
+    def test_batch_skips_unobservable_instructions(self, db_env):
+        record_compliance_batch(
+            {"M01": False, "M03": False, "M04": True, "M05": False, "M06": True},
+            "obs-session",
+        )
+        recorded = {r["instruction_id"] for r in _rows()}
+        assert recorded == {"M04", "M05", "M06"}
+
+    def test_batch_of_only_unobservable_writes_nothing(self, db_env):
+        record_compliance_batch({"M01": True, "M03": True}, "obs-none")
+        assert _rows() == []
+
+
+class TestRecordedInstructionTwoSampleProof:
+    """One text that must match, one that must not, per recorded instruction."""
+
+    @pytest.mark.parametrize(
+        ("instr_id", "hit", "miss"),
+        [
+            (
+                "M04",
+                "Consult the Reference Loading Table before starting work.",
+                "I read the file and fixed the bug.",
+            ),
+            (
+                "M05",
+                "Deliver the finished product. Ship the complete thing.",
+                "Here is the implementation you requested.",
+            ),
+            (
+                "M06",
+                "Write dense. High fidelity, minimum words.",
+                "Let me explain every change in detail.",
+            ),
+        ],
+    )
+    def test_two_sample_proof(self, instr_id, hit, miss):
+        assert check_compliance(hit)[instr_id] is True
+        assert check_compliance(miss)[instr_id] is False
+
+
+class TestSkipRateGateVerdict:
+    """The gate recommendation reads only instructions this hook can observe."""
+
+    def _seed(self, instruction_id: str, compliant: int, non_compliant: int) -> None:
+        from learning_db_v2 import record_instruction_compliance_batch
+
+        record_instruction_compliance_batch(
+            [(instruction_id, True, "seed") for _ in range(compliant)]
+            + [(instruction_id, False, "seed") for _ in range(non_compliant)]
+        )
+
+    def _run(self, db_dir: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+        env = {**os.environ, "CLAUDE_LEARNING_DIR": str(db_dir), "PYTHONPATH": str(LIB_DIR)}
+        return subprocess.run(
+            [sys.executable, str(CLI_PATH), "skip-rate", *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+    def test_unobservable_instruction_never_flagged(self, db_env):
+        self._seed("M01", compliant=5, non_compliant=35)  # 87.5% skip, 40 obs
+        result = self._run(db_env, ["--json"])
+        assert result.returncode == 0
+        m01 = next(r for r in json.loads(result.stdout) if r["id"] == "M01")
+        assert m01["observations"] == 40  # historical rows stay visible
+        assert m01["status"] != "CONVERT_TO_GATE"
+
+    def test_observable_instruction_still_flagged(self, db_env):
+        self._seed("M04", compliant=5, non_compliant=35)
+        result = self._run(db_env, ["--json"])
+        m04 = next(r for r in json.loads(result.stdout) if r["id"] == "M04")
+        assert m04["status"] == "CONVERT_TO_GATE"
+
+    def test_flagged_count_excludes_unobservable(self, db_env):
+        self._seed("M01", compliant=5, non_compliant=35)
+        result = self._run(db_env, [])
+        assert result.returncode == 0
+        assert "M01" in result.stdout  # row stays in the table
+        assert "No instructions flagged" in result.stdout

--- a/hooks/tests/test_routing_pipeline_token.py
+++ b/hooks/tests/test_routing_pipeline_token.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Tests for the ` pipeline=<name>` token on the [do-route] marker.
+
+build-dispatch.py emits `pipeline={name}` whenever the router picks a workflow
+pipeline. The recorder never parsed it, so every pipeline pick was invisible:
+the `evidence_route_decisions.pipeline` column stayed NULL on every row.
+
+Covers:
+- A marker carrying `pipeline=X` writes X to the DECISION event and to the
+  evidence_route_decisions.pipeline column.
+- A marker without the token writes no event field and leaves the column NULL.
+- Marker-line scoping: `pipeline=` in the task body is prose, never a token.
+
+Uses a throwaway learning.db via CLAUDE_LEARNING_DIR — never the real DB.
+
+Run with: python3 -m pytest hooks/tests/test_routing_pipeline_token.py -v
+"""
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent
+LIB_DIR = HOOKS_DIR / "lib"
+A_PATH = HOOKS_DIR / "routing-decision-recorder.py"
+
+
+@pytest.fixture()
+def db_env(tmp_path, monkeypatch):
+    """Point the learning DB and the bridge state dir at a throwaway location."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    import routing_outcome_state as ros
+
+    monkeypatch.setattr(ros, "_STATE_DIR", tmp_path / "state")
+    yield {"db_dir": db_dir, "state": tmp_path / "state"}
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    with patch("sys.exit"):
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def _event(marker_body, *, session, body="do the work"):
+    """PostToolUse:Agent event whose prompt starts with the supplied marker line."""
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Agent",
+        "session_id": session,
+        "tool_input": {
+            "subagent_type": "python-general-engineer",
+            "description": "do work",
+            "prompt": marker_body + "\n" + body,
+        },
+        "tool_result": {"output": "ok", "is_error": False},
+    }
+
+
+def _run(db_env, monkeypatch, marker_body, session, body="do the work"):
+    """Run the recorder on one marker; return (decision event, evidence row)."""
+    a = _load(A_PATH, f"rdr_pipe_{session}")
+    monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+    monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+    event = _event(marker_body, session=session, body=body)
+    with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+        a.main()
+    return _decision_event(db_env), _evidence_row(db_env, session)
+
+
+def _decision_event(db_env):
+    path = db_env["db_dir"] / "route-events.jsonl"
+    events = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    return next(e for e in events if e["type"] == "decision")
+
+
+def _evidence_row(db_env, session):
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    conn = sqlite3.connect(ldb.get_db_path())
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT * FROM evidence_route_decisions WHERE session_id = ?",
+            (session,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+_MARKER = "[do-route] agent=python-general-engineer skill=pr-workflow complexity=medium"
+
+
+class TestPipelineToken:
+    def test_pipeline_token_recorded(self, db_env, monkeypatch):
+        decision, row = _run(
+            db_env,
+            monkeypatch,
+            f"{_MARKER} pipeline=doc-pipeline model=opus",
+            "pipe-yes",
+        )
+        assert decision["pipeline"] == "doc-pipeline"
+        assert row["pipeline"] == "doc-pipeline"
+        assert decision["model"] == "opus"  # sibling tokens still parse
+
+    def test_absent_pipeline_token_records_null(self, db_env, monkeypatch):
+        decision, row = _run(db_env, monkeypatch, _MARKER, "pipe-no")
+        assert "pipeline" not in decision
+        assert row["pipeline"] is None
+
+    def test_pipeline_in_body_ignored(self, db_env, monkeypatch):
+        # Marker-line scoping: prose mentioning pipeline= is not a router token.
+        decision, row = _run(
+            db_env,
+            monkeypatch,
+            _MARKER,
+            "pipe-body",
+            body="Document the pipeline=doc-pipeline token syntax.",
+        )
+        assert "pipeline" not in decision
+        assert row["pipeline"] is None
+
+    def test_dash_pipeline_records_null(self, db_env, monkeypatch):
+        decision, row = _run(db_env, monkeypatch, f"{_MARKER} pipeline=-", "pipe-dash")
+        assert "pipeline" not in decision
+        assert row["pipeline"] is None
+
+
+class TestParsePipelineUnit:
+    def test_parse_pipeline_reads_marker_line(self):
+        a = _load(A_PATH, "rdr_pipe_unit")
+        assert a.parse_pipeline(f"{_MARKER} pipeline=research-pipeline") == "research-pipeline"
+        assert a.parse_pipeline(_MARKER) is None
+        assert a.parse_pipeline("no marker here pipeline=doc-pipeline") is None

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -1447,23 +1447,60 @@ def cmd_backfill_routing_outcomes(args: argparse.Namespace) -> None:
     print(f"  Unchanged: {unchanged}")
 
 
+# The recording hook owns the observability declaration; this mirror is used
+# only when it cannot be imported (cross-repo copy, missing file).
+_OBSERVABLE_FALLBACK = frozenset({"M04", "M05", "M06"})
+
+
+def _observable_instructions() -> frozenset[str]:
+    """Instruction IDs the recording hook declares it CAN observe.
+
+    Source of truth: hooks/instruction-compliance.py INSTRUCTIONS. Anything not
+    in this set is unobservable, including an ID the hook no longer declares.
+    Unobservable rows stay in the table — they are history — but a skip rate
+    measured on a surface that cannot show compliance must never recommend a
+    blocking gate.
+    """
+    try:
+        import importlib.util
+
+        hook = _repo_root / "hooks" / "instruction-compliance.py"
+        spec = importlib.util.spec_from_file_location("instruction_compliance", hook)
+        if spec is None or spec.loader is None:
+            return _OBSERVABLE_FALLBACK
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return frozenset(i for i, d in mod.INSTRUCTIONS.items() if d.get("observable", False))
+    except Exception:
+        return _OBSERVABLE_FALLBACK
+
+
 def cmd_skip_rate(args: argparse.Namespace) -> None:
     """Display instruction skip-rate report from the instruction_compliance table.
 
     Queries the dedicated instruction_compliance table for per-observation
     data and computes skip rate per instruction. Flags instructions with
-    >20% skip rate over 30+ observations for conversion to programmatic gates.
+    >20% skip rate over 30+ observations for conversion to programmatic gates —
+    but only instructions the recording hook can actually observe. Unobservable
+    ones keep their historical rows and are reported as NOT MEASURABLE.
     """
     init_db()
 
-    # Instruction ID -> human-readable name mapping
+    # Instruction ID -> human-readable name mapping. M05/M06 measure whether the
+    # directive reached the prompt, not whether the output followed it.
     instr_names: dict[str, str] = {
         "M01": "Phase Banners",
         "M03": "Routing Decision",
         "M04": "Reference Loading",
-        "M05": "Completeness",
-        "M06": "Density Standard",
+        "M05": "Completeness Injected",
+        "M06": "Density Injected",
     }
+    observable = _observable_instructions()
+
+    def _status(instr_id: str, skip_rate: float, observations: int, gate_label: str) -> str:
+        if instr_id not in observable:
+            return "NOT MEASURABLE"
+        return gate_label if skip_rate > 20 and observations >= 30 else "OK"
 
     results = query_instruction_skip_rate(days=30)
 
@@ -1482,7 +1519,7 @@ def cmd_skip_rate(args: argparse.Namespace) -> None:
                     "observations": r["observations"],
                     "non_compliant": r["non_compliant"],
                     "skip_rate": r["skip_rate"],
-                    "status": "CONVERT_TO_GATE" if r["skip_rate"] > 20 and r["observations"] >= 30 else "OK",
+                    "status": _status(instr_id, r["skip_rate"], r["observations"], "CONVERT_TO_GATE"),
                 }
             )
         print(json.dumps(report, indent=2))
@@ -1498,20 +1535,24 @@ def cmd_skip_rate(args: argparse.Namespace) -> None:
         instr_id = r["instruction_id"]
         name = instr_names.get(instr_id, instr_id)
         skip_rate = r["skip_rate"]
-
-        if skip_rate > 20 and r["observations"] >= 30:
-            status = "CONVERT TO GATE"
-        else:
-            status = "OK"
+        status = _status(instr_id, skip_rate, r["observations"], "CONVERT TO GATE")
 
         print(f"{instr_id:<6}{name:<22}{r['observations']:>14}{skip_rate:>11.1f}%{status:>17}")
 
     print("-" * 72)
-    flagged = sum(1 for r in results if r["skip_rate"] > 20 and r["observations"] >= 30)
+    flagged = sum(
+        1 for r in results if r["instruction_id"] in observable and r["skip_rate"] > 20 and r["observations"] >= 30
+    )
     if flagged:
         print(f"{flagged} instruction(s) flagged for conversion to programmatic gates (>20% skip, 30+ obs)")
     else:
         print("No instructions flagged. Threshold: >20% skip rate over 30+ observations.")
+    unmeasurable = sorted(r["instruction_id"] for r in results if r["instruction_id"] not in observable)
+    if unmeasurable:
+        print(
+            f"NOT MEASURABLE, so not scored: {', '.join(unmeasurable)} — "
+            "the recording hook cannot observe these; see hooks/instruction-compliance.py"
+        )
 
 
 _BASIS_LABELS = (

--- a/scripts/tests/test_instruction_compliance.py
+++ b/scripts/tests/test_instruction_compliance.py
@@ -256,7 +256,11 @@ class TestRecordCompliance:
                 assert len(rows) == 3
 
     def test_batch_recording(self, tmp_path: Path) -> None:
-        """Batch recording inserts all results in one transaction."""
+        """Batch recording inserts the observable results in one transaction.
+
+        M01/M03 are declared unobservable from this hook's surface and are
+        dropped. Full contract: hooks/tests/test_instruction_observability.py.
+        """
         with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": str(tmp_path)}):
             import learning_db_v2
 
@@ -269,9 +273,9 @@ class TestRecordCompliance:
 
             with learning_db_v2.get_connection() as conn:
                 rows = conn.execute("SELECT * FROM instruction_compliance").fetchall()
-                assert len(rows) == 5
+                assert len(rows) == 3
                 ids = {r["instruction_id"] for r in rows}
-                assert ids == {"M01", "M03", "M04", "M05", "M06"}
+                assert ids == {"M04", "M05", "M06"}
 
 
 # ─── Hook stdin integration tests ────────────────────────────────


### PR DESCRIPTION
The router emits `pipeline=` on the `[do-route]` marker and nothing ever parsed it, so `evidence_route_decisions.pipeline` was NULL on all 341 rows. Parsed and stored now, both surfaces.

`instruction-compliance` scored M01/M03 from PostToolUse:Agent, which never carries main-thread output — their 99.3% / 100% skip rates measured the surface, not the behavior. Instructions now declare `observable`; unobservable ones are not recorded, and `skip-rate` drops them from the CONVERT TO GATE verdict (5 flagged to 3). Historical rows stay. M05/M06 renamed: they measure injection presence, not compliance.

`docs/route-loop-validation.md` still said to expect NO-SIGNAL; `route-signal-check.py` exits 3.
