### PR TITLE
fix(learning): unstarve the injection pool

### DIFF
--- a/agents/hook-development-engineer/references/learning-database.md
+++ b/agents/hook-development-engineer/references/learning-database.md
@@ -197,16 +197,21 @@ python3 ~/.claude/scripts/learning-db.py import-retro retro/
 ## Confidence Lifecycle
 
 ```
-New error pattern recorded at confidence 0.55
-  → Success (+0.12): 0.55 → 0.67
-  → Success (+0.12): 0.67 → 0.79  ← Now above 0.7 injection threshold
-  → Failure (-0.18): 0.79 → 0.61  ← Drops below threshold
-  → Success (+0.12): 0.61 → 0.73  ← Back above threshold
+New error pattern recorded at confidence 0.55  ← already above the injection floor
+  → Success (+0.15): 0.55 → 0.70
+  → Failure (-0.10): 0.70 → 0.60
+  → Stale 30 days (-0.05): 0.60 → 0.55
 
-Injection threshold: ≥ 0.7
+Injection floor: learning_db_v2.INJECTION_MIN_CONFIDENCE (0.5)
 Pruning threshold: < 0.3 AND older than 90 days
-Graduation: manually marked when embedded into agent/skill
+Graduation: marked when the knowledge is embedded in a durable repo file
 ```
+
+The floor must stay strictly below the lowest birth confidence. Confidence
+rises only for learnings that get injected, so a floor at or above birth
+confidence is a one-way ratchet: a new learning never injects, so it never gets
+boosted, so it never crosses the floor. Both injectors import the constant;
+`hooks/tests/test_injection_floor.py` fails if it ever rises.
 
 ---
 
@@ -217,7 +222,19 @@ When a learning is mature enough to embed directly into an agent:
 ```python
 from learning_db_v2 import mark_graduated
 
-mark_graduated("go-patterns", "mutex-over-atomics", "golang-general-engineer")
+mark_graduated("go-patterns", "mutex-over-atomics", "agent:golang-general-engineer")
 ```
 
-Graduated entries are excluded from injection by default (`exclude_graduated=True`).
+Graduated entries are excluded from injection by default (`exclude_graduated=True`),
+so the target must name a durable repo artifact. `mark_graduated` resolves
+`agent:X` to `agents/X.md`, `skill:X` to that skill's `SKILL.md`, and
+`target:PATH` to `PATH`. It refuses ephemeral targets (`session-artifact`,
+`pruned:*`) and returns False; a path-shaped target that does not resolve is
+written with a stderr warning.
+
+Repair a database that already carries bad targets:
+
+```bash
+python3 scripts/learning-db.py repair-graduations          # dry run: review the table
+python3 scripts/learning-db.py repair-graduations --apply  # clear non-durable targets
+```

--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -21,6 +21,8 @@ import json
 import os
 import re
 import sqlite3
+import sys
+from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -43,6 +45,25 @@ CATEGORY_DEFAULTS = {
 }
 
 VALID_CATEGORIES = set(CATEGORY_DEFAULTS.keys())
+
+# Confidence floor for injecting a learning into context. Shared by every
+# injector (hooks/pretool-learning-injector.py, hooks/session-context.py) so
+# the value cannot drift apart in two places.
+#
+# INVARIANT: the floor must sit strictly below the lowest birth confidence in
+# CATEGORY_DEFAULTS for any injectable category (error, at 0.55, is the lowest
+# today). Confidence rises only for learnings that get injected: an injected
+# hint is re-recorded and boosted, an un-injected one never is. So a floor at
+# or above birth confidence is a one-way ratchet -- a new learning never
+# injects, so it never gets boosted, so it never crosses the floor -- while
+# confidence-decay.py keeps pulling it down. A 0.70 floor against a 0.55 birth
+# confidence starved the injectable pool to 3 rows.
+#
+# 0.5 also absorbs float drift: decay stores 0.55 - 0.05 as 0.5499999999999999,
+# strictly below a naive 0.55 floor.
+#
+# Enforced by hooks/tests/test_injection_floor.py.
+INJECTION_MIN_CONFIDENCE = 0.5
 
 # Carried over from learning_db.py for backward compatibility
 ERROR_TYPES = {
@@ -1806,12 +1827,145 @@ def decay_confidence(topic: str, key: str, delta: float = 0.10) -> float:
         return new_conf
 
 
-def mark_graduated(topic: str, key: str, target: str) -> bool:
+# ─── Graduation Targets ───────────────────────────────────────
+#
+# A graduated learning is excluded from injection forever (exclude_graduated is
+# the default in query_learnings/search_learnings). So `graduated_to` must name
+# a durable artifact in the repo. Ephemeral values -- "session-artifact" and the
+# "pruned:" family -- suppressed 98 rows permanently while naming nothing a
+# reader could open.
+
+_GRADUATION_SENTINELS = frozenset({"session-artifact", "environment-artifact"})
+_GRADUATION_SENTINEL_PREFIXES = ("pruned:",)
+
+_AGENT_PREFIX = "agent:"
+_SKILL_PREFIX = "skill:"
+_TARGET_PREFIX = "target:"
+
+# agent:/skill: names index into a fixed layout, so keep them to plain names.
+_SAFE_TARGET_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+# Result of resolving a `graduated_to` value against the repo tree.
+#   raw:      the stored value, stripped
+#   path:     repo-relative path it normalizes to, or None when not path-shaped
+#   durable:  True when `path` exists inside the repo
+#   reason:   resolved | missing | outside-repo | sentinel | empty
+#
+# collections.namedtuple, not typing.NamedTuple: `typing` costs ~4ms to import
+# and this module loads on every Bash and Edit tool call.
+GraduationTarget = namedtuple("GraduationTarget", "raw path durable reason")
+
+
+def default_repo_root() -> Path:
+    """Return the repo root: CLAUDE_PROJECT_DIR, else nearest .git ancestor, else cwd."""
+    env_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env_dir:
+        return Path(env_dir)
+    cwd = Path.cwd()
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return cwd
+
+
+def _resolve_repo_path(raw: str, value: str, root: Path) -> GraduationTarget:
+    """Resolve a path-shaped target under `root`. Anything escaping it is out of repo."""
+    try:
+        root_real = root.expanduser().resolve()
+        expanded = Path(value).expanduser()
+        candidate = expanded if expanded.is_absolute() else root_real / expanded
+        rel = candidate.resolve().relative_to(root_real)
+    except (ValueError, OSError, RuntimeError):
+        return GraduationTarget(raw, None, False, "outside-repo")
+
+    rel_str = rel.as_posix()
+    if not rel_str or rel_str == ".":
+        return GraduationTarget(raw, None, False, "outside-repo")
+    if (root_real / rel_str).exists():
+        return GraduationTarget(raw, rel_str, True, "resolved")
+    return GraduationTarget(raw, rel_str, False, "missing")
+
+
+def resolve_graduation_target(target: object, *, repo_root: Path | str | None = None) -> GraduationTarget:
+    """Resolve a `graduated_to` value to a durable repo artifact.
+
+    Normalizes every notation the database carries:
+    `agent:X` -> `agents/X.md`, `skill:X` -> that skill's SKILL.md in any
+    group, `target:PATH` -> `PATH`, and a bare path as-is. Values naming no
+    file -- sentinels, deleted paths, machine-local paths outside the repo --
+    come back with durable=False.
+
+    Args:
+        target: The stored `graduated_to` value.
+        repo_root: Root to resolve against. Defaults to default_repo_root().
+    """
+    raw = target.strip() if isinstance(target, str) else ""
+    if not raw:
+        return GraduationTarget(raw, None, False, "empty")
+
+    root = Path(repo_root) if repo_root is not None else default_repo_root()
+
+    value = raw
+    if value.startswith(_TARGET_PREFIX):
+        value = value[len(_TARGET_PREFIX) :].strip()
+        if not value:
+            return GraduationTarget(raw, None, False, "empty")
+
+    lowered = value.lower()
+    if lowered in _GRADUATION_SENTINELS or lowered.startswith(_GRADUATION_SENTINEL_PREFIXES):
+        return GraduationTarget(raw, None, False, "sentinel")
+
+    if value.startswith(_AGENT_PREFIX):
+        name = value[len(_AGENT_PREFIX) :].strip()
+        if not _SAFE_TARGET_NAME.match(name):
+            return GraduationTarget(raw, None, False, "missing")
+        return _resolve_repo_path(raw, f"agents/{name}.md", root)
+
+    if value.startswith(_SKILL_PREFIX):
+        name = value[len(_SKILL_PREFIX) :].strip()
+        if not _SAFE_TARGET_NAME.match(name):
+            return GraduationTarget(raw, None, False, "missing")
+        for match in sorted(root.glob(f"skills/*/{name}/SKILL.md")):
+            return _resolve_repo_path(raw, match.relative_to(root).as_posix(), root)
+        return GraduationTarget(raw, f"skills/{name}", False, "missing")
+
+    return _resolve_repo_path(raw, value, root)
+
+
+def mark_graduated(topic: str, key: str, target: str, *, repo_root: Path | str | None = None) -> bool:
     """Mark entry as graduated to a permanent location.
 
+    Refuses ephemeral targets (`session-artifact`, `pruned:*`, empty): a
+    graduated row never injects again, and a session artifact is not a durable
+    home for a learning. A path-shaped target that does not currently resolve
+    is written with a warning, because the file may exist in another checkout.
+
+    Args:
+        topic: Learning topic.
+        key: Learning key.
+        target: Durable artifact the knowledge moved into.
+        repo_root: Root used to resolve `target`. Defaults to default_repo_root().
+
     Returns:
-        True if an entry was updated, False if no matching entry was found.
+        True if an entry was updated, False if the target was refused or no
+        matching entry was found.
     """
+    resolved = resolve_graduation_target(target, repo_root=repo_root)
+    if resolved.reason in ("sentinel", "empty"):
+        print(
+            f"WARNING: mark_graduated refused non-durable target {target!r} for "
+            f"{topic}/{key} — graduation needs a durable file in the repo",
+            file=sys.stderr,
+        )
+        return False
+    if not resolved.durable:
+        print(
+            f"WARNING: mark_graduated target {target!r} does not resolve to a repo "
+            f"file ({resolved.reason}) — recording anyway for {topic}/{key}",
+            file=sys.stderr,
+        )
+
     init_db()
     with get_connection() as conn:
         cursor = conn.execute(
@@ -1820,8 +1974,6 @@ def mark_graduated(topic: str, key: str, target: str) -> bool:
         )
         conn.commit()
         if cursor.rowcount == 0:
-            import sys
-
             print(f"WARNING: mark_graduated found no entry for topic={topic!r} key={key!r}", file=sys.stderr)
             return False
         return True

--- a/hooks/pretool-learning-injector.py
+++ b/hooks/pretool-learning-injector.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 """
 PreToolUse Hook: Proactive Learning Injection
 
@@ -14,7 +14,7 @@ Design Principles:
 - Sub-50ms execution (fires on EVERY tool use)
 - Non-blocking (always exits 0)
 - Lightweight output (max 500 chars to avoid context bloat)
-- Only injects for high-confidence patterns (>= 0.7)
+- Only injects at or above learning_db_v2.INJECTION_MIN_CONFIDENCE
 """
 
 import json
@@ -26,8 +26,12 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
+# INJECTION_MIN_CONFIDENCE is the shared injection floor, defined once in
+# learning_db_v2 so it cannot drift above birth confidence. A floor above birth
+# confidence starves the pool: a new learning never injects, so it never gets
+# boosted, so it never crosses the floor.
 from hook_utils import context_output, empty_output, get_session_id, record_activations_safe
-from learning_db_v2 import sanitize_for_context
+from learning_db_v2 import INJECTION_MIN_CONFIDENCE, sanitize_for_context
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "PreToolUse"
@@ -37,9 +41,6 @@ MAX_CONTEXT_CHARS = 500
 
 # Max DB results to fetch
 MAX_RESULTS = 3
-
-# Minimum confidence for injection
-MIN_CONFIDENCE = 0.7
 
 # Keywords extracted from commands that map to learnable domains.
 # These are intentionally broad — the DB query narrows via tag matching.
@@ -168,6 +169,30 @@ def extract_edit_tags(tool_input: dict) -> list[str]:
     return list(tags)[:10]
 
 
+# error-learner stores a learning as "<error> <arrow> <solution>" and re-records
+# nest it ("<error> <arrow> <previous value>"), so the LAST arrow marks the
+# solution. Unicode is the arrow in use (762 rows); 7 older rows use ASCII.
+_SOLUTION_SEPARATORS = (" \u2192 ", " -> ")
+
+
+def _solution_summary(value: str) -> str:
+    """Return the one-line solution half of a stored learning value.
+
+    Searches the whole value, not just its first line: a captured error message
+    is usually multi-line, so the arrow sits on the last line. Reading only the
+    first line surfaced the raw capture instead -- nginx configs, ssh debug
+    output, diff hunks -- as the hint. Values with no arrow (prose gotchas) fall
+    back to their first line.
+    """
+    for separator in _SOLUTION_SEPARATORS:
+        if separator in value:
+            value = value.rsplit(separator, 1)[1]
+            break
+    line = value.split("\n")[0]
+    # Drop control characters (BEL, ANSI escapes) captured from tool output.
+    return "".join(ch for ch in line if ch >= " " or ch == "\t").strip()[:120]
+
+
 def format_hints(results: list[dict]) -> str:
     """Format DB results as a compact hint string.
 
@@ -175,17 +200,15 @@ def format_hints(results: list[dict]) -> str:
     """
     lines = ["[learning-hint] Known patterns for this operation:"]
     chars = len(lines[0])
+    seen: set[str] = set()
 
     for r in results:
-        # Build a one-line summary from the value field
-        value = sanitize_for_context(r.get("value", ""))
-        first_line = value.split("\n")[0]
-
-        # If value has " -> " separator (error -> solution format), use the solution part
-        if " -> " in first_line:
-            summary = first_line.split(" -> ", 1)[1][:120]
-        else:
-            summary = first_line[:120]
+        summary = _solution_summary(sanitize_for_context(r.get("value", "")))
+        # Distinct rows often carry the same generic solution ("Fix timeout
+        # error in Bash"). Emit it once -- repeats only eat the char budget.
+        if not summary or summary in seen:
+            continue
+        seen.add(summary)
 
         category = r.get("category", "")
         error_type = r.get("error_type", "")
@@ -241,7 +264,7 @@ def main():
         query_str = " OR ".join(tags)
         results = search_learnings(
             query_str,
-            min_confidence=MIN_CONFIDENCE,
+            min_confidence=INJECTION_MIN_CONFIDENCE,
             exclude_graduated=True,
             categories=INJECTABLE_CATEGORIES,
             project_path=cwd,

--- a/hooks/session-context.py
+++ b/hooks/session-context.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 2.0.0
+# hook-version: 2.1.0
 """
 SessionStart Hook: Learning Context Loader
 
@@ -12,7 +12,7 @@ and surfaces a one-line overnight dream notice (if dream ran recently).
 Design Principles:
 - SILENT unless meaningful patterns found
 - Project-aware (loads patterns for current directory)
-- High-confidence only (>0.7 threshold)
+- Confidence-gated by learning_db_v2.INJECTION_MIN_CONFIDENCE
 - Fast execution (<50ms target)
 - Non-blocking (always exits 0)
 - Pure file reader for dream integration — no LLM work, no learning.db queries
@@ -28,6 +28,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import context_output, empty_output, get_session_id, hook_error, record_activations_safe
 from learning_db_v2 import (
+    INJECTION_MIN_CONFIDENCE,
     get_stats,
     query_learnings,
     sanitize_for_context,
@@ -158,7 +159,7 @@ def main():
         # Get high-confidence learnings from learning.db
         learnings = query_learnings(
             category="error",
-            min_confidence=0.7,
+            min_confidence=INJECTION_MIN_CONFIDENCE,
             project_path=cwd,
             limit=10,
         )

--- a/hooks/tests/test_graduation_targets.py
+++ b/hooks/tests/test_graduation_targets.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Tests for graduation-target resolution and the mark_graduated write guard.
+
+A graduated learning is suppressed from injection forever, so `graduated_to`
+must name a durable artifact in the repo. Ephemeral sentinels such as
+`session-artifact` suppressed 97 rows permanently.
+
+Covers:
+- every notation the database carries: bare path, `agent:X`, `skill:X`,
+  `target:PATH`, sentinels, out-of-repo paths, traversal, empty;
+- mark_graduated refuses a sentinel target and records nothing;
+- mark_graduated warns but still writes a path-shaped target that is missing.
+
+Run with: python3 -m pytest hooks/tests/test_graduation_targets.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import learning_db_v2 as db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    """Use a fresh temp learning.db for each test -- never the real one."""
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path / "learning"))
+    db._initialized = False
+    yield
+    db._initialized = False
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A tmp tree shaped like the toolkit repo."""
+    root = tmp_path / "repo"
+    for rel in (
+        "agents/golang-general-engineer.md",
+        "skills/meta/install/SKILL.md",
+        "skills/process/worktree-agent/SKILL.md",
+        "skills/meta/retro/SKILL.md",
+        "docs/what-didnt-work.md",
+        "hooks/error-learner.py",
+    ):
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("stub\n")
+    (root / "scripts").mkdir(parents=True, exist_ok=True)
+    return root
+
+
+class TestResolveGraduationTarget:
+    def test_repo_relative_path_that_exists_is_durable(self, repo):
+        result = db.resolve_graduation_target("docs/what-didnt-work.md", repo_root=repo)
+        assert result.durable is True
+        assert result.reason == "resolved"
+        assert result.path == "docs/what-didnt-work.md"
+
+    def test_repo_relative_directory_that_exists_is_durable(self, repo):
+        result = db.resolve_graduation_target("scripts/", repo_root=repo)
+        assert result.durable is True
+
+    def test_repo_relative_path_that_is_missing_is_not_durable(self, repo):
+        result = db.resolve_graduation_target("agents/general-purpose.md", repo_root=repo)
+        assert result.durable is False
+        assert result.reason == "missing"
+        assert result.path == "agents/general-purpose.md"
+
+    def test_agent_prefix_normalizes_to_agents_markdown(self, repo):
+        result = db.resolve_graduation_target("agent:golang-general-engineer", repo_root=repo)
+        assert result.durable is True
+        assert result.path == "agents/golang-general-engineer.md"
+
+    def test_agent_prefix_for_unknown_agent_is_not_durable(self, repo):
+        result = db.resolve_graduation_target("agent:general-purpose", repo_root=repo)
+        assert result.durable is False
+        assert result.reason == "missing"
+
+    def test_skill_prefix_normalizes_to_skill_directory(self, repo):
+        result = db.resolve_graduation_target("skill:install", repo_root=repo)
+        assert result.durable is True
+        assert result.path == "skills/meta/install/SKILL.md"
+
+    def test_skill_prefix_finds_skill_in_any_group(self, repo):
+        result = db.resolve_graduation_target("skill:worktree-agent", repo_root=repo)
+        assert result.durable is True
+        assert result.path == "skills/process/worktree-agent/SKILL.md"
+
+    def test_skill_prefix_for_unknown_skill_is_not_durable(self, repo):
+        result = db.resolve_graduation_target("skill:does-not-exist", repo_root=repo)
+        assert result.durable is False
+
+    def test_target_prefix_strips_to_the_path(self, repo):
+        result = db.resolve_graduation_target("target:skills/meta/retro/SKILL.md", repo_root=repo)
+        assert result.durable is True
+        assert result.path == "skills/meta/retro/SKILL.md"
+
+    def test_target_prefix_composes_with_agent_prefix(self, repo):
+        result = db.resolve_graduation_target("target:agents/golang-general-engineer.md", repo_root=repo)
+        assert result.durable is True
+
+    @pytest.mark.parametrize("sentinel", ["session-artifact", "pruned:environment-artifact", "pruned:anything"])
+    def test_sentinels_are_not_durable(self, sentinel, repo):
+        result = db.resolve_graduation_target(sentinel, repo_root=repo)
+        assert result.durable is False
+        assert result.reason == "sentinel"
+        assert result.path is None
+
+    @pytest.mark.parametrize("value", ["", "   ", None])
+    def test_empty_target_is_not_durable(self, value, repo):
+        result = db.resolve_graduation_target(value, repo_root=repo)
+        assert result.durable is False
+        assert result.reason == "empty"
+
+    def test_absolute_path_outside_the_repo_is_not_durable(self, repo, tmp_path):
+        outside = tmp_path / "elsewhere" / "SKILL.md"
+        outside.parent.mkdir(parents=True, exist_ok=True)
+        outside.write_text("stub\n")
+        result = db.resolve_graduation_target(str(outside), repo_root=repo)
+        assert result.durable is False
+        assert result.reason == "outside-repo"
+
+    def test_home_relative_path_is_not_durable(self, repo):
+        result = db.resolve_graduation_target("~/.claude/hooks/scanner.py", repo_root=repo)
+        assert result.durable is False
+        assert result.reason == "outside-repo"
+
+    def test_traversal_escaping_the_repo_is_not_durable(self, repo):
+        result = db.resolve_graduation_target("../../etc/passwd", repo_root=repo)
+        assert result.durable is False
+        assert result.reason == "outside-repo"
+
+    def test_absolute_path_inside_the_repo_resolves_relative(self, repo):
+        result = db.resolve_graduation_target(str(repo / "docs/what-didnt-work.md"), repo_root=repo)
+        assert result.durable is True
+        assert result.path == "docs/what-didnt-work.md"
+
+    def test_skill_name_with_a_slash_is_rejected(self, repo):
+        result = db.resolve_graduation_target("skill:../../etc", repo_root=repo)
+        assert result.durable is False
+
+
+class TestMarkGraduatedGuard:
+    def _seed(self):
+        db.record_learning(
+            topic="import_error",
+            key="sig-1",
+            value="module missing -> pip install it",
+            category="error",
+            source="hook:error-learner",
+        )
+
+    def _graduated_to(self):
+        with db.get_connection() as conn:
+            row = conn.execute(
+                "SELECT graduated_to FROM learnings WHERE topic = 'import_error' AND key = 'sig-1'"
+            ).fetchone()
+        return row["graduated_to"]
+
+    def test_sentinel_target_is_refused_and_nothing_is_written(self, repo, capsys):
+        self._seed()
+        assert db.mark_graduated("import_error", "sig-1", "session-artifact", repo_root=repo) is False
+        assert self._graduated_to() is None
+        assert "session-artifact" in capsys.readouterr().err
+
+    def test_pruned_sentinel_is_refused(self, repo):
+        self._seed()
+        assert db.mark_graduated("import_error", "sig-1", "pruned:environment-artifact", repo_root=repo) is False
+        assert self._graduated_to() is None
+
+    def test_durable_target_is_written_without_warning(self, repo, capsys):
+        self._seed()
+        assert db.mark_graduated("import_error", "sig-1", "agent:golang-general-engineer", repo_root=repo) is True
+        assert self._graduated_to() == "agent:golang-general-engineer"
+        assert capsys.readouterr().err == ""
+
+    def test_missing_path_target_warns_but_still_writes(self, repo, capsys):
+        self._seed()
+        assert db.mark_graduated("import_error", "sig-1", "agents/not-yet-created.md", repo_root=repo) is True
+        assert self._graduated_to() == "agents/not-yet-created.md"
+        assert "does not resolve" in capsys.readouterr().err
+
+    def test_missing_row_still_returns_false(self, repo):
+        assert db.mark_graduated("nope", "nope", "agent:golang-general-engineer", repo_root=repo) is False

--- a/hooks/tests/test_injection_floor.py
+++ b/hooks/tests/test_injection_floor.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Tests for the shared learning-injection confidence floor.
+
+The floor must sit strictly below the birth confidence of every injectable
+category. Confidence rises only for learnings that get injected, so a floor at
+or above birth confidence is a one-way ratchet: a new learning never injects,
+so it never gets boosted, so it never crosses the floor -- while decay pulls it
+further down. That ratchet starved the injectable pool (activations fell from
+9,755 rows in one month to 1 in the next).
+
+Covers:
+- the floor sits strictly below the lowest injectable birth confidence;
+- neither injector hardcodes its own floor literal;
+- both injectors return a learning seeded at the error birth confidence.
+
+Run with: python3 -m pytest hooks/tests/test_injection_floor.py -v
+"""
+
+import importlib.util
+import io
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import learning_db_v2 as db
+
+_HOOKS_DIR = Path(__file__).resolve().parent.parent
+PRETOOL_PATH = _HOOKS_DIR / "pretool-learning-injector.py"
+SESSION_CONTEXT_PATH = _HOOKS_DIR / "session-context.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pretool = _load("pretool_learning_injector", PRETOOL_PATH)
+session_context = _load("session_context", SESSION_CONTEXT_PATH)
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    """Use a fresh temp learning.db for each test -- never the real one."""
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path))
+    db._initialized = False
+    yield tmp_path
+    db._initialized = False
+
+
+def _additional_context(output: str) -> str:
+    if not output.strip():
+        return ""
+    parsed = json.loads(output.strip())
+    return parsed.get("hookSpecificOutput", {}).get("additionalContext", "") or ""
+
+
+# ---------------------------------------------------------------------------
+# The invariant
+# ---------------------------------------------------------------------------
+
+
+class TestFloorInvariant:
+    def test_floor_sits_below_every_injectable_birth_confidence(self):
+        """The bug that starved the pool. Keep this assertion strict."""
+        # session-context injects category "error"; the pretool injector adds
+        # the rest of its allowlist.
+        injectable = set(pretool.INJECTABLE_CATEGORIES) | {"error"}
+        lowest_birth = min(db.CATEGORY_DEFAULTS[c] for c in injectable)
+        assert lowest_birth > db.INJECTION_MIN_CONFIDENCE, (
+            f"injection floor {db.INJECTION_MIN_CONFIDENCE} is not below the lowest "
+            f"injectable birth confidence {lowest_birth}; newly captured learnings "
+            "can never enter the loop that would raise them"
+        )
+
+    def test_every_injectable_category_has_a_birth_confidence(self):
+        for category in set(pretool.INJECTABLE_CATEGORIES) | {"error"}:
+            assert category in db.CATEGORY_DEFAULTS
+
+    @pytest.mark.parametrize("path", [PRETOOL_PATH, SESSION_CONTEXT_PATH])
+    def test_injector_does_not_hardcode_a_floor(self, path):
+        """Both injectors must read the shared constant, not a local literal."""
+        source = path.read_text()
+        hardcoded = re.search(r"min_confidence\s*=\s*[0-9]", source, re.IGNORECASE)
+        assert hardcoded is None, f"{path.name} hardcodes a confidence floor: {hardcoded.group(0)!r}"
+        assert "INJECTION_MIN_CONFIDENCE" in source
+
+
+# ---------------------------------------------------------------------------
+# Both injectors surface a learning born at the error default
+# ---------------------------------------------------------------------------
+
+
+class TestInjectorsSeeBirthConfidenceLearnings:
+    def test_pretool_injector_returns_hint_for_birth_confidence_learning(self, tmp_path):
+        db.record_learning(
+            topic="import_error",
+            key="pytest-missing-plugin",
+            value="pytest fails on a missing plugin -> pip install the plugin first",
+            category="error",
+            confidence=db.CATEGORY_DEFAULTS["error"],
+            tags=["python", "pytest"],
+            source="hook:error-learner",
+            project_path=str(tmp_path),
+        )
+
+        event = json.dumps(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "pytest hooks/tests"},
+                "cwd": str(tmp_path),
+            }
+        )
+        stdout = io.StringIO()
+        with (
+            patch.object(pretool, "read_stdin", return_value=event),
+            patch("sys.stdout", stdout),
+        ):
+            try:
+                pretool.main()
+            except SystemExit:
+                pass
+
+        context = _additional_context(stdout.getvalue())
+        assert "learning-hint" in context
+        assert "pip install the plugin" in context
+
+    def test_session_context_returns_birth_confidence_learning(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        db.record_learning(
+            topic="missing_file",
+            key="config-not-found",
+            value="config.yaml missing -> create it from config.yaml.example",
+            category="error",
+            confidence=db.CATEGORY_DEFAULTS["error"],
+            source="hook:error-learner",
+            project_path=str(project),
+        )
+
+        monkeypatch.chdir(project)
+        stdout = io.StringIO()
+        with (
+            patch.object(session_context, "inject_dream_payload", return_value=""),
+            patch.object(session_context, "surface_dream_report", return_value=""),
+            patch("sys.stdout", stdout),
+        ):
+            try:
+                session_context.main()
+            except SystemExit:
+                pass
+
+        context = _additional_context(stdout.getvalue())
+        assert "[learned-context] Loaded 1 high-confidence patterns" in context
+
+    def test_session_context_activation_is_recorded(self, tmp_path, monkeypatch):
+        """Injection must land a row in activations -- the ROI signal that went to zero."""
+        project = tmp_path / "project"
+        project.mkdir()
+        db.record_learning(
+            topic="permissions",
+            key="denied-on-write",
+            value="permission denied -> check the directory mode before writing",
+            category="error",
+            confidence=db.CATEGORY_DEFAULTS["error"],
+            source="hook:error-learner",
+            project_path=str(project),
+        )
+
+        monkeypatch.chdir(project)
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "test-session")
+        stdout = io.StringIO()
+        with (
+            patch.object(session_context, "inject_dream_payload", return_value=""),
+            patch.object(session_context, "surface_dream_report", return_value=""),
+            patch("sys.stdout", stdout),
+        ):
+            try:
+                session_context.main()
+            except SystemExit:
+                pass
+
+        with db.get_connection() as conn:
+            rows = conn.execute("SELECT topic, key FROM activations").fetchall()
+        assert [(r["topic"], r["key"]) for r in rows] == [("permissions", "denied-on-write")]
+
+
+# ---------------------------------------------------------------------------
+# Non-blocking contract
+# ---------------------------------------------------------------------------
+
+
+class TestNonBlocking:
+    @pytest.mark.parametrize("hook", [PRETOOL_PATH, SESSION_CONTEXT_PATH])
+    def test_hook_exits_zero_on_empty_stdin(self, hook, tmp_path):
+        import subprocess
+
+        env = dict(os.environ, CLAUDE_LEARNING_DIR=str(tmp_path))
+        result = subprocess.run(
+            [sys.executable, str(hook)],
+            input="",
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=15,
+        )
+        assert result.returncode == 0, result.stderr

--- a/hooks/tests/test_pretool_learning_injector.py
+++ b/hooks/tests/test_pretool_learning_injector.py
@@ -366,3 +366,78 @@ class TestInjectorStillFires:
         _record("go-patterns", "low-conf", "Low confidence tip", category="error", confidence=0.4)
         parsed = _run_main(_make_bash_event("go test ./..."))
         assert _additional_context(parsed) == ""
+
+
+# ---------------------------------------------------------------------------
+# format_hints separator handling
+# ---------------------------------------------------------------------------
+
+
+class TestFormatHintsSeparator:
+    """error-learner writes "<error> → <solution>" with a Unicode arrow.
+
+    format_hints must show the solution half. Splitting on the ASCII "->" only
+    made it emit the raw captured error text instead -- nginx configs, ssh
+    debug output, diff hunks -- for the 762 rows that store the Unicode form.
+    """
+
+    def test_unicode_arrow_yields_the_solution_half(self):
+        hints = mod.format_hints(
+            [{"value": "ls: cannot access '/tmp/x' → create the directory first", "error_type": "missing_file"}]
+        )
+        assert "create the directory first" in hints
+        assert "cannot access" not in hints
+
+    def test_ascii_arrow_yields_the_solution_half(self):
+        hints = mod.format_hints(
+            [{"value": "Found 3 matches -> pass replace_all=True", "error_type": "multiple_matches"}]
+        )
+        assert "pass replace_all=True" in hints
+        assert "Found 3 matches" not in hints
+
+    def test_multiline_error_finds_the_arrow_on_a_later_line(self):
+        """The stored error half is usually multi-line, so the arrow is last."""
+        value = (
+            "server {\n    listen 80;\n}\nnginx: configuration file test failed \u2192 run nginx -t and fix the block"
+        )
+        hints = mod.format_hints([{"value": value, "error_type": "unknown"}])
+        assert "run nginx -t and fix the block" in hints
+        assert "server {" not in hints
+
+    def test_nested_arrows_keep_the_innermost_solution(self):
+        """Re-recording nests "<error> -> <previous value>"; the last arrow wins."""
+        value = "exit 1 \u2192 timeout on fetch \u2192 retry with a longer --timeout"
+        hints = mod.format_hints([{"value": value, "error_type": "timeout"}])
+        assert "retry with a longer --timeout" in hints
+        assert "exit 1" not in hints
+
+    def test_control_characters_are_stripped_from_the_hint(self):
+        hints = mod.format_hints([{"value": "\x07mysqladmin: connect failed", "error_type": "unknown"}])
+        assert "\x07" not in hints
+        assert "mysqladmin: connect failed" in hints
+
+    def test_identical_summaries_are_emitted_once(self):
+        """Distinct rows often share one generic solution; repeating it wastes the budget."""
+        results = [
+            {"value": "diff --git a/x \u2192 Fix timeout error in Bash", "error_type": "timeout"},
+            {"value": "some other capture \u2192 Fix timeout error in Bash", "error_type": "timeout"},
+            {"value": "third capture \u2192 Fix unknown error in Bash", "error_type": "unknown"},
+        ]
+        hints = mod.format_hints(results)
+        assert hints.count("Fix timeout error in Bash") == 1
+        assert hints.count("Fix unknown error in Bash") == 1
+
+    def test_value_without_a_separator_falls_back_to_the_first_line(self):
+        hints = mod.format_hints([{"value": "Prefer rg over grep", "category": "gotcha"}])
+        assert "Prefer rg over grep" in hints
+
+    def test_end_to_end_injection_shows_the_solution(self):
+        _record(
+            "go-patterns",
+            "sig-unicode",
+            "go test: config.yaml: No such file or directory → copy config.yaml.example first",
+        )
+        parsed = _run_main(_make_bash_event("go test ./..."))
+        context = _additional_context(parsed)
+        assert "copy config.yaml.example first" in context
+        assert "No such file or directory" not in context

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -14,6 +14,8 @@ Usage:
     python3 scripts/learning-db.py import --from-retro ~/.claude/retro
     python3 scripts/learning-db.py import --from-patterns ~/.claude/learning/patterns.db
     python3 scripts/learning-db.py graduate TOPIC KEY TARGET
+    python3 scripts/learning-db.py repair-graduations [--repo-root PATH] [--json]
+    python3 scripts/learning-db.py repair-graduations --apply
     python3 scripts/learning-db.py boost TOPIC KEY [--delta 0.15]
     python3 scripts/learning-db.py prune --category error --dry-run
     python3 scripts/learning-db.py prune --topic unknown --max-confidence 0.5 --older-than 90 --apply
@@ -66,8 +68,10 @@ _repo_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_repo_root / "hooks" / "lib"))
 
 from learning_db_v2 import (
+    INJECTION_MIN_CONFIDENCE,
     boost_confidence,
     decay_confidence,
+    default_repo_root,
     export_markdown,
     get_connection,
     get_db_path,
@@ -84,6 +88,7 @@ from learning_db_v2 import (
     query_instruction_skip_rate,
     query_learnings,
     record_learning,
+    resolve_graduation_target,
     search_learnings,
 )
 
@@ -210,8 +215,145 @@ def cmd_import(args):
 
 
 def cmd_graduate(args):
-    mark_graduated(args.topic, args.key, args.target)
+    if not mark_graduated(args.topic, args.key, args.target):
+        print(f"Not graduated: {args.topic}/{args.key} → {args.target}", file=sys.stderr)
+        sys.exit(1)
     print(f"Graduated: {args.topic}/{args.key} → {args.target}")
+
+
+# Categories the injectors read. Kept in sync with
+# hooks/pretool-learning-injector.py INJECTABLE_CATEGORIES; session-context.py
+# reads the "error" subset.
+_INJECTABLE_CATEGORIES = ("error", "gotcha", "debug")
+
+_POOL_SQL = (
+    "SELECT COUNT(*) FROM learnings "
+    "WHERE category IN ('error', 'gotcha', 'debug') "
+    "AND source NOT LIKE 'test%' "
+    "AND confidence >= ? "
+)
+
+
+def _pool_count(conn: sqlite3.Connection) -> int:
+    """Rows the injectors can currently reach."""
+    return conn.execute(_POOL_SQL + "AND graduated_to IS NULL", (INJECTION_MIN_CONFIDENCE,)).fetchone()[0]
+
+
+def _pool_gain(conn: sqlite3.Connection, targets: list[str]) -> int:
+    """Rows that would rejoin the pool if `targets` were cleared."""
+    if not targets:
+        return 0
+    gained = 0
+    for chunk in _chunks(targets, 400):
+        placeholders = ", ".join("?" for _ in chunk)
+        gained += conn.execute(
+            _POOL_SQL
+            + f"AND graduated_to IN ({placeholders})",  # security-review: ignore (placeholders only; values bound as ?)
+            (INJECTION_MIN_CONFIDENCE, *chunk),
+        ).fetchone()[0]
+    return gained
+
+
+def _chunks(items: list, size: int):
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def cmd_repair_graduations(args):
+    """Clear graduated_to where the target names no durable repo artifact.
+
+    Dry-run by default; --apply writes. A graduated row is excluded from
+    injection forever, so a target that resolves nowhere — an ephemeral
+    "session-artifact", a deleted path, a machine-local path outside the repo —
+    suppresses the row for nothing. Targets that resolve are left graduated,
+    including the agent:/skill:/target: notations, which are normalized before
+    the existence check.
+    """
+    repo_root = Path(args.repo_root) if args.repo_root else default_repo_root()
+
+    init_db()
+    with get_connection() as conn:
+        grouped = conn.execute(
+            "SELECT graduated_to AS target, COUNT(*) AS n FROM learnings "
+            "WHERE graduated_to IS NOT NULL AND TRIM(graduated_to) != '' "
+            "GROUP BY graduated_to ORDER BY n DESC, target"
+        ).fetchall()
+
+        rows = []
+        for row in grouped:
+            resolved = resolve_graduation_target(row["target"], repo_root=repo_root)
+            rows.append(
+                {
+                    "target": row["target"],
+                    "count": row["n"],
+                    "resolves_to": resolved.path,
+                    "resolved": resolved.durable,
+                    "reason": resolved.reason,
+                    "action": "keep" if resolved.durable else "clear",
+                }
+            )
+
+        clear_targets = [r["target"] for r in rows if r["action"] == "clear"]
+        rows_to_clear = sum(r["count"] for r in rows if r["action"] == "clear")
+        pool_before = _pool_count(conn)
+        pool_after = pool_before + _pool_gain(conn, clear_targets)
+
+        cleared = None
+        if args.apply and clear_targets:
+            for chunk in _chunks(clear_targets, 400):
+                placeholders = ", ".join("?" for _ in chunk)
+                cursor = conn.execute(
+                    f"UPDATE learnings SET graduated_to = NULL WHERE graduated_to IN ({placeholders})",  # security-review: ignore (placeholders only; values bound as ?)
+                    chunk,
+                )
+                cleared = (cleared or 0) + cursor.rowcount
+            conn.commit()
+            pool_after = _pool_count(conn)
+        elif args.apply:
+            cleared = 0
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "repo_root": str(repo_root),
+                    "applied": bool(args.apply),
+                    "targets": rows,
+                    "rows_to_clear": rows_to_clear,
+                    "rows_cleared": cleared,
+                    "pool_before": pool_before,
+                    "pool_after": pool_after,
+                    "injectable_categories": list(_INJECTABLE_CATEGORIES),
+                    "min_confidence": INJECTION_MIN_CONFIDENCE,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    print(f"Repo root: {repo_root}")
+    print(f"Graduation targets: {len(rows)} distinct, {sum(r['count'] for r in rows)} rows")
+    print()
+    print(f"{'COUNT':>5}  {'ACTION':<6}  {'REASON':<12}  TARGET")
+    for r in rows:
+        suffix = ""
+        if r["resolves_to"] and r["resolves_to"] != r["target"]:
+            suffix = f" -> {r['resolves_to']}"
+        print(f"{r['count']:>5}  {r['action']:<6}  {r['reason']:<12}  {r['target']}{suffix}")
+    print()
+    print(
+        f"Injectable pool (error/gotcha/debug, confidence >= {INJECTION_MIN_CONFIDENCE}, not graduated): "
+        f"{pool_before} -> {pool_after}"
+    )
+
+    if not args.apply:
+        print(f"Rows that would be cleared: {rows_to_clear}")
+        print()
+        print("DRY RUN — nothing written. Re-run with --apply to clear.")
+        print("Back up the database first: cp <db> <db>.bak-$(date +%Y%m%d)")
+        return
+
+    print(f"Cleared graduated_to on {cleared} rows.")
 
 
 def cmd_boost(args):
@@ -2284,6 +2426,21 @@ def main():
     p_grad.add_argument("key")
     p_grad.add_argument("target", help="Target (e.g., agent:golang-general-engineer)")
     p_grad.set_defaults(func=cmd_graduate)
+
+    p_repair = subparsers.add_parser(
+        "repair-graduations",
+        help="Clear graduated_to where the target is not a durable repo artifact (dry-run default)",
+    )
+    p_repair.add_argument(
+        "--repo-root",
+        default=None,
+        help="Root used to resolve targets (default: CLAUDE_PROJECT_DIR, else nearest .git ancestor)",
+    )
+    p_repair.add_argument("--json", action="store_true", help="Machine-readable report")
+    p_repair_mode = p_repair.add_mutually_exclusive_group()
+    p_repair_mode.add_argument("--dry-run", action="store_true", help="Preview the table (default)")
+    p_repair_mode.add_argument("--apply", action="store_true", help="Clear graduated_to on non-durable targets")
+    p_repair.set_defaults(func=cmd_repair_graduations)
 
     # boost
     p_boost = subparsers.add_parser("boost", help="Boost confidence")

--- a/scripts/tests/test_learning_db_repair_graduations.py
+++ b/scripts/tests/test_learning_db_repair_graduations.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Tests for the `repair-graduations` subcommand in scripts/learning-db.py.
+
+Covers: dry-run writes nothing, --apply clears only non-durable targets,
+alternate notations that resolve stay graduated, and the report table.
+
+Run with: python3 -m pytest scripts/tests/test_learning_db_repair_graduations.py -v
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_repo_root / "hooks" / "lib"))
+
+SCRIPT_PATH = str(_repo_root / "scripts" / "learning-db.py")
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point learning.db at a temp directory for each test -- never the real one."""
+    learning_dir = tmp_path / "learning"
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(learning_dir))
+    import importlib
+
+    import learning_db_v2
+
+    importlib.reload(learning_db_v2)
+    learning_db_v2.init_db()
+    yield learning_dir
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """A tmp tree shaped like the toolkit repo."""
+    root = tmp_path / "repo"
+    for rel in (
+        "agents/golang-general-engineer.md",
+        "skills/meta/toolkit-evolution/SKILL.md",
+        "skills/meta/install/SKILL.md",
+    ):
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("stub\n")
+    return root
+
+
+def _connect(learning_dir: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(learning_dir / "learning.db")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _insert(learning_dir: Path, topic: str, key: str, graduated_to: str | None) -> None:
+    conn = _connect(learning_dir)
+    conn.execute(
+        "INSERT INTO learnings (topic, key, value, category, confidence, source, graduated_to) "
+        "VALUES (?, ?, ?, 'error', 0.55, 'hook:error-learner', ?)",
+        (topic, key, f"value for {topic}/{key}", graduated_to),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _graduated(learning_dir: Path) -> dict[str, str | None]:
+    conn = _connect(learning_dir)
+    rows = conn.execute("SELECT key, graduated_to FROM learnings").fetchall()
+    conn.close()
+    return {r["key"]: r["graduated_to"] for r in rows}
+
+
+def _run_cli(fake_repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, SCRIPT_PATH, "repair-graduations", "--repo-root", str(fake_repo), *args],
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+        timeout=30,
+    )
+
+
+def _seed_mixed(learning_dir: Path) -> None:
+    _insert(learning_dir, "t", "durable-path", "skills/meta/toolkit-evolution/SKILL.md")
+    _insert(learning_dir, "t", "durable-agent-notation", "agent:golang-general-engineer")
+    _insert(learning_dir, "t", "durable-skill-notation", "skill:install")
+    _insert(learning_dir, "t", "sentinel", "session-artifact")
+    _insert(learning_dir, "t", "pruned-sentinel", "pruned:environment-artifact")
+    _insert(learning_dir, "t", "missing-path", "agents/general-purpose.md")
+    _insert(learning_dir, "t", "outside-repo", "~/.claude/hooks/scanner.py")
+    _insert(learning_dir, "t", "not-graduated", None)
+
+
+class TestDryRun:
+    def test_dry_run_writes_nothing(self, isolated_db, fake_repo):
+        _seed_mixed(isolated_db)
+        before = _graduated(isolated_db)
+
+        result = _run_cli(fake_repo)
+
+        assert result.returncode == 0, result.stderr
+        assert _graduated(isolated_db) == before
+        assert "DRY RUN" in result.stdout
+
+    def test_dry_run_is_the_default(self, isolated_db, fake_repo):
+        _seed_mixed(isolated_db)
+        assert _run_cli(fake_repo, "--dry-run").stdout == _run_cli(fake_repo).stdout
+
+    def test_report_lists_targets_with_count_and_action(self, isolated_db, fake_repo):
+        _seed_mixed(isolated_db)
+        out = _run_cli(fake_repo).stdout
+
+        assert "session-artifact" in out
+        assert "skills/meta/toolkit-evolution/SKILL.md" in out
+        assert "keep" in out
+        assert "clear" in out
+
+    def test_report_shows_pool_counts(self, isolated_db, fake_repo):
+        _seed_mixed(isolated_db)
+        out = _run_cli(fake_repo).stdout
+        assert "Injectable pool" in out
+
+
+class TestApply:
+    def test_apply_clears_only_non_durable_targets(self, isolated_db, fake_repo):
+        _seed_mixed(isolated_db)
+
+        result = _run_cli(fake_repo, "--apply")
+
+        assert result.returncode == 0, result.stderr
+        after = _graduated(isolated_db)
+        # Durable targets survive, in every notation.
+        assert after["durable-path"] == "skills/meta/toolkit-evolution/SKILL.md"
+        assert after["durable-agent-notation"] == "agent:golang-general-engineer"
+        assert after["durable-skill-notation"] == "skill:install"
+        # Non-durable targets are cleared.
+        assert after["sentinel"] is None
+        assert after["pruned-sentinel"] is None
+        assert after["missing-path"] is None
+        assert after["outside-repo"] is None
+        # Never-graduated rows are untouched.
+        assert after["not-graduated"] is None
+
+    def test_apply_reports_rows_cleared(self, isolated_db, fake_repo):
+        _seed_mixed(isolated_db)
+        out = _run_cli(fake_repo, "--apply").stdout
+        assert "Cleared graduated_to on 4 row" in out
+
+    def test_apply_is_idempotent(self, isolated_db, fake_repo):
+        _seed_mixed(isolated_db)
+        _run_cli(fake_repo, "--apply")
+        first = _graduated(isolated_db)
+        second = _run_cli(fake_repo, "--apply")
+        assert second.returncode == 0
+        assert _graduated(isolated_db) == first
+
+    def test_apply_on_a_clean_database_is_a_noop(self, isolated_db, fake_repo):
+        _insert(isolated_db, "t", "only-durable", "skills/meta/install/SKILL.md")
+        result = _run_cli(fake_repo, "--apply")
+        assert result.returncode == 0
+        assert _graduated(isolated_db) == {"only-durable": "skills/meta/install/SKILL.md"}
+
+
+class TestJsonOutput:
+    def test_json_output_is_machine_readable(self, isolated_db, fake_repo):
+        import json
+
+        _seed_mixed(isolated_db)
+        out = _run_cli(fake_repo, "--json").stdout
+        payload = json.loads(out)
+        by_target = {row["target"]: row for row in payload["targets"]}
+        assert by_target["session-artifact"]["action"] == "clear"
+        assert by_target["agent:golang-general-engineer"]["action"] == "keep"
+        assert payload["rows_to_clear"] == 4

--- a/skills/meta/auto-dream/dream-prompt.md
+++ b/skills/meta/auto-dream/dream-prompt.md
@@ -311,6 +311,10 @@ Steps:
    "
    ```
 
+   `{target_file}` must be a durable repo path (or `agent:X` / `skill:X`).
+   `mark_graduated` refuses ephemeral targets such as `session-artifact` and
+   returns False, leaving the entry ungraduated for the next cycle.
+
 6. Record graduations in the report (Phase 7). Include:
    - Number of candidates evaluated
    - Number accepted/rejected with reasons


### PR DESCRIPTION
The learning system wrote constantly and injected almost nothing: activations fell from 9,755 rows in July to 1 in August. Error learnings are born at 0.55 and both injectors required 0.70, so a new learning could never inject, never get boosted, and never cross the floor, while decay pulled it down. Separately, 103 rows carried a `graduated_to` target that names no durable file (97 of them `session-artifact`), and a graduated row is excluded from injection forever.

Defines the injection floor once in `learning_db_v2` at 0.5, imports it in both injectors, and adds a test that fails if it ever rises above the lowest injectable birth confidence. Adds `learning-db.py repair-graduations` (dry-run by default, `--apply` to write) that normalizes `agent:` / `skill:` / `target:` notations, keeps every target that resolves, and clears only the ones that resolve nowhere. `mark_graduated` now refuses ephemeral targets so `session-artifact` cannot be recorded again.

Also fixes `format_hints`, which searched only the first line for an ASCII `->` while 762 rows store a multi-line error and a Unicode arrow. It was emitting raw captured output — nginx configs, ssh debug text, diff hunks — as the hint instead of the solution half.

Injectable pool on the live database: 28 -> 126 rows. The pretool injector returns hints for commands that previously returned none, and activations are landing again.
