### PR TITLE
fix(tests): unbreak local collection, isolate the learning DB, cut suite runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,9 @@ jobs:
       - run: pip install -r requirements.lock pytest pillow numpy
       # INDEX.json is generated (untracked); tests that read the real index need it.
       - run: python scripts/generate-skill-index.py && python scripts/generate-agent-index.py
-      - run: python -m pytest --tb=short -q
+      # -m "" clears the default marker filter in pyproject.toml, so CI still
+      # runs the install.sh end-to-end tests and the performance benchmarks.
+      - run: python -m pytest --tb=short -q -m ""
 
   routing-benchmark:
     runs-on: ubuntu-latest

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,55 @@
+"""Repository-wide pytest fixtures.
+
+Keeps every test off the production learning database at
+`~/.claude/learning/learning.db`. Redirection is belt-and-braces because one
+lever is not enough:
+
+- `CLAUDE_LEARNING_DIR` covers the modules that read it (`learning_db_v2`,
+  `usage_db`, `route_events`) and every child process a test spawns.
+- Patching `learning_db_v2._DEFAULT_DB_DIR` covers the fallback a test reaches
+  when it deliberately unsets that env var, as
+  `scripts/tests/test_install_doctor.py` does.
+
+The fixture then asserts the resolved path sits outside the real `~/.claude`,
+on setup and again on teardown, so a leak fails the test that caused it instead
+of silently corrupting production data.
+"""
+
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent
+_LIB_DIR = _REPO_ROOT / "hooks" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import learning_db_v2
+
+# Resolved at import time, before any test can monkeypatch HOME.
+_PRODUCTION_CLAUDE_DIR = Path.home() / ".claude"
+
+
+def _assert_db_is_isolated(phase: str) -> None:
+    """Fail if the learning DB resolves inside the real ~/.claude tree."""
+    resolved = learning_db_v2.get_db_path().resolve()
+    assert not resolved.is_relative_to(_PRODUCTION_CLAUDE_DIR), (
+        f"learning DB resolved to {resolved} at {phase}: tests must never read "
+        f"or write anything under {_PRODUCTION_CLAUDE_DIR}"
+    )
+
+
+@pytest.fixture(autouse=True)
+def isolate_learning_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Point the learning database at a throwaway directory for one test."""
+    # Not tmp_path/"learning": several tests create that exact directory
+    # themselves with a bare mkdir() and would collide with this fixture.
+    db_dir = tmp_path / "isolated-learning-db"
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    monkeypatch.setattr(learning_db_v2, "_DEFAULT_DB_DIR", db_dir)
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+    _assert_db_is_isolated("setup")
+    yield db_dir
+    _assert_db_is_isolated("teardown")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,11 +150,21 @@ pythonpath = ["."]
 # exists at collection time.
 # tmp/ holds local scratch projects and generated experiments, not repository
 # tests. Collecting them makes the suite depend on untracked local artifacts.
-norecursedirs = ["fixtures", ".claude", ".git", "venv", "node_modules", "tmp"]
+# .codex/ is the gitignored Codex mirror of the repo. Its test_*.py copies
+# share basenames with the real ones, so collecting it aborts the entire local
+# run with 23 duplicate-basename errors. CI never sees this: .codex/ is
+# gitignored and absent on runners.
+norecursedirs = ["fixtures", ".claude", ".codex", ".git", "venv", "node_modules", "tmp"]
 markers = [
     "slow: marks tests as slow (subprocess calls)",
-    "integration: marks tests requiring external tools (e.g., Chrome headless)",
+    "integration: marks tests that drive a real external tool end to end (install.sh, Chrome headless)",
+    "performance: marks tests that assert a timing or throughput budget",
 ]
+# The default run skips the four install.sh end-to-end files (slow AND
+# integration, ~830s of the ~1070s scripts/tests wall time) and the timing
+# benchmarks, so the local loop stays usable. CI passes `-m ""` to clear this
+# filter and run the full set — see .github/workflows/test.yml.
+addopts = ["-m", "not (slow and integration) and not performance"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/scripts/tests/test_codex_hooks_install.py
+++ b/scripts/tests/test_codex_hooks_install.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 import pytest
 
+# Shells out to the full install.sh. Deselected from the default local run
+# by the marker filter in pyproject.toml; CI still runs it via `-m ""`.
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
 # tomllib is stdlib on Python 3.11+. On 3.10, skip the subset of tests that
 # use it to parse the post-install config.toml. Other tests still run.
 try:

--- a/scripts/tests/test_install_hook_mirror_safety.py
+++ b/scripts/tests/test_install_hook_mirror_safety.py
@@ -10,6 +10,10 @@ from typing import cast
 
 import pytest
 
+# Shells out to the full install.sh. Deselected from the default local run
+# by the marker filter in pyproject.toml; CI still runs it via `-m ""`.
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_NAME = "user-correction-capture.py"
 BASH_PATH = shutil.which("bash")

--- a/scripts/tests/test_install_profile_filtering.py
+++ b/scripts/tests/test_install_profile_filtering.py
@@ -15,6 +15,10 @@ from pathlib import Path
 
 import pytest
 
+# Shells out to the full install.sh. Deselected from the default local run
+# by the marker filter in pyproject.toml; CI still runs it via `-m ""`.
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 INSTALL_SH = REPO_ROOT / "install.sh"
 CONFIGURE = REPO_ROOT / "scripts" / "configure-profile.py"

--- a/scripts/tests/test_install_runtime_gating.py
+++ b/scripts/tests/test_install_runtime_gating.py
@@ -14,6 +14,10 @@ from pathlib import Path
 
 import pytest
 
+# Shells out to the full install.sh. Deselected from the default local run
+# by the marker filter in pyproject.toml; CI still runs it via `-m ""`.
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 INSTALL_SH = REPO_ROOT / "install.sh"
 NODE = shutil.which("node")

--- a/scripts/tests/test_route_weights.py
+++ b/scripts/tests/test_route_weights.py
@@ -144,6 +144,7 @@ def test_no_writes(isolated_db: Path) -> None:
 
 
 @pytest.mark.slow
+@pytest.mark.performance
 def test_performance_10k_rows(isolated_db: Path) -> None:
     """Reads 10k rows in under 100ms (query time, excluding interpreter start)."""
     from learning_db_v2 import record_learning

--- a/tests/test_learning_loop_fixes.py
+++ b/tests/test_learning_loop_fixes.py
@@ -458,14 +458,22 @@ class TestGetDbDirExported:
             result = get_db_dir()
             assert result == custom
 
-    def test_get_db_dir_default(self):
-        from learning_db_v2 import get_db_dir
+    def test_get_db_dir_falls_back_to_the_module_default(self, monkeypatch):
+        """With CLAUDE_LEARNING_DIR unset, get_db_dir() returns _DEFAULT_DB_DIR."""
+        import learning_db_v2
 
-        env = os.environ.copy()
-        with patch.dict(os.environ, {}, clear=True):
-            os.environ["HOME"] = env.get("HOME", "/tmp")
-            result = get_db_dir()
-            assert str(result).endswith(".claude/learning")
+        monkeypatch.delenv("CLAUDE_LEARNING_DIR", raising=False)
+        assert learning_db_v2.get_db_dir() == learning_db_v2._DEFAULT_DB_DIR
+
+    def test_module_default_is_the_claude_learning_dir(self):
+        """That default is ~/.claude/learning.
+
+        Asserted against the source, not the live constant: the repo-wide
+        conftest fixture repoints the constant at a tmp dir so that no test can
+        reach production data.
+        """
+        source = (HOOKS_DIR / "lib" / "learning_db_v2.py").read_text()
+        assert '_DEFAULT_DB_DIR = Path.home() / ".claude" / "learning"' in source
 
     def test_graduation_proposer_uses_get_db_dir(self):
         """knowledge-graduation-proposer.py must import get_db_dir, not

--- a/tests/test_pytest_config.py
+++ b/tests/test_pytest_config.py
@@ -1,5 +1,39 @@
 """Contract tests for repository-wide pytest collection settings."""
 
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Full-repo mirrors. Their test_*.py copies share basenames with the real
+# tests, so collecting one aborts the whole run with import errors.
+MIRROR_DIRS = [".claude", ".codex"]
+
 
 def test_local_tmp_tree_is_not_collected(pytestconfig):
-    assert "tmp" in pytestconfig.getini("norecursedirs")
+    assert "tmp" in pytestconfig.getini("norecursedirs"), (
+        "tmp/ holds local scratch projects, so collecting it makes the suite depend on untracked artifacts"
+    )
+
+
+@pytest.mark.parametrize("mirror", MIRROR_DIRS)
+def test_repo_mirror_dir_is_not_collected(pytestconfig, mirror):
+    assert mirror in pytestconfig.getini("norecursedirs"), (
+        f"{mirror}/ mirrors the whole repo, so collecting it aborts the run with duplicate-basename errors"
+    )
+
+
+def test_install_e2e_and_performance_tests_are_deselected_by_default(pytestconfig):
+    """The default run must skip the install.sh e2e files and the benchmarks."""
+    addopts = " ".join(pytestconfig.getini("addopts"))
+    assert "not (slow and integration)" in addopts, "the install.sh e2e files must stay out of the default run"
+    assert "not performance" in addopts, "the timing benchmarks must stay out of the default run"
+
+
+def test_ci_clears_the_default_marker_filter():
+    """CI must run the full set, including whatever the default filter drops."""
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8")
+    assert '- run: python -m pytest --tb=short -q -m ""' in workflow, (
+        'CI lost `-m ""`, so it silently stopped running the slow install and performance tests'
+    )


### PR DESCRIPTION
`norecursedirs` missed the gitignored `.codex` mirror, so repo-root `pytest` aborted with 23 collection errors and ran zero tests; duplicate basenames there also shadowed 55 real tests. It is excluded now, and the config contract test that only checked `tmp` checks the mirror dirs too.

A root `conftest.py` repoints the learning DB at a per-test tmp dir and fails any test whose `get_db_path()` resolves under `~/.claude`. `hooks/tests/test_learning_system.py` was writing 3 rows per run into the production DB; the 495 accumulated `source='test'` rows are deleted from it, after a verified SQLite online backup, with the injectable pool unchanged at 2074.

The four `install.sh` end-to-end files are marked `slow` + `integration` and the route-weights 10k-row benchmark `performance`, and `addopts` deselects both from the default run: `scripts/tests` drops from 1040s to 169s. CI passes `-m ""` in `.github/workflows/test.yml`, which clears that filter and runs all 8545 tests, so nothing loses coverage.
