### PR TITLE
fix(learning): drop contentless hints and scope the skip-rate denominator

### DIFF
--- a/agents/hook-development-engineer/references/learning-database.md
+++ b/agents/hook-development-engineer/references/learning-database.md
@@ -215,6 +215,38 @@ boosted, so it never crosses the floor. Both injectors import the constant;
 
 ---
 
+## Second Injection Gate: A Hint Must Carry a Solution
+
+Confidence says a learning recurs. It does not say the learning tells you
+anything. `error-learner.py` writes `DEFAULT_FIX_SOLUTION_TEMPLATE` — "Fix
+<error_type> error in <tool>: <snippet>" — whenever it cannot map an error to a
+real fix, and those rows never acquire a real solution. They dominated the
+injectable pool (99 of 126 rows), so injection spent context to restate the
+error type back to the agent.
+
+Both injectors gate on `hint_has_solution(value)` after the confidence filter:
+
+```python
+from learning_db_v2 import hint_has_solution
+
+results = [r for r in results if hint_has_solution(r.get("value", ""))]
+```
+
+Three rules hold this together:
+
+- The matcher is derived from `DEFAULT_FIX_SOLUTION_TEMPLATE`, the same string
+  that writes the stubs. Renaming the template updates the matcher in the same
+  edit; a hardcoded regex would silently stop matching.
+- Stub rows stay in the database. Their recurrence and frequency still feed
+  error classification and the auto-feedback loop; they are only unfit to inject.
+- Fetch more candidates than you inject. Most of the pool is stubs, so a query
+  limited to the injection cap returns stubs alone and drops a real hint that
+  ranked just below them.
+
+Emitting no hint is the correct outcome when only stubs match.
+
+---
+
 ## Graduation
 
 When a learning is mature enough to embed directly into an agent:

--- a/hooks/error-learner.py
+++ b/hooks/error-learner.py
@@ -28,6 +28,7 @@ from feedback_tracker import check_pending_feedback, set_pending_feedback
 from hook_utils import get_tool_error, get_tool_output, get_tool_result, is_tool_error
 from learning_db_v2 import (
     DEFAULT_FIX_ACTIONS,
+    DEFAULT_FIX_SOLUTION_TEMPLATE,
     boost_confidence,
     decay_confidence,
     generate_signature,
@@ -241,7 +242,9 @@ def main():
             fix_info = DEFAULT_FIX_ACTIONS.get(error_type, {"fix_type": "manual", "fix_action": "investigate"})
             fix_type = fix_info["fix_type"]
             fix_action = fix_info["fix_action"]
-            solution = f"Fix {error_type} error in {tool_name}: {error_message[:80].strip()}"
+            solution = DEFAULT_FIX_SOLUTION_TEMPLATE.format(
+                error_type=error_type, tool_name=tool_name, error=error_message[:80].strip()
+            )
 
             print(f"[new-error] {error_type}: {error_message[:100]}")
             if fix_type == "auto":

--- a/hooks/instruction-compliance.py
+++ b/hooks/instruction-compliance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.1.0
+# hook-version: 1.2.0
 """PostToolUse Hook: Instruction Compliance Measurement
 
 Fires after Agent tool dispatches to check whether MANDATORY instructions
@@ -14,11 +14,18 @@ its own reply is unmeasurable here and is declared `observable: False`. Those
 instructions are not recorded at all: a skip rate computed from a surface that
 structurally cannot show compliance measures the surface, not the behavior.
 
+POPULATION — which dispatches a reading applies to. scripts/build-dispatch.py
+injects the M04/M05/M06 directives into /do-routed prompts only. Reviewer
+fan-out and nested subagent dispatches legitimately carry none, so a non-match
+there is expected, not a skip. Each observation records whether the dispatch
+carried the `[do-route]` marker (`injected_by_do_route` says which instructions
+that gates), and the skip-rate report scores only the expected population.
+
 Design Principles:
 - Informational only (always exits 0, never blocks)
 - Lightweight string-presence checks (<50ms)
 - Multiple signal patterns per instruction for reduced false negatives
-- Record only what this surface can observe
+- Record only what this surface can observe, against the population it applies to
 """
 
 import json
@@ -29,9 +36,10 @@ from pathlib import Path
 
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
-
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 from hook_utils import empty_output, get_session_id, get_tool_output, get_tool_result, hook_error
 from learning_db_v2 import record_instruction_compliance_batch
+from route_types import has_do_route_marker
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "PostToolUse"
@@ -41,6 +49,11 @@ EVENT_NAME = "PostToolUse"
 # `observable` declares whether THIS hook's surface (dispatch prompt + subagent
 # report) can show the signal. False => the patterns stay for reference, but no
 # observation is recorded, because a non-match proves nothing about behavior.
+#
+# `injected_by_do_route` declares whether the directive reaches a prompt ONLY
+# via scripts/build-dispatch.py, which runs for /do-routed dispatches. True =>
+# the observation counts toward the skip rate only when the dispatch carried the
+# `[do-route]` marker. False => the directive is expected on every dispatch.
 INSTRUCTIONS: dict[str, dict[str, str | bool | list[re.Pattern[str]]]] = {
     "M01": {
         "name": "Phase Banners",
@@ -48,6 +61,7 @@ INSTRUCTIONS: dict[str, dict[str, str | bool | list[re.Pattern[str]]]] = {
         # from both the dispatch prompt and the subagent report. Measuring them
         # needs a main-thread surface (a Stop-event transcript reader).
         "observable": False,
+        "injected_by_do_route": False,
         "patterns": [
             re.compile(r"##\s*Phase\s+\d", re.IGNORECASE),
             re.compile(r"Phase\s+\d\s*:", re.IGNORECASE),
@@ -58,6 +72,7 @@ INSTRUCTIONS: dict[str, dict[str, str | bool | list[re.Pattern[str]]]] = {
         # Unobservable: the routing banner is main-thread orchestrator output,
         # printed before dispatch. Same correct surface as M01.
         "observable": False,
+        "injected_by_do_route": False,
         "patterns": [
             re.compile(r"^={3,}\s*$", re.MULTILINE),
             re.compile(r"(?:^|\s)ROUTING\s*:", re.IGNORECASE | re.MULTILINE),
@@ -69,6 +84,8 @@ INSTRUCTIONS: dict[str, dict[str, str | bool | list[re.Pattern[str]]]] = {
         # Observable: the reference-loading directive and an agent's own
         # reference-table mentions both land in the scanned strings.
         "observable": True,
+        # build-dispatch.py injects it; a non-/do dispatch never carries it.
+        "injected_by_do_route": True,
         "patterns": [
             re.compile(r"Reference\s+Loading", re.IGNORECASE),
             re.compile(r"reference.*table", re.IGNORECASE),
@@ -81,6 +98,7 @@ INSTRUCTIONS: dict[str, dict[str, str | bool | list[re.Pattern[str]]]] = {
         # whether the agent delivered a complete result. Renamed to say so.
         "name": "Completeness Injected",
         "observable": True,
+        "injected_by_do_route": True,
         "patterns": [
             re.compile(r"deliver\s+the\s+finished\s+product", re.IGNORECASE),
             re.compile(r"ship\s+the\s+complete\s+thing", re.IGNORECASE),
@@ -93,6 +111,7 @@ INSTRUCTIONS: dict[str, dict[str, str | bool | list[re.Pattern[str]]]] = {
         # the output was written dense. Renamed to say so.
         "name": "Density Injected",
         "observable": True,
+        "injected_by_do_route": True,
         "patterns": [
             re.compile(r"write\s+dense", re.IGNORECASE),
             re.compile(r"high\s+fidelity,?\s+minimum\s+words", re.IGNORECASE),
@@ -127,9 +146,22 @@ def is_observable(instr_id: str) -> bool:
     return bool(INSTRUCTIONS.get(instr_id, {}).get("observable", False))
 
 
+def directive_expected(instr_id: str, do_routed: bool | None) -> bool | None:
+    """Report whether this dispatch was expected to carry the directive.
+
+    None when the caller cannot say whether the dispatch was /do-routed: the
+    reading is real but its population is unknown, and the report must say so
+    rather than fold it into either bucket.
+    """
+    if not INSTRUCTIONS.get(instr_id, {}).get("injected_by_do_route", False):
+        return True
+    return do_routed
+
+
 def record_compliance_batch(
     results: dict[str, bool],
     session_id: str,
+    do_routed: bool | None = None,
 ) -> None:
     """Record observable instruction compliance observations in one transaction.
 
@@ -139,8 +171,14 @@ def record_compliance_batch(
     Args:
         results: Dict mapping instruction ID to compliance boolean.
         session_id: Current session identifier.
+        do_routed: Whether the dispatch prompt carried the `[do-route]` marker.
+            None (the default) records an unknown population.
     """
-    records = [(instr_id, compliant, session_id) for instr_id, compliant in results.items() if is_observable(instr_id)]
+    records = [
+        (instr_id, compliant, session_id, directive_expected(instr_id, do_routed))
+        for instr_id, compliant in results.items()
+        if is_observable(instr_id)
+    ]
     record_instruction_compliance_batch(records)
 
 
@@ -171,21 +209,33 @@ def main() -> None:
         else:
             output_text = ""
 
-        # Also check tool_input (agent prompt) for M04/M05/M06
-        tool_input = event.get("tool_input", event.get("input", ""))
-        if isinstance(tool_input, dict):
-            tool_input = json.dumps(tool_input)
-        elif not isinstance(tool_input, str):
-            tool_input = ""
+        # Also check tool_input (agent prompt) for M04/M05/M06. The marker is
+        # anchored to the start of a line, so keep the raw prompt too:
+        # json.dumps() escapes its newlines and the anchor never matches.
+        raw_input = event.get("tool_input", event.get("input", ""))
+        if isinstance(raw_input, dict):
+            prompt = raw_input.get("prompt")
+            tool_input = json.dumps(raw_input)
+        elif isinstance(raw_input, str):
+            prompt = tool_input = raw_input
+        else:
+            prompt = tool_input = ""
+        if not isinstance(prompt, str):
+            prompt = ""
 
         combined_text = f"{tool_input}\n{output_text}"
 
         if not combined_text.strip():
             empty_output(EVENT_NAME).print_and_exit()
 
+        # Read the population off the PROMPT only. The subagent report can quote
+        # the marker back; counting that would mark an unrouted dispatch as
+        # expected and reintroduce the denominator error.
+        do_routed = has_do_route_marker(prompt)
+
         # Check and record compliance for all instructions in one transaction
         results = check_compliance(combined_text)
-        record_compliance_batch(results, session_id)
+        record_compliance_batch(results, session_id, do_routed)
 
         empty_output(EVENT_NAME).print_and_exit()
 

--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 _DEFAULT_DB_DIR = Path.home() / ".claude" / "learning"
 
-_CURRENT_SCHEMA_VERSION = 7
+_CURRENT_SCHEMA_VERSION = 9
 
 CATEGORY_DEFAULTS = {
     "error": 0.55,
@@ -95,6 +95,103 @@ DEFAULT_FIX_ACTIONS = {
     "memory": {"fix_type": "manual", "fix_action": "reduce_memory"},
     "multiple_matches": {"fix_type": "auto", "fix_action": "use_replace_all"},
 }
+
+# error-learner.py writes this as the solution half whenever it cannot map an
+# error onto a real fix. The result restates the error type and the tool and
+# carries no instruction, so an injector must not spend context on it.
+DEFAULT_FIX_SOLUTION_TEMPLATE = "Fix {error_type} error in {tool_name}: {error}"
+
+
+# ─── Contentless Hint Detection ────────────────────────────────
+
+# error-learner stores a learning as "<error> <arrow> <solution>" and re-records
+# nest it ("<error> <arrow> <previous value>"), so the LAST arrow marks the
+# solution. Unicode is the arrow in use (762 rows); 7 older rows use ASCII.
+_SOLUTION_SEPARATORS = (" → ", " -> ")
+
+# Per-placeholder matchers for the stub template. error_type and tool_name are
+# single tokens; the error snippet is free text and is absent from rows written
+# before the snippet was appended to the template.
+_STUB_FIELD_PATTERNS = {"error_type": r"\S+", "tool_name": r"\S+", "error": r".*"}
+_STUB_OPTIONAL_FIELDS = frozenset({"error"})
+
+
+def _stub_literal(text: str, loose: bool) -> str:
+    """Escape a template literal, turning each whitespace run into a matcher."""
+    whitespace = r"\s*" if loose else r"\s+"
+    out: list[str] = []
+    in_run = False
+    for char in text:
+        if char.isspace():
+            if not in_run:
+                out.append(whitespace)
+                in_run = True
+        else:
+            in_run = False
+            out.append(re.escape(char))
+    return "".join(out)
+
+
+def _build_stub_solution_pattern(template: str = DEFAULT_FIX_SOLUTION_TEMPLATE) -> "re.Pattern[str]":
+    """Compile the stub matcher from the template that writes stubs.
+
+    Deriving the matcher from DEFAULT_FIX_SOLUTION_TEMPLATE keeps one source of
+    truth: renaming the template updates the matcher in the same edit instead of
+    stranding a hardcoded regex that silently stops matching.
+    """
+    parts = re.split(r"\{(\w+)\}", template)
+    segments: list[str] = []
+    for index, part in enumerate(parts):
+        if index % 2 == 0:
+            segments.append(_stub_literal(part, loose=False))
+            continue
+        field = _STUB_FIELD_PATTERNS.get(part, r"\S+")
+        if part in _STUB_OPTIONAL_FIELDS:
+            # Fold the preceding literal into the optional group: the older rows
+            # stop at the tool name, with neither separator nor snippet.
+            literal = _stub_literal(parts[index - 1], loose=True)
+            segments[-1] = f"(?:{literal}{field})?"
+        else:
+            segments.append(field)
+    return re.compile("^" + "".join(segments) + "$")
+
+
+_STUB_SOLUTION_RE = _build_stub_solution_pattern()
+
+
+def solution_summary(value: object) -> str:
+    """Return the one-line solution half of a stored learning value.
+
+    Returns "" for anything that is not a string: a malformed row carries no
+    solution, and callers must not have to pre-check the type.
+
+    Searches the whole value, not just its first line: a captured error message
+    is usually multi-line, so the arrow sits on the last line. Reading only the
+    first line surfaced the raw capture instead -- nginx configs, ssh debug
+    output, diff hunks -- as the hint. Values with no arrow (prose gotchas) fall
+    back to their first line.
+    """
+    if not isinstance(value, str):
+        return ""
+    for separator in _SOLUTION_SEPARATORS:
+        if separator in value:
+            value = value.rsplit(separator, 1)[1]
+            break
+    line = value.split("\n")[0]
+    # Drop control characters (BEL, ANSI escapes) captured from tool output.
+    return "".join(ch for ch in line if ch >= " " or ch == "\t").strip()[:120]
+
+
+def hint_has_solution(value: object) -> bool:
+    """Report whether a stored learning carries an injectable solution.
+
+    False for an empty or malformed value and for a generic stub, both of which
+    cost context and return no instruction. The row itself stays in the database:
+    its recurrence and frequency signal still feeds error classification and the
+    auto-feedback loop, it is only unfit to inject.
+    """
+    summary = solution_summary(value)
+    return bool(summary) and not _STUB_SOLUTION_RE.match(summary)
 
 
 # ─── Database Connection ───────────────────────────────────────
@@ -244,6 +341,22 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
         conn.execute(
             "INSERT OR IGNORE INTO schema_migrations (version, description) "
             "VALUES (8, 'add pipeline column to evidence_route_decisions')"
+        )
+
+    if current < 9:
+        # v8 -> v9: record whether the observed dispatch was expected to carry
+        # the directive at all. Historical rows stay NULL — an unknown
+        # population, never folded into either bucket. The column may already
+        # exist from an ad-hoc ALTER on a live DB; the duplicate-column error is
+        # the expected no-op there.
+        try:
+            conn.execute("ALTER TABLE instruction_compliance ADD COLUMN directive_expected BOOLEAN")
+        except sqlite3.OperationalError:
+            pass  # column already present
+        conn.execute("PRAGMA user_version = 9")
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, description) "
+            "VALUES (9, 'add directive_expected column to instruction_compliance')"
         )
 
     conn.commit()
@@ -597,6 +710,7 @@ CREATE TABLE IF NOT EXISTS instruction_compliance (
     instruction_id TEXT NOT NULL,
     compliant BOOLEAN NOT NULL,
     session_id TEXT,
+    directive_expected BOOLEAN,
     timestamp TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -1713,6 +1827,7 @@ def record_instruction_compliance(
     instruction_id: str,
     compliant: bool,
     session_id: str | None = None,
+    directive_expected: bool | None = None,
 ) -> None:
     """Record a single instruction compliance observation.
 
@@ -1723,26 +1838,32 @@ def record_instruction_compliance(
         instruction_id: Instruction identifier (e.g. "M01").
         compliant: Whether the instruction was followed.
         session_id: Current session identifier.
+        directive_expected: Whether this dispatch was expected to carry the
+            directive at all. None means the caller cannot say.
     """
-    record_instruction_compliance_batch([(instruction_id, compliant, session_id)])
+    record_instruction_compliance_batch([(instruction_id, compliant, session_id, directive_expected)])
 
 
 def record_instruction_compliance_batch(
-    records: list[tuple[str, bool, str | None]],
+    records: list[tuple[str, bool, str | None]] | list[tuple[str, bool, str | None, bool | None]],
 ) -> None:
     """Record multiple instruction compliance observations in one transaction.
 
     Args:
-        records: List of (instruction_id, compliant, session_id) tuples.
+        records: List of (instruction_id, compliant, session_id) or
+            (instruction_id, compliant, session_id, directive_expected) tuples.
+            A 3-tuple records an unknown population (NULL): a caller that does
+            not state whether the directive was expected must not be guessed at.
     """
     if not records:
         return
     init_db()
     now = datetime.now().isoformat()
-    rows = [(instr_id, compliant, sid, now) for instr_id, compliant, sid in records]
+    rows = [(record[0], record[1], record[2], record[3] if len(record) > 3 else None, now) for record in records]
     with get_connection() as conn:
         conn.executemany(
-            "INSERT INTO instruction_compliance (instruction_id, compliant, session_id, timestamp) VALUES (?, ?, ?, ?)",
+            "INSERT INTO instruction_compliance "
+            "(instruction_id, compliant, session_id, directive_expected, timestamp) VALUES (?, ?, ?, ?, ?)",
             rows,
         )
         conn.commit()
@@ -1751,11 +1872,19 @@ def record_instruction_compliance_batch(
 def query_instruction_skip_rate(days: int = 30) -> list[dict]:
     """Query instruction compliance skip rates from the dedicated table.
 
+    The skip rate is computed ONLY over observations where the directive was
+    expected (directive_expected = 1). Dispatches that never carried the
+    directive, and rows recorded before the flag existed, are counted and
+    reported separately — folding either into the rate would measure the wrong
+    population. skip_rate is None when the scored population is empty.
+
     Args:
         days: Look back window in days (default 30).
 
     Returns:
-        List of dicts with instruction_id, observations, non_compliant, skip_rate.
+        List of dicts with instruction_id, observations, non_compliant,
+        scored_observations, scored_non_compliant, not_expected, unknown,
+        and skip_rate.
     """
     init_db()
     with get_connection() as conn:
@@ -1763,7 +1892,11 @@ def query_instruction_skip_rate(days: int = 30) -> list[dict]:
             """
             SELECT instruction_id,
                    COUNT(*) as observations,
-                   SUM(CASE WHEN NOT compliant THEN 1 ELSE 0 END) as non_compliant
+                   SUM(CASE WHEN NOT compliant THEN 1 ELSE 0 END) as non_compliant,
+                   SUM(CASE WHEN directive_expected = 1 THEN 1 ELSE 0 END) as scored,
+                   SUM(CASE WHEN directive_expected = 1 AND NOT compliant THEN 1 ELSE 0 END) as scored_skipped,
+                   SUM(CASE WHEN directive_expected = 0 THEN 1 ELSE 0 END) as not_expected,
+                   SUM(CASE WHEN directive_expected IS NULL THEN 1 ELSE 0 END) as unknown
             FROM instruction_compliance
             WHERE timestamp > datetime('now', ?)
             GROUP BY instruction_id
@@ -1773,15 +1906,18 @@ def query_instruction_skip_rate(days: int = 30) -> list[dict]:
         ).fetchall()
         results = []
         for row in rows:
-            obs = row["observations"]
-            nc = row["non_compliant"]
-            skip_rate = (nc / obs * 100) if obs > 0 else 0.0
+            scored = row["scored"]
+            scored_skipped = row["scored_skipped"]
             results.append(
                 {
                     "instruction_id": row["instruction_id"],
-                    "observations": obs,
-                    "non_compliant": nc,
-                    "skip_rate": round(skip_rate, 1),
+                    "observations": row["observations"],
+                    "non_compliant": row["non_compliant"],
+                    "scored_observations": scored,
+                    "scored_non_compliant": scored_skipped,
+                    "not_expected": row["not_expected"],
+                    "unknown": row["unknown"],
+                    "skip_rate": round(scored_skipped / scored * 100, 1) if scored else None,
                 }
             )
         return results

--- a/hooks/pretool-learning-injector.py
+++ b/hooks/pretool-learning-injector.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.1.0
+# hook-version: 1.2.0
 """
 PreToolUse Hook: Proactive Learning Injection
 
@@ -15,6 +15,7 @@ Design Principles:
 - Non-blocking (always exits 0)
 - Lightweight output (max 500 chars to avoid context bloat)
 - Only injects at or above learning_db_v2.INJECTION_MIN_CONFIDENCE
+- Only injects rows that carry a real solution (learning_db_v2.hint_has_solution)
 """
 
 import json
@@ -31,7 +32,12 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 # confidence starves the pool: a new learning never injects, so it never gets
 # boosted, so it never crosses the floor.
 from hook_utils import context_output, empty_output, get_session_id, record_activations_safe
-from learning_db_v2 import INJECTION_MIN_CONFIDENCE, sanitize_for_context
+from learning_db_v2 import (
+    INJECTION_MIN_CONFIDENCE,
+    hint_has_solution,
+    sanitize_for_context,
+    solution_summary,
+)
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "PreToolUse"
@@ -39,8 +45,14 @@ EVENT_NAME = "PreToolUse"
 # Max characters in the injected context to stay lightweight
 MAX_CONTEXT_CHARS = 500
 
-# Max DB results to fetch
+# Max hints to inject
 MAX_RESULTS = 3
+
+# Max DB rows to fetch before the contentless ones are dropped. Most of the pool
+# carries a generic stub solution (99 of 126 rows when this was measured), so
+# fetching only MAX_RESULTS would usually return stubs alone and inject nothing
+# even when a real hint ranks just below them.
+MAX_CANDIDATES = 12
 
 # Keywords extracted from commands that map to learnable domains.
 # These are intentionally broad — the DB query narrows via tag matching.
@@ -169,30 +181,6 @@ def extract_edit_tags(tool_input: dict) -> list[str]:
     return list(tags)[:10]
 
 
-# error-learner stores a learning as "<error> <arrow> <solution>" and re-records
-# nest it ("<error> <arrow> <previous value>"), so the LAST arrow marks the
-# solution. Unicode is the arrow in use (762 rows); 7 older rows use ASCII.
-_SOLUTION_SEPARATORS = (" \u2192 ", " -> ")
-
-
-def _solution_summary(value: str) -> str:
-    """Return the one-line solution half of a stored learning value.
-
-    Searches the whole value, not just its first line: a captured error message
-    is usually multi-line, so the arrow sits on the last line. Reading only the
-    first line surfaced the raw capture instead -- nginx configs, ssh debug
-    output, diff hunks -- as the hint. Values with no arrow (prose gotchas) fall
-    back to their first line.
-    """
-    for separator in _SOLUTION_SEPARATORS:
-        if separator in value:
-            value = value.rsplit(separator, 1)[1]
-            break
-    line = value.split("\n")[0]
-    # Drop control characters (BEL, ANSI escapes) captured from tool output.
-    return "".join(ch for ch in line if ch >= " " or ch == "\t").strip()[:120]
-
-
 def format_hints(results: list[dict]) -> str:
     """Format DB results as a compact hint string.
 
@@ -203,9 +191,9 @@ def format_hints(results: list[dict]) -> str:
     seen: set[str] = set()
 
     for r in results:
-        summary = _solution_summary(sanitize_for_context(r.get("value", "")))
-        # Distinct rows often carry the same generic solution ("Fix timeout
-        # error in Bash"). Emit it once -- repeats only eat the char budget.
+        summary = solution_summary(sanitize_for_context(r.get("value", "")))
+        # Distinct rows can share one solution (the same fix recorded against
+        # several captures). Emit it once -- repeats only eat the char budget.
         if not summary or summary in seen:
             continue
         seen.add(summary)
@@ -268,12 +256,18 @@ def main():
             exclude_graduated=True,
             categories=INJECTABLE_CATEGORIES,
             project_path=cwd,
-            limit=MAX_RESULTS,
+            limit=MAX_CANDIDATES,
         )
+
+        # Drop rows whose solution half is a generic stub before anything else
+        # reads them: a stub costs context and returns no instruction, and an
+        # activation recorded for a hint that was never shown is a false ROI
+        # signal. Emitting nothing is the correct outcome when only stubs match.
+        results = [r for r in results if hint_has_solution(r.get("value", ""))][:MAX_RESULTS]
 
         if not results:
             if debug:
-                print(f"[pretool] No patterns for tags={tags}", file=sys.stderr)
+                print(f"[pretool] No injectable patterns for tags={tags}", file=sys.stderr)
             empty_output(EVENT_NAME).print_and_exit()
 
         # Format and inject

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -74,7 +74,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 from hook_utils import hook_error
-from route_types import HealthGateInputs
+from route_types import DO_ROUTE_MARKER_RE, HealthGateInputs
 from routing_outcome_state import append_pending_outcome, claim_dispatch
 from stdin_timeout import read_stdin
 
@@ -91,10 +91,8 @@ EVENT_NAME = "PostToolUse"
 # Anchored to line start (^\s*, MULTILINE) so a quoted/forwarded marker
 # mid-prose (e.g. a user pasting "...the [do-route] line...") doesn't get
 # recorded — only a marker /do itself emitted at the head of a line counts.
-_DO_ROUTE_RE = re.compile(
-    r"^\s*\[do-route\]\s+agent=([a-z0-9][a-z0-9-]*)(?:\s+skill=([a-z0-9-]*|-)?)?",
-    re.IGNORECASE | re.MULTILINE,
-)
+# Defined in route_types so instruction-compliance.py reads the SAME marker.
+_DO_ROUTE_RE = DO_ROUTE_MARKER_RE
 
 # Optional complexity field on the same marker line, recorded into the T3 event
 # log for replay. Absent => "".

--- a/hooks/session-context.py
+++ b/hooks/session-context.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 2.1.0
+# hook-version: 2.2.0
 """
 SessionStart Hook: Learning Context Loader
 
@@ -13,6 +13,7 @@ Design Principles:
 - SILENT unless meaningful patterns found
 - Project-aware (loads patterns for current directory)
 - Confidence-gated by learning_db_v2.INJECTION_MIN_CONFIDENCE
+- Counts only rows that carry a real solution (learning_db_v2.hint_has_solution)
 - Fast execution (<50ms target)
 - Non-blocking (always exits 0)
 - Pure file reader for dream integration — no LLM work, no learning.db queries
@@ -30,6 +31,7 @@ from hook_utils import context_output, empty_output, get_session_id, hook_error,
 from learning_db_v2 import (
     INJECTION_MIN_CONFIDENCE,
     get_stats,
+    hint_has_solution,
     query_learnings,
     sanitize_for_context,
 )
@@ -47,6 +49,11 @@ DREAM_PAYLOAD_MAX_CHARS = 7000
 
 # Dream report notice is surfaced if dream ran within the last 24 hours
 DREAM_REPORT_MAX_AGE_HOURS = 24
+
+# Max learnings summarized in the injected context, and max rows fetched before
+# the contentless ones are dropped.
+MAX_LEARNINGS = 10
+MAX_CANDIDATES = 40
 
 
 def _project_hash(cwd: str) -> str:
@@ -161,8 +168,14 @@ def main():
             category="error",
             min_confidence=INJECTION_MIN_CONFIDENCE,
             project_path=cwd,
-            limit=10,
+            limit=MAX_CANDIDATES,
         )
+
+        # Drop rows whose solution half is a generic stub. Most error rows carry
+        # one, and a count of contentless rows ("Loaded 34 high-confidence
+        # patterns") reports a pool the session can do nothing with. Fetching
+        # MAX_CANDIDATES first keeps real solutions from being crowded out.
+        learnings = [ln for ln in learnings if hint_has_solution(ln.get("value", ""))][:MAX_LEARNINGS]
 
         if learnings:
             # Record activations for ROI tracking

--- a/hooks/tests/test_instruction_observability.py
+++ b/hooks/tests/test_instruction_observability.py
@@ -139,11 +139,12 @@ class TestSkipRateGateVerdict:
     """The gate recommendation reads only instructions this hook can observe."""
 
     def _seed(self, instruction_id: str, compliant: int, non_compliant: int) -> None:
+        """Seed /do-routed observations — the population the rate is scored over."""
         from learning_db_v2 import record_instruction_compliance_batch
 
         record_instruction_compliance_batch(
-            [(instruction_id, True, "seed") for _ in range(compliant)]
-            + [(instruction_id, False, "seed") for _ in range(non_compliant)]
+            [(instruction_id, True, "seed", True) for _ in range(compliant)]
+            + [(instruction_id, False, "seed", True) for _ in range(non_compliant)]
         )
 
     def _run(self, db_dir: Path, args: list[str]) -> subprocess.CompletedProcess[str]:

--- a/hooks/tests/test_instruction_population.py
+++ b/hooks/tests/test_instruction_population.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Tests for scoping the instruction skip rate to the population that carried
+the directive.
+
+M04/M05/M06 measure whether a directive reached the dispatch prompt, but only
+scripts/build-dispatch.py injects those directives, and only into /do-routed
+prompts. Reviewer fan-out and nested subagent dispatches legitimately carry
+none, so a skip rate computed over every Agent dispatch measures the wrong
+population. Each observation now records whether the dispatch carried the
+`[do-route]` marker, and the report scores only the expected population.
+
+Covers:
+- has_do_route_marker: True for a line-start marker, False otherwise.
+- The hook records directive_expected True for a /do-routed prompt, False for a
+  plain one.
+- Skip rate excludes not-expected and unknown rows and states its denominator.
+- CONVERT TO GATE is computed only over the expected population.
+- The v8 -> v9 migration runs twice without error and leaves history unknown.
+- The hook exits 0 on empty and malformed stdin.
+
+Uses a throwaway learning.db via CLAUDE_LEARNING_DIR — never the real DB.
+
+Run with: python3 -m pytest hooks/tests/test_instruction_population.py -v
+"""
+
+import importlib.util
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = REPO_ROOT / "hooks" / "lib"
+SCRIPTS_LIB_DIR = REPO_ROOT / "scripts" / "lib"
+HOOK_PATH = REPO_ROOT / "hooks" / "instruction-compliance.py"
+CLI_PATH = REPO_ROOT / "scripts" / "learning-db.py"
+
+for _path in (LIB_DIR, SCRIPTS_LIB_DIR):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+import learning_db_v2 as ldb
+from route_types import has_do_route_marker
+
+_spec = importlib.util.spec_from_file_location("instruction_compliance", HOOK_PATH)
+assert _spec is not None and _spec.loader is not None
+hook = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hook)
+
+DO_ROUTE_PROMPT = (
+    "[do-route] agent=hook-development-engineer skill=pr-workflow complexity=medium\n\n"
+    "Consult the Reference Loading Table before starting work.\n"
+    "Deliver the finished product. Ship the complete thing.\n"
+    "Write dense. High fidelity, minimum words.\n"
+)
+PLAIN_PROMPT = (
+    "Consult the Reference Loading Table before starting work.\n"
+    "Deliver the finished product. Ship the complete thing.\n"
+    "Write dense. High fidelity, minimum words.\n"
+)
+
+
+@pytest.fixture()
+def db_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path))
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    yield tmp_path
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+
+
+def _rows() -> list[dict]:
+    with ldb.get_connection() as conn:
+        return [dict(r) for r in conn.execute("SELECT * FROM instruction_compliance")]
+
+
+def _run_hook(prompt: str, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    event = json.dumps(
+        {
+            "session_id": "pop-session",
+            "tool_name": "Agent",
+            "tool_input": {"prompt": prompt},
+            "tool_response": {"output": "done"},
+        }
+    )
+    env = {**os.environ, "CLAUDE_LEARNING_DIR": str(tmp_path)}
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=event,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+def _run_skip_rate(tmp_path: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "CLAUDE_LEARNING_DIR": str(tmp_path), "PYTHONPATH": str(LIB_DIR)}
+    return subprocess.run(
+        [sys.executable, str(CLI_PATH), "skip-rate", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+def _seed(instruction_id: str, compliant: int, non_compliant: int, expected: bool | None) -> None:
+    ldb.record_instruction_compliance_batch(
+        [(instruction_id, True, "seed", expected) for _ in range(compliant)]
+        + [(instruction_id, False, "seed", expected) for _ in range(non_compliant)]
+    )
+
+
+# ── marker detection ──────────────────────────────────────────────
+
+
+class TestMarkerDetection:
+    def test_line_start_marker_is_detected(self):
+        assert has_do_route_marker(DO_ROUTE_PROMPT) is True
+
+    def test_plain_prompt_carries_no_marker(self):
+        assert has_do_route_marker(PLAIN_PROMPT) is False
+
+    def test_quoted_mid_prose_mention_is_not_a_marker(self):
+        assert has_do_route_marker("I changed the [do-route] agent=x line in the docs.") is False
+
+    @pytest.mark.parametrize("value", ["", None])
+    def test_empty_input_carries_no_marker(self, value):
+        assert has_do_route_marker(value) is False
+
+
+# ── recording the population ──────────────────────────────────────
+
+
+class TestPopulationRecording:
+    def test_do_routed_dispatch_records_expected_true(self, db_env):
+        assert _run_hook(DO_ROUTE_PROMPT, db_env).returncode == 0
+        rows = _rows()
+        assert {r["instruction_id"] for r in rows} == {"M04", "M05", "M06"}
+        assert all(r["directive_expected"] == 1 for r in rows)
+
+    def test_unrouted_dispatch_records_expected_false(self, db_env):
+        assert _run_hook(PLAIN_PROMPT, db_env).returncode == 0
+        rows = _rows()
+        assert rows
+        assert all(r["directive_expected"] == 0 for r in rows)
+
+    def test_caller_that_states_no_population_records_unknown(self, db_env):
+        hook.record_compliance_batch({"M04": True}, "no-population")
+        assert [r["directive_expected"] for r in _rows()] == [None]
+
+    def test_every_observable_instruction_declares_its_population(self):
+        for instr_id, instr in hook.INSTRUCTIONS.items():
+            assert isinstance(instr.get("injected_by_do_route"), bool), f"{instr_id} lacks a population declaration"
+
+
+# ── skip-rate denominator ─────────────────────────────────────────
+
+
+class TestSkipRateDenominator:
+    def test_rate_ignores_not_expected_and_unknown_rows(self, db_env):
+        _seed("M04", compliant=30, non_compliant=10, expected=True)  # 25% of 40
+        _seed("M04", compliant=0, non_compliant=500, expected=False)
+        _seed("M04", compliant=0, non_compliant=100, expected=None)
+
+        result = _run_skip_rate(db_env, ["--json"])
+        assert result.returncode == 0
+        m04 = next(r for r in json.loads(result.stdout) if r["id"] == "M04")
+        assert m04["scored_observations"] == 40
+        assert m04["skip_rate"] == 25.0
+        assert m04["not_expected"] == 500
+        assert m04["unknown"] == 100
+        assert m04["status"] == "CONVERT_TO_GATE"
+
+    def test_gate_verdict_needs_an_expected_population(self, db_env):
+        _seed("M05", compliant=0, non_compliant=600, expected=False)
+        _seed("M05", compliant=0, non_compliant=400, expected=None)
+
+        result = _run_skip_rate(db_env, ["--json"])
+        m05 = next(r for r in json.loads(result.stdout) if r["id"] == "M05")
+        assert m05["scored_observations"] == 0
+        assert m05["skip_rate"] is None
+        assert m05["status"] != "CONVERT_TO_GATE"
+
+    def test_unobservable_instruction_stays_not_measurable(self, db_env):
+        _seed("M01", compliant=5, non_compliant=35, expected=True)
+        result = _run_skip_rate(db_env, ["--json"])
+        m01 = next(r for r in json.loads(result.stdout) if r["id"] == "M01")
+        assert m01["observations"] == 40
+        assert m01["status"] == "NOT MEASURABLE"
+
+    def test_report_states_its_denominator(self, db_env):
+        _seed("M04", compliant=30, non_compliant=10, expected=True)
+        _seed("M04", compliant=0, non_compliant=500, expected=False)
+        result = _run_skip_rate(db_env, [])
+        assert result.returncode == 0
+        assert "[do-route]" in result.stdout
+        assert "Not expected" in result.stdout
+        assert "Unknown" in result.stdout
+
+    def test_no_gate_recommendation_from_the_wrong_population(self, db_env):
+        _seed("M06", compliant=10, non_compliant=990, expected=False)
+        result = _run_skip_rate(db_env, [])
+        assert "CONVERT TO GATE" not in result.stdout
+        assert "No instructions flagged" in result.stdout
+
+
+# ── migration ─────────────────────────────────────────────────────
+
+
+class TestMigration:
+    def test_column_exists_after_init(self, db_env):
+        with ldb.get_connection() as conn:
+            columns = {r[1] for r in conn.execute("PRAGMA table_info(instruction_compliance)")}
+        assert "directive_expected" in columns
+
+    def test_migration_runs_twice_without_error(self, db_env):
+        with ldb.get_connection() as conn:
+            ldb._run_migrations(conn)
+            ldb._run_migrations(conn)
+            columns = {r[1] for r in conn.execute("PRAGMA table_info(instruction_compliance)")}
+        assert "directive_expected" in columns
+
+    def test_pre_migration_rows_become_unknown(self, tmp_path, monkeypatch):
+        """A v8 database keeps its history and reports it as an unknown population."""
+        monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path))
+        monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+        db_path = tmp_path / "learning.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE instruction_compliance ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, instruction_id TEXT NOT NULL, "
+            "compliant BOOLEAN NOT NULL, session_id TEXT, "
+            "timestamp TEXT NOT NULL DEFAULT (datetime('now')))"
+        )
+        conn.execute("INSERT INTO instruction_compliance (instruction_id, compliant) VALUES ('M04', 0)")
+        conn.execute("PRAGMA user_version = 8")
+        conn.commit()
+        conn.close()
+
+        ldb.init_db()
+        with ldb.get_connection() as connection:
+            rows = [dict(r) for r in connection.execute("SELECT * FROM instruction_compliance")]
+        assert len(rows) == 1
+        assert rows[0]["directive_expected"] is None
+        monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+
+
+# ── non-blocking ──────────────────────────────────────────────────
+
+
+class TestNonBlocking:
+    @pytest.mark.parametrize("payload", ["", "{not json", "null"])
+    def test_hook_exits_zero(self, payload, tmp_path):
+        env = {**os.environ, "CLAUDE_LEARNING_DIR": str(tmp_path)}
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        assert result.returncode == 0

--- a/hooks/tests/test_stub_hint_filter.py
+++ b/hooks/tests/test_stub_hint_filter.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Tests for the contentless-hint filter shared by both learning injectors.
+
+error-learner.py writes a generic stub solution whenever it cannot classify an
+error ("Fix <type> error in <tool>: <snippet>"). Those rows keep their
+recurrence signal, but the solution half carries no instruction, so injecting
+them spends context for nothing. hint_has_solution() is the shared predicate
+that drops them at injection time.
+
+Covers:
+- hint_has_solution on a real solution, on a stub built from every
+  DEFAULT_FIX_ACTIONS entry, on multi-line and Unicode-arrow values, and on
+  empty or malformed input.
+- The matcher is derived from DEFAULT_FIX_SOLUTION_TEMPLATE, so renaming the
+  template cannot leave a stale regex behind.
+- pretool-learning-injector emits nothing when only stubs match, and still
+  emits when a real solution sits behind a wall of stubs.
+- session-context drops stub-only learnings instead of counting them.
+- Both hooks exit 0 on empty and malformed stdin.
+
+Uses a throwaway learning.db via CLAUDE_LEARNING_DIR — never the real DB.
+
+Run with: python3 -m pytest hooks/tests/test_stub_hint_filter.py -v
+"""
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = REPO_ROOT / "hooks" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+import learning_db_v2 as db
+
+
+def _load(name: str, filename: str):
+    path = REPO_ROOT / "hooks" / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+injector = _load("pretool_learning_injector", "pretool-learning-injector.py")
+session_context = _load("session_context", "session-context.py")
+
+ARROW = "→"
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    """Point every test at a throwaway learning.db."""
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path))
+    db._initialized = False
+    yield tmp_path
+    db._initialized = False
+
+
+def _record(topic: str, key: str, value: str, category: str = "error") -> None:
+    db.record_learning(
+        topic=topic,
+        key=key,
+        value=value,
+        category=category,
+        confidence=0.9,
+        source="manual",
+        project_path=None,
+    )
+
+
+def _stub(error_type: str, tool: str = "Bash", snippet: str = "exit status 1") -> str:
+    return db.DEFAULT_FIX_SOLUTION_TEMPLATE.format(error_type=error_type, tool_name=tool, error=snippet)
+
+
+def _context(output: str) -> str:
+    text = output.strip()
+    if not text:
+        return ""
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return ""
+    return parsed.get("hookSpecificOutput", {}).get("additionalContext", "") or ""
+
+
+def _run_injector(command: str) -> str:
+    """Run the injector's main() on a Bash event; return the injected context."""
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+    stdout = io.StringIO()
+    with (
+        patch.object(injector, "read_stdin", return_value=payload),
+        patch("sys.stdout", stdout),
+    ):
+        try:
+            injector.main()
+        except SystemExit:
+            pass
+    return _context(stdout.getvalue())
+
+
+def _run_session_context() -> str:
+    """Run session-context's main() with the dream readers stubbed out."""
+    stdout = io.StringIO()
+    with (
+        patch.object(session_context, "inject_dream_payload", return_value=""),
+        patch.object(session_context, "surface_dream_report", return_value=""),
+        patch("sys.stdout", stdout),
+    ):
+        try:
+            session_context.main()
+        except SystemExit:
+            pass
+    return _context(stdout.getvalue())
+
+
+def _run_hook_subprocess(filename: str, stdin_text: str, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "CLAUDE_LEARNING_DIR": str(tmp_path)}
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "hooks" / filename)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+# ── hint_has_solution ─────────────────────────────────────────────
+
+
+class TestHintHasSolution:
+    def test_real_solution_is_kept(self):
+        value = f"config.yaml: No such file or directory {ARROW} copy config.yaml.example first"
+        assert db.hint_has_solution(value) is True
+
+    @pytest.mark.parametrize("error_type", sorted(db.DEFAULT_FIX_ACTIONS) + ["unknown"])
+    def test_stub_for_every_fix_action_is_dropped(self, error_type):
+        value = f"boom {ARROW} {_stub(error_type)}"
+        assert db.hint_has_solution(value) is False
+
+    def test_bare_stub_without_a_snippet_is_dropped(self):
+        """Rows written before the snippet was appended end at the tool name."""
+        assert db.hint_has_solution(f"boom {ARROW} Fix timeout error in Bash") is False
+
+    def test_stub_with_an_empty_snippet_is_dropped(self):
+        assert db.hint_has_solution(f"boom {ARROW} {_stub('unknown', snippet='')}") is False
+
+    def test_multiline_error_half_does_not_hide_the_stub(self):
+        value = f"server {{\n    listen 80;\n}}\nnginx: test failed {ARROW} {_stub('unknown', snippet='nginx: t')}"
+        assert db.hint_has_solution(value) is False
+
+    def test_multiline_error_half_keeps_a_real_solution(self):
+        value = f"server {{\n    listen 80;\n}}\nnginx: test failed {ARROW} run nginx -t and fix the block"
+        assert db.hint_has_solution(value) is True
+
+    def test_ascii_arrow_value_is_read_the_same_way(self):
+        assert db.hint_has_solution("Found 3 matches -> pass replace_all=True") is True
+        assert db.hint_has_solution("Found 3 matches -> Fix multiple_matches error in Edit") is False
+
+    def test_nested_arrows_read_the_last_solution(self):
+        assert db.hint_has_solution(f"exit 1 {ARROW} timeout {ARROW} Fix timeout error in Bash") is False
+        assert db.hint_has_solution(f"exit 1 {ARROW} timeout {ARROW} retry with --timeout 300") is True
+
+    @pytest.mark.parametrize("value", ["", "   ", f"boom {ARROW} ", f"boom {ARROW}   \n\n", None, 42])
+    def test_empty_or_malformed_values_carry_no_solution(self, value):
+        assert db.hint_has_solution(value) is False
+
+    def test_prose_gotcha_without_an_arrow_is_kept(self):
+        assert db.hint_has_solution("Prefer rg over grep; grep misses .gitignored paths") is True
+
+    def test_matcher_tracks_the_template(self):
+        """The matcher is built from the template, so a rename cannot strand it."""
+        rebuilt = db._build_stub_solution_pattern("Repair {error_type} fault in {tool_name}: {error}")
+        assert rebuilt.match("Repair timeout fault in Bash: exit 1")
+        assert not rebuilt.match("Fix timeout error in Bash: exit 1")
+
+
+# ── pretool-learning-injector ─────────────────────────────────────
+
+
+class TestInjectorDropsStubs:
+    def test_stub_only_pool_emits_nothing(self):
+        _record("timeout", "sig-1", f"go test timed out {ARROW} {_stub('timeout')}")
+        _record("unknown", "sig-2", f"go build failed {ARROW} {_stub('unknown')}")
+        assert _run_injector("go test ./...") == ""
+
+    def test_real_solution_still_reaches_the_prompt(self):
+        _record("missing_file", "sig-real", f"go test: config.yaml missing {ARROW} copy config.yaml.example first")
+        assert "copy config.yaml.example first" in _run_injector("go test ./...")
+
+    def test_real_solution_survives_a_wall_of_stubs(self):
+        """Stubs must not crowd the real hint out of the fetch window."""
+        for index in range(8):
+            _record("unknown", f"stub-{index}", f"go build failed {index} {ARROW} {_stub('unknown')}")
+        _record("missing_file", "sig-real", f"go test: config.yaml missing {ARROW} copy config.yaml.example first")
+        context = _run_injector("go test ./...")
+        assert "copy config.yaml.example first" in context
+        assert "Fix unknown error in Bash" not in context
+
+    def test_no_activation_recorded_for_a_dropped_stub(self):
+        _record("timeout", "sig-1", f"go test timed out {ARROW} {_stub('timeout')}")
+        assert _run_injector("go test ./...") == ""
+        with db.get_connection() as conn:
+            assert conn.execute("SELECT COUNT(*) FROM activations").fetchone()[0] == 0
+
+    def test_exits_zero_on_empty_stdin(self, tmp_path):
+        assert _run_hook_subprocess("pretool-learning-injector.py", "", tmp_path).returncode == 0
+
+    def test_exits_zero_on_malformed_stdin(self, tmp_path):
+        assert _run_hook_subprocess("pretool-learning-injector.py", "{not json", tmp_path).returncode == 0
+
+
+# ── session-context ───────────────────────────────────────────────
+
+
+class TestSessionContextDropsStubs:
+    def test_stub_only_pool_emits_nothing(self):
+        for index in range(3):
+            _record("unknown", f"stub-{index}", f"boom {index} {ARROW} {_stub('unknown')}")
+        assert _run_session_context() == ""
+
+    def test_real_solutions_are_still_counted(self):
+        _record("missing_file", "real-1", f"config.yaml missing {ARROW} copy config.yaml.example first")
+        for index in range(3):
+            _record("unknown", f"stub-{index}", f"boom {index} {ARROW} {_stub('unknown')}")
+        context = _run_session_context()
+        assert "[learned-context] Loaded 1 high-confidence patterns" in context
+        assert "missing_file(1)" in context
+        assert "unknown" not in context
+
+    def test_exits_zero_on_empty_stdin(self, tmp_path):
+        assert _run_hook_subprocess("session-context.py", "", tmp_path).returncode == 0
+
+    def test_exits_zero_on_malformed_stdin(self, tmp_path):
+        assert _run_hook_subprocess("session-context.py", "{not json", tmp_path).returncode == 0

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -1620,11 +1620,15 @@ def _observable_instructions() -> frozenset[str]:
 def cmd_skip_rate(args: argparse.Namespace) -> None:
     """Display instruction skip-rate report from the instruction_compliance table.
 
-    Queries the dedicated instruction_compliance table for per-observation
-    data and computes skip rate per instruction. Flags instructions with
-    >20% skip rate over 30+ observations for conversion to programmatic gates —
-    but only instructions the recording hook can actually observe. Unobservable
-    ones keep their historical rows and are reported as NOT MEASURABLE.
+    Two scoping rules keep the number honest, and the report states both.
+
+    Surface: only instructions the recording hook can observe are scored;
+    unobservable ones keep their historical rows and read NOT MEASURABLE.
+
+    Population: the rate counts only dispatches that were expected to carry the
+    directive (the prompt carried the `[do-route]` marker). Dispatches that
+    never carried it, and rows recorded before the marker was tracked, are
+    reported in their own columns and move nothing.
     """
     init_db()
 
@@ -1638,11 +1642,22 @@ def cmd_skip_rate(args: argparse.Namespace) -> None:
         "M06": "Density Injected",
     }
     observable = _observable_instructions()
+    denominator = "observations where the directive was expected ([do-route] marker present)"
 
-    def _status(instr_id: str, skip_rate: float, observations: int, gate_label: str) -> str:
-        if instr_id not in observable:
+    def _flagged(row: dict) -> bool:
+        return (
+            row["instruction_id"] in observable
+            and row["skip_rate"] is not None
+            and row["skip_rate"] > 20
+            and row["scored_observations"] >= 30
+        )
+
+    def _status(row: dict, gate_label: str) -> str:
+        if row["instruction_id"] not in observable:
             return "NOT MEASURABLE"
-        return gate_label if skip_rate > 20 and observations >= 30 else "OK"
+        if row["skip_rate"] is None:
+            return "NO EXPECTED OBS"
+        return gate_label if _flagged(row) else "OK"
 
     results = query_instruction_skip_rate(days=30)
 
@@ -1660,8 +1675,13 @@ def cmd_skip_rate(args: argparse.Namespace) -> None:
                     "name": instr_names.get(instr_id, instr_id),
                     "observations": r["observations"],
                     "non_compliant": r["non_compliant"],
+                    "scored_observations": r["scored_observations"],
+                    "scored_non_compliant": r["scored_non_compliant"],
+                    "not_expected": r["not_expected"],
+                    "unknown": r["unknown"],
                     "skip_rate": r["skip_rate"],
-                    "status": _status(instr_id, r["skip_rate"], r["observations"], "CONVERT_TO_GATE"),
+                    "denominator": denominator,
+                    "status": _status(r, "CONVERT_TO_GATE"),
                 }
             )
         print(json.dumps(report, indent=2))
@@ -1669,26 +1689,26 @@ def cmd_skip_rate(args: argparse.Namespace) -> None:
 
     # Human-readable output
     print("Instruction Skip Rate Report")
-    print("=" * 72)
-    print(f"{'ID':<6}{'Instruction':<22}{'Observations':>14}{'Skip Rate':>12}{'Status':>18}")
-    print("-" * 72)
+    print("=" * 92)
+    print(f"{'ID':<6}{'Instruction':<24}{'Scored':>8}{'Skip Rate':>12}{'Not expected':>14}{'Unknown':>10}{'Status':>18}")  # fmt: skip
+    print("-" * 92)
 
     for r in results:
         instr_id = r["instruction_id"]
         name = instr_names.get(instr_id, instr_id)
-        skip_rate = r["skip_rate"]
-        status = _status(instr_id, skip_rate, r["observations"], "CONVERT TO GATE")
+        rate = "n/a" if r["skip_rate"] is None else f"{r['skip_rate']:.1f}%"
+        print(f"{instr_id:<6}{name:<24}{r['scored_observations']:>8}{rate:>12}{r['not_expected']:>14}{r['unknown']:>10}{_status(r, 'CONVERT TO GATE'):>18}")  # fmt: skip
 
-        print(f"{instr_id:<6}{name:<22}{r['observations']:>14}{skip_rate:>11.1f}%{status:>17}")
-
-    print("-" * 72)
-    flagged = sum(
-        1 for r in results if r["instruction_id"] in observable and r["skip_rate"] > 20 and r["observations"] >= 30
-    )
+    print("-" * 92)
+    print("Scored = " + denominator + ".")
+    print("Not expected = dispatches the directive is never injected into (reviewer fan-out,")
+    print("nested subagents). Unknown = rows recorded before the marker was tracked.")
+    print("Neither moves the rate.")
+    flagged = sum(1 for r in results if _flagged(r))
     if flagged:
-        print(f"{flagged} instruction(s) flagged for conversion to programmatic gates (>20% skip, 30+ obs)")
+        print(f"{flagged} instruction(s) flagged for conversion to programmatic gates (>20% skip, 30+ scored obs)")
     else:
-        print("No instructions flagged. Threshold: >20% skip rate over 30+ observations.")
+        print("No instructions flagged. Threshold: >20% skip rate over 30+ scored observations.")
     unmeasurable = sorted(r["instruction_id"] for r in results if r["instruction_id"] not in observable)
     if unmeasurable:
         print(

--- a/scripts/lib/route_types.py
+++ b/scripts/lib/route_types.py
@@ -6,13 +6,47 @@ Defines the structured return types and input shapes used across:
   - Step 1.5: health-aware re-rank (HealthAdjustResult)
   - routing-decision-recorder hook (HealthGateInputs)
 
+Also owns the `[do-route]` marker itself: one regex, read by every hook that
+needs to know whether a dispatch came from /do.
+
 All types use TypedDict so callers get static type-checking without
 runtime overhead. Import from here; do not redefine these shapes.
 """
 
 from __future__ import annotations
 
+import re
 from typing import Literal, TypedDict
+
+# ---------------------------------------------------------------------------
+# The /do routing marker
+# ---------------------------------------------------------------------------
+
+# /do (SKILL.md Phase 4 Step 2) prepends this line to every agent prompt IT
+# routes. Its presence is the SOLE signal that a dispatch came from /do:
+#   [do-route] agent=python-general-engineer skill=test-driven-development ...
+# skill may be empty, "-", or absent (agent-only routing). Sub-agent fan-out
+# (reviewer rosters, nested dispatches) carries no marker.
+#
+# Anchored to line start (^\s*, MULTILINE) so a quoted or forwarded marker
+# mid-prose (a user pasting "...the [do-route] line...") does not count — only a
+# marker /do itself emitted at the head of a line does.
+#
+# One definition, two readers: routing-decision-recorder.py parses agent and
+# skill out of it, instruction-compliance.py tests only for its presence. A
+# second copy would drift and silently mis-scope one of them.
+DO_ROUTE_MARKER_RE = re.compile(
+    r"^\s*\[do-route\]\s+agent=([a-z0-9][a-z0-9-]*)(?:\s+skill=([a-z0-9-]*|-)?)?",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def has_do_route_marker(prompt: str | None) -> bool:
+    """Report whether a dispatch prompt carries the /do routing marker."""
+    if not prompt or "[do-route]" not in prompt.lower():
+        return False
+    return DO_ROUTE_MARKER_RE.search(prompt) is not None
+
 
 # ---------------------------------------------------------------------------
 # Step 0: semantic routing decision (held by the orchestrator LLM)

--- a/scripts/tests/test_instruction_compliance.py
+++ b/scripts/tests/test_instruction_compliance.py
@@ -36,11 +36,25 @@ record_compliance_batch = _module.record_compliance_batch
 INSTRUCTIONS = _module.INSTRUCTIONS
 
 
-def record_compliance(instr_id: str, instr_name: str, compliant: bool, session_id: str) -> None:
-    """Thin wrapper for tests: single-observation convenience using batch API."""
+def record_compliance(
+    instr_id: str,
+    instr_name: str,
+    compliant: bool,
+    session_id: str,
+    directive_expected: bool | None = True,
+) -> None:
+    """Thin wrapper for tests: single-observation convenience using batch API.
+
+    Defaults to the /do-routed population — the one the skip rate is scored over.
+    """
     from learning_db_v2 import record_instruction_compliance
 
-    record_instruction_compliance(instruction_id=instr_id, compliant=compliant, session_id=session_id)
+    record_instruction_compliance(
+        instruction_id=instr_id,
+        compliant=compliant,
+        session_id=session_id,
+        directive_expected=directive_expected,
+    )
 
 
 # ─── check_compliance unit tests ──────────────────────────────────
@@ -407,4 +421,6 @@ class TestSkipRateCommand:
         m01 = next(r for r in data if r["id"] == "M01")
         assert m01["observations"] == 5
         assert m01["non_compliant"] == 2
+        assert m01["scored_observations"] == 5
         assert m01["skip_rate"] == 40.0
+        assert "[do-route]" in m01["denominator"]


### PR DESCRIPTION
The injector spent context on hints that said nothing. 99 of the 126 injectable rows carried error-learner's generic stub solution, so `docker build .` got back "Fix timeout error in Bash" and "Fix unknown error in Bash" — the error type restated, no instruction. Both injectors now gate on `hint_has_solution()`, whose matcher is built from the stub template itself so the two cannot drift, and both fetch more candidates than they inject so a real hint is not crowded out by stubs. Stub rows stay in the DB; their recurrence still feeds classification. Injectable pool 126 -> 27, and emitting nothing is now the correct outcome when only stubs match.

Separately, the M04/M05/M06 skip rate counted every Agent dispatch, but build-dispatch.py injects those directives only into /do-routed prompts. Reviewer fan-out and nested subagents never carried them, so the 89-99% "skip" was a wrong-population reading and all three CONVERT TO GATE verdicts rested on it. instruction-compliance now records whether the dispatch prompt carried the `[do-route]` marker (new `directive_expected` column, v8->v9 migration), the rate is computed only over that population, historical rows report as an explicitly unknown bucket rather than being folded into either side, and the report states its denominator. Against real history all three gate verdicts disappear.

The `[do-route]` regex moved to `scripts/lib/route_types.py` so routing-decision-recorder and instruction-compliance read one definition.
