### PR TITLE
feat(learning): add dedupe subcommand and graduate verified gotchas into skills

### DIFF
--- a/agents/base-instructions.md
+++ b/agents/base-instructions.md
@@ -41,6 +41,12 @@ Only make changes directly requested or clearly necessary. Keep solutions simple
 
 Read and follow repository CLAUDE.md files before any implementation. Project instructions override default agent behaviors.
 
+## Test Execution
+
+Run test suites and other verification commands in the foreground, and read the result in the same turn.
+
+A dispatched agent that ends its turn to wait for a background command's completion notification ends its run instead: the notification arrives after the agent is gone, and the task returns with no deliverable (observed twice in one task, 2026-07-02). When you dispatch an agent that runs tests, put the same rule in its prompt.
+
 ## Temporary File Cleanup
 
 - Clean up temporary files created during iteration at task completion

--- a/agents/toolkit-governance-engineer/references/routing-table-patterns.md
+++ b/agents/toolkit-governance-engineer/references/routing-table-patterns.md
@@ -231,6 +231,37 @@ Regenerate `agents/INDEX.json` immediately after any agent add, rename, or delet
 
 ---
 
+### Move All Four Registration Invariants Together
+
+A PR that adds a skill plus a hook has to update four places at once. Each holds its own copy of facts the others also hold, and CI fails on whichever one lags.
+
+**Detection**:
+```bash
+# Both skill-path maps carry their own copy of the mapping table
+grep -c SKILL_MAPPING scripts/fix-skill-paths.py scripts/migrate-skills-to-folders.py
+
+# Both routers carry their own semantic-guard table
+grep -n "^SEMANTIC_GUARDS" scripts/pre-route.py scripts/index-router.py
+
+# Counts claimed in prose vs counts on disk
+python3 scripts/validate-doc-counts.py
+```
+
+**Signal**: CI fails on a doc-count claim; or the new skill force-routes from one router and falls through the other; or a path-fixing script rewrites every skill path except the new one.
+
+| Invariant | Lives in | Fails as |
+|-----------|----------|----------|
+| Component counts | `README.md`, `docs/*.md` — checked by `scripts/validate-doc-counts.py` | CI count mismatch |
+| `SKILL_MAPPING` | `scripts/fix-skill-paths.py` **and** `scripts/migrate-skills-to-folders.py` | Path rewrites skip the new skill |
+| `SEMANTIC_GUARDS` | `scripts/pre-route.py` **and** `scripts/index-router.py` | Routing differs between the two routers |
+| Trigger specificity | The new skill's `routing.triggers` | A single-word `force_route` trigger hijacks unrelated requests (see Trigger Phrase Specificity above) |
+
+**Why this matters**: Each pair duplicates the same fact in two files. Updating one and not its twin produces a component that is half-registered — it routes in one code path and vanishes in the other, with no error anywhere.
+
+**Preferred action**: Update all four before pushing, then run `validate-doc-counts.py` **after** merging main. Two branches that each add a component both bump the same README number from 78 to 79, and git reports a conflict where both sides read 79 while the true merged value is 80. Resolving that conflict by taking either side leaves the count wrong; recount from the filesystem instead.
+
+---
+
 ### Remove Self-References from pairs_with
 
 **Detection**:

--- a/docs/what-didnt-work.md
+++ b/docs/what-didnt-work.md
@@ -102,6 +102,13 @@ Experiments recorded after the seed set. Same four bold fields; `###` headings k
 - **Evidence**: branch `feat/review-contract-provenance` (pushed, unmerged); workflow run `wf_d2f09dbd-850`; master list `tmp/agent-scripts-master-list.json`.
 - **Decision**: rejected. Keep baseline `systematic-code-review`/`parallel-code-review` unchanged; revisit-if a stronger variant and a larger A/B.
 
+### 2026-05-23 Parity-audit agent cited source values that exist in no source file
+
+- **Expectation**: an audit agent comparing a Go port against its VB6 original would report real divergences, citable by file and line.
+- **What happened**: the audit reported a progression table as "live VB6" whose values appear in no `.frm` file; the Go code already matched the real ones. 5 of 6 reported divergences were audit errors. Acting on them would have deleted live behavior. Requiring the fix agents to re-read the VB6 source before editing caught it.
+- **Evidence**: `learning.db` `skill:vb6-to-go-backend-port/16afac8918b8`; the port itself lives outside this repo.
+- **Decision**: rejected as-is. An agent-produced citation is a claim, not evidence. Re-read the cited authority before acting on a finding. This applies to any review or audit agent that quotes line numbers, not only this port.
+
 ## 2026-06-05 Provenance footers on every answer
 
 - **Expectation**: per-answer footers (source tier, confidence, reviewed-by, freshness, owner) improve auditability.

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -19,6 +19,8 @@ Usage:
     python3 scripts/learning-db.py boost TOPIC KEY [--delta 0.15]
     python3 scripts/learning-db.py prune --category error --dry-run
     python3 scripts/learning-db.py prune --topic unknown --max-confidence 0.5 --older-than 90 --apply
+    python3 scripts/learning-db.py dedupe [--category voice] [--prefix 120] [--json]
+    python3 scripts/learning-db.py dedupe --apply
     python3 scripts/learning-db.py stale [--min-age-days 30] [--json]
     python3 scripts/learning-db.py stale-prune --dry-run [--min-age-days 30]
     python3 scripts/learning-db.py stale-prune --confirm [--min-age-days 30]
@@ -456,6 +458,183 @@ def cmd_prune(args):
         total_after = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
         conn.execute("VACUUM")
     print(f"Deleted {deleted} entries. Total learnings: {total_before} -> {total_after}.")
+
+
+# ─── Deduplication ─────────────────────────────────────────────
+
+# Values that match after this normalization are treated as the same learning.
+# Lowercasing and dropping non-alphanumerics absorbs re-recording noise
+# (whitespace, an added "→", a trailing period); the prefix bounds the
+# comparison so a shared preamble with a divergent tail still collapses.
+DEDUPE_PREFIX_CHARS = 120
+_DEDUPE_NOISE_RE = re.compile(r"[^a-z0-9]")
+
+
+def normalize_learning_value(value: object, prefix: int = DEDUPE_PREFIX_CHARS) -> str:
+    """Return the cluster key for a learning value: lowercase alphanumerics, truncated."""
+    if not isinstance(value, str):
+        return ""
+    return _DEDUPE_NOISE_RE.sub("", value.lower())[:prefix]
+
+
+def _survivor_rank(row: sqlite3.Row) -> tuple:
+    """Sort key that puts the row to keep first.
+
+    Highest confidence wins. Ties break on most observations, then earliest
+    first_seen, then lowest id — so the same cluster always yields the same
+    survivor, which keeps a dry run an honest preview of --apply.
+    """
+    return (
+        -(row["confidence"] or 0.0),
+        -(row["observation_count"] or 0),
+        row["first_seen"] or "",
+        row["id"],
+    )
+
+
+def find_duplicate_clusters(
+    conn: sqlite3.Connection,
+    *,
+    category: str | None = None,
+    prefix: int = DEDUPE_PREFIX_CHARS,
+) -> list[list[sqlite3.Row]]:
+    """Group rows into near-duplicate clusters of 2 or more, survivor first.
+
+    Rows graduated or read by route-weights are excluded, matching `prune`.
+    Rows whose normalized value is empty are skipped, because an empty key
+    would collapse every punctuation-only value into one cluster.
+    """
+    sql = (
+        "SELECT id, topic, key, category, value, confidence, observation_count, "
+        f"first_seen, last_seen, source FROM learnings WHERE {_PRUNE_PROTECT_SQL}"  # security-review: ignore (fixed clause; user values bound as ?)
+    )
+    params: list = []
+    if category is not None:
+        sql += " AND category = ?"
+        params.append(category)
+
+    groups: dict[tuple[str, str], list[sqlite3.Row]] = {}
+    for row in conn.execute(sql, params):
+        norm = normalize_learning_value(row["value"], prefix)
+        if not norm:
+            continue
+        groups.setdefault((row["category"], norm), []).append(row)
+
+    clusters = [sorted(members, key=_survivor_rank) for members in groups.values() if len(members) > 1]
+    clusters.sort(key=lambda members: (-len(members), members[0]["id"]))
+    return clusters
+
+
+def _collapse_cluster(conn: sqlite3.Connection, members: list[sqlite3.Row]) -> int:
+    """Fold a cluster into its survivor and delete the rest. Returns activations re-pointed.
+
+    The survivor inherits the cluster's earliest first_seen, latest last_seen,
+    and highest observation_count, so age and frequency signal survive. Each
+    victim's activations rows re-point to the survivor's (topic, key) before the
+    delete, so ROI history is not lost.
+    """
+    survivor, victims = members[0], members[1:]
+    conn.execute(
+        "UPDATE learnings SET first_seen = ?, last_seen = ?, observation_count = ? WHERE id = ?",
+        (
+            min((m["first_seen"] for m in members if m["first_seen"]), default=survivor["first_seen"]),
+            max((m["last_seen"] for m in members if m["last_seen"]), default=survivor["last_seen"]),
+            max((m["observation_count"] or 0) for m in members),
+            survivor["id"],
+        ),
+    )
+    repointed = 0
+    for victim in victims:
+        cursor = conn.execute(
+            "UPDATE activations SET topic = ?, key = ? WHERE topic = ? AND key = ?",
+            (survivor["topic"], survivor["key"], victim["topic"], victim["key"]),
+        )
+        repointed += cursor.rowcount
+        conn.execute("DELETE FROM learnings WHERE id = ?", (victim["id"],))
+    return repointed
+
+
+def _fts_integrity_ok(conn: sqlite3.Connection) -> bool:
+    """Run the FTS5 integrity-check on learnings_fts.
+
+    The check is written as an INSERT, so it opens a transaction that must be
+    closed before a caller can VACUUM.
+    """
+    try:
+        conn.execute("INSERT INTO learnings_fts(learnings_fts) VALUES ('integrity-check')")
+        return True
+    except sqlite3.DatabaseError:
+        return False
+    finally:
+        conn.commit()
+
+
+def cmd_dedupe(args):
+    """Collapse near-duplicate learnings. Dry-run by default; --apply deletes + VACUUM.
+
+    Hook capture re-records the same text under a fresh key, so one insight can
+    occupy hundreds of rows and crowd every injection budget that reads the table.
+    """
+    init_db()
+    with get_connection() as conn:
+        total_before = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
+        clusters = find_duplicate_clusters(conn, category=args.category, prefix=args.prefix)
+        redundant = sum(len(members) - 1 for members in clusters)
+
+        report = {
+            "clusters": len(clusters),
+            "rows_removed": redundant,
+            "total_before": total_before,
+            "total_after": total_before - redundant,
+            "applied": bool(args.apply),
+            "activations_repointed": 0,
+            "fts_integrity_ok": None,
+        }
+
+        if args.apply and clusters:
+            repointed = sum(_collapse_cluster(conn, members) for members in clusters)
+            conn.commit()
+            report["activations_repointed"] = repointed
+            report["total_after"] = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
+            report["fts_integrity_ok"] = _fts_integrity_ok(conn)
+            conn.execute("VACUUM")
+
+        if args.json:
+            report["top_clusters"] = [
+                {
+                    "size": len(members),
+                    "category": members[0]["category"],
+                    "keep": {"id": members[0]["id"], "topic": members[0]["topic"], "key": members[0]["key"]},
+                    "sample": (members[0]["value"] or "")[:120],
+                }
+                for members in clusters[: args.top]
+            ]
+            print(json.dumps(report, indent=2, default=str))
+            return
+
+        print(f"Total learnings before: {total_before}")
+        print(f"Near-duplicate clusters: {len(clusters)} (match on first {args.prefix} normalized chars)")
+        print(f"Redundant rows: {redundant}")
+        for members in clusters[: args.top]:
+            survivor = members[0]
+            print(
+                f"  n={len(members):<4} [{survivor['category']}] keep id={survivor['id']} "
+                f"{survivor['topic']}/{survivor['key']}"
+            )
+            print(f"        {(survivor['value'] or '')[:100]}")
+        if len(clusters) > args.top:
+            print(f"  … {len(clusters) - args.top} more clusters")
+
+        if not args.apply:
+            print()
+            print("DRY RUN — nothing deleted. Re-run with --apply to collapse.")
+            print("Back up the database first: cp <db> <db>.bak-$(date +%Y%m%d)")
+            return
+
+        print()
+        print(f"Removed {redundant} rows. Total learnings: {total_before} -> {report['total_after']}.")
+        print(f"Activations re-pointed to survivors: {report['activations_repointed']}")
+        print(f"FTS integrity check: {'PASS' if report['fts_integrity_ok'] else 'FAIL'}")
 
 
 def _query_stale_entries(conn: sqlite3.Connection, min_age_days: int) -> list[dict]:
@@ -2487,6 +2666,24 @@ def main():
     p_prune_mode.add_argument("--dry-run", action="store_true", help="Preview counts (default)")
     p_prune_mode.add_argument("--apply", action="store_true", help="Delete matched rows, then VACUUM")
     p_prune.set_defaults(func=cmd_prune)
+
+    # dedupe (collapse near-duplicate learnings)
+    p_dedupe = subparsers.add_parser(
+        "dedupe", help="Collapse near-duplicate learnings (dry-run default; --apply deletes)"
+    )
+    p_dedupe.add_argument("--category", help="Restrict to one category (e.g., voice)")
+    p_dedupe.add_argument(
+        "--prefix",
+        type=int,
+        default=DEDUPE_PREFIX_CHARS,
+        help=f"Normalized characters compared (default: {DEDUPE_PREFIX_CHARS})",
+    )
+    p_dedupe.add_argument("--top", type=int, default=10, help="Clusters to list (default: 10)")
+    p_dedupe.add_argument("--json", action="store_true", help="Output as JSON")
+    p_dedupe_mode = p_dedupe.add_mutually_exclusive_group()
+    p_dedupe_mode.add_argument("--dry-run", action="store_true", help="Preview clusters (default)")
+    p_dedupe_mode.add_argument("--apply", action="store_true", help="Collapse clusters, then VACUUM")
+    p_dedupe.set_defaults(func=cmd_dedupe)
 
     # stale (show stale entries)
     p_stale = subparsers.add_parser("stale", help="Show entries that appear stale")

--- a/scripts/tests/test_learning_db_dedupe.py
+++ b/scripts/tests/test_learning_db_dedupe.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Tests for the `dedupe` subcommand in scripts/learning-db.py.
+
+Covers: cluster detection, dry-run leaving the table untouched, survivor
+selection under --apply, first_seen/observation_count merging, activations
+re-pointing, FTS index consistency, and graduated-row protection.
+
+Run with: python3 -m pytest scripts/tests/test_learning_db_dedupe.py -v
+"""
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_repo_root / "hooks" / "lib"))
+
+SCRIPT_PATH = str(_repo_root / "scripts" / "learning-db.py")
+
+# Same text, re-recorded with the noise the capture hooks add: case change,
+# extra whitespace, a doubled arrow, a trailing period.
+BASE_VALUE = "Run validate-doc-counts.py after merging main, because both branches bump the same README count"
+NOISY_VALUE = "run  validate-doc-counts.py   after merging main, because both branches bump the same README count."
+ARROW_VALUE = "Run validate-doc-counts.py after merging main → → because both branches bump the same README count"
+OTHER_VALUE = "Fork PRs skip CI entirely while mergeable_state is dirty; resolve the conflict to unblock checks"
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point learning.db at a temp directory for each test."""
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path))
+    import importlib
+
+    import learning_db_v2
+
+    importlib.reload(learning_db_v2)
+    learning_db_v2.init_db()
+    yield tmp_path
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    return subprocess.run(
+        [sys.executable, SCRIPT_PATH, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def _connect(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "learning.db")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _insert(
+    tmp_path: Path,
+    topic: str,
+    key: str,
+    value: str,
+    *,
+    category: str = "gotcha",
+    confidence: float = 0.5,
+    observation_count: int = 1,
+    age_days: int = 0,
+    graduated_to: str | None = None,
+) -> None:
+    ts = (datetime.now() - timedelta(days=age_days)).isoformat()
+    conn = _connect(tmp_path)
+    conn.execute(
+        "INSERT INTO learnings (topic, key, value, category, confidence, source, "
+        "observation_count, first_seen, last_seen, graduated_to) "
+        "VALUES (?, ?, ?, ?, ?, 'test', ?, ?, ?, ?)",
+        (topic, key, value, category, confidence, observation_count, ts, ts, graduated_to),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _activate(tmp_path: Path, topic: str, key: str, outcome: str = "success") -> None:
+    conn = _connect(tmp_path)
+    conn.execute(
+        "INSERT INTO activations (topic, key, session_id, timestamp, outcome) VALUES (?, ?, 's1', ?, ?)",
+        (topic, key, datetime.now().isoformat(), outcome),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _rows(tmp_path: Path) -> list[sqlite3.Row]:
+    conn = _connect(tmp_path)
+    rows = conn.execute("SELECT * FROM learnings ORDER BY id").fetchall()
+    conn.close()
+    return rows
+
+
+def _dedupe_json(*args: str) -> dict:
+    result = _run_cli("dedupe", "--json", *args)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _seed_cluster(tmp_path: Path) -> None:
+    """Three noisy recordings of one insight, plus one unrelated row."""
+    _insert(tmp_path, "skill:pr-workflow", "a", BASE_VALUE, confidence=0.5, age_days=30)
+    _insert(tmp_path, "skill:pr-workflow", "b", NOISY_VALUE, confidence=0.7, observation_count=3, age_days=10)
+    _insert(tmp_path, "skill:pr-workflow", "c", ARROW_VALUE, confidence=0.6, age_days=1)
+    _insert(tmp_path, "skill:pr-workflow", "d", OTHER_VALUE, confidence=0.9)
+
+
+def test_detects_cluster_of_noisy_rerecordings(tmp_path: Path):
+    _seed_cluster(tmp_path)
+    report = _dedupe_json()
+    assert report["clusters"] == 1
+    assert report["rows_removed"] == 2
+    assert report["total_before"] == 4
+    assert report["total_after"] == 2
+    assert report["top_clusters"][0]["size"] == 3
+
+
+def test_distinct_values_are_not_clustered(tmp_path: Path):
+    _insert(tmp_path, "skill:do", "a", BASE_VALUE)
+    _insert(tmp_path, "skill:do", "b", OTHER_VALUE)
+    report = _dedupe_json()
+    assert report["clusters"] == 0
+    assert report["rows_removed"] == 0
+
+
+def test_same_value_in_different_categories_is_not_clustered(tmp_path: Path):
+    _insert(tmp_path, "skill:do", "a", BASE_VALUE, category="gotcha")
+    _insert(tmp_path, "skill:do", "b", BASE_VALUE, category="error")
+    report = _dedupe_json()
+    assert report["clusters"] == 0
+
+
+def test_dry_run_writes_nothing(tmp_path: Path):
+    _seed_cluster(tmp_path)
+    before = [dict(r) for r in _rows(tmp_path)]
+
+    report = _dedupe_json()
+    assert report["applied"] is False
+    assert report["activations_repointed"] == 0
+
+    assert [dict(r) for r in _rows(tmp_path)] == before
+
+
+def test_explicit_dry_run_flag_writes_nothing(tmp_path: Path):
+    _seed_cluster(tmp_path)
+    before = [dict(r) for r in _rows(tmp_path)]
+    result = _run_cli("dedupe", "--dry-run")
+    assert result.returncode == 0
+    assert "DRY RUN" in result.stdout
+    assert [dict(r) for r in _rows(tmp_path)] == before
+
+
+def test_apply_keeps_highest_confidence_survivor(tmp_path: Path):
+    _seed_cluster(tmp_path)
+    report = _dedupe_json("--apply")
+
+    assert report["applied"] is True
+    assert report["rows_removed"] == 2
+    assert report["total_after"] == 2
+
+    keys = {r["key"] for r in _rows(tmp_path)}
+    assert keys == {"b", "d"}
+
+
+def test_survivor_inherits_earliest_first_seen_and_highest_observation_count(tmp_path: Path):
+    _seed_cluster(tmp_path)
+    _run_cli("dedupe", "--apply")
+
+    conn = _connect(tmp_path)
+    survivor = conn.execute("SELECT * FROM learnings WHERE key = 'b'").fetchone()
+    oldest = conn.execute("SELECT MIN(first_seen) FROM learnings").fetchone()[0]
+    conn.close()
+
+    assert survivor["observation_count"] == 3
+    # The 30-day-old sibling's first_seen moved onto the survivor.
+    assert survivor["first_seen"] == oldest
+    assert (datetime.now() - datetime.fromisoformat(survivor["first_seen"])).days >= 29
+
+
+def test_apply_repoints_activations_to_survivor(tmp_path: Path):
+    _seed_cluster(tmp_path)
+    _activate(tmp_path, "skill:pr-workflow", "a")
+    _activate(tmp_path, "skill:pr-workflow", "c")
+    _activate(tmp_path, "skill:pr-workflow", "b")
+
+    report = _dedupe_json("--apply")
+    assert report["activations_repointed"] == 2
+
+    conn = _connect(tmp_path)
+    counts = dict(conn.execute("SELECT key, COUNT(*) FROM activations GROUP BY key").fetchall())
+    conn.close()
+
+    assert counts == {"b": 3}
+
+
+def test_apply_leaves_fts_index_consistent(tmp_path: Path):
+    _seed_cluster(tmp_path)
+    report = _dedupe_json("--apply")
+    assert report["fts_integrity_ok"] is True
+
+    conn = _connect(tmp_path)
+    # The deleted rows' text is gone from the index; the survivor's is still findable.
+    hits = conn.execute("SELECT rowid FROM learnings_fts WHERE learnings_fts MATCH 'validate'").fetchall()
+    conn.execute("INSERT INTO learnings_fts(learnings_fts) VALUES ('integrity-check')")
+    surviving_ids = {r["id"] for r in conn.execute("SELECT id FROM learnings").fetchall()}
+    conn.close()
+
+    assert len(hits) == 1
+    assert {h["rowid"] for h in hits} <= surviving_ids
+
+
+def test_graduated_rows_are_protected(tmp_path: Path):
+    _insert(tmp_path, "skill:do", "a", BASE_VALUE, confidence=0.5)
+    _insert(tmp_path, "skill:do", "b", NOISY_VALUE, confidence=0.9, graduated_to="docs/PHILOSOPHY.md")
+
+    report = _dedupe_json("--apply")
+    assert report["clusters"] == 0
+    assert report["rows_removed"] == 0
+    assert len(_rows(tmp_path)) == 2
+
+
+def test_routing_effectiveness_rows_are_protected(tmp_path: Path):
+    _insert(tmp_path, "routing", "a", BASE_VALUE, category="effectiveness")
+    _insert(tmp_path, "routing", "b", NOISY_VALUE, category="effectiveness")
+
+    report = _dedupe_json("--apply")
+    assert report["clusters"] == 0
+    assert len(_rows(tmp_path)) == 2
+
+
+def test_category_filter_scopes_the_run(tmp_path: Path):
+    _insert(tmp_path, "voice-sample", "a", BASE_VALUE, category="voice")
+    _insert(tmp_path, "voice-sample", "b", NOISY_VALUE, category="voice")
+    _insert(tmp_path, "skill:do", "c", BASE_VALUE, category="gotcha")
+    _insert(tmp_path, "skill:do", "d", NOISY_VALUE, category="gotcha")
+
+    assert _dedupe_json("--category", "voice")["rows_removed"] == 1
+    assert _dedupe_json()["rows_removed"] == 2
+
+
+def test_prefix_bounds_the_comparison(tmp_path: Path):
+    shared = "x" * 200
+    _insert(tmp_path, "skill:do", "a", shared + " tail one")
+    _insert(tmp_path, "skill:do", "b", shared + " tail two")
+
+    # A 120-char window sees only the shared preamble.
+    assert _dedupe_json()["clusters"] == 1
+    # A wider window reaches the divergent tails.
+    assert _dedupe_json("--prefix", "400")["clusters"] == 0
+
+
+def test_empty_normalized_values_are_skipped(tmp_path: Path):
+    _insert(tmp_path, "skill:do", "a", "→→→")
+    _insert(tmp_path, "skill:do", "b", "!!! ...")
+
+    report = _dedupe_json("--apply")
+    assert report["clusters"] == 0
+    assert len(_rows(tmp_path)) == 2
+
+
+def test_no_duplicates_reports_clean(tmp_path: Path):
+    _insert(tmp_path, "skill:do", "a", BASE_VALUE)
+    result = _run_cli("dedupe")
+    assert result.returncode == 0
+    assert "Near-duplicate clusters: 0" in result.stdout

--- a/skills/meta/do/references/hooks-guide.md
+++ b/skills/meta/do/references/hooks-guide.md
@@ -22,6 +22,15 @@
 | `once: true` | Hook runs only once per session |
 | `timeout` | Maximum execution time in ms |
 | Cascading output | Hooks can inject context into prompts |
+| Async rewake | Hand LLM-grade work back to the session model from a hook |
+
+## Async Rewake
+
+A hook that needs judgment rather than a pattern match re-wakes the session agent and lets it do the work. `async_rewake(message, summary)` in `hooks/lib/hook_utils.py` writes `{"rewakeSummary": ...}` to stdout, the full context to stderr, and exits 2.
+
+This costs no SDK and no metered API key — the session model already running does the work. `hooks/security-review-hook.py` uses it on `Stop` to hand a working-tree diff back for review.
+
+Reserve it for work a script cannot decide. A hook that re-wakes on every event turns one tool call into a full model turn.
 
 ## Error Learning
 

--- a/skills/meta/do/references/worktree-rules.md
+++ b/skills/meta/do/references/worktree-rules.md
@@ -128,11 +128,44 @@ bash scripts/worktree-cleanup.sh --force
 
 `git worktree remove` frees the materialized checkout while preserving its branch for recovery. The cleanup script then prunes stale records and removes merged harness branches.
 
+## Dispatcher Rules
+
+These two rules bind the orchestrator that dispatches agents, not the worktree agent itself. `hooks/pretool-worktree-edit-guard.py` blocks a worktree agent from writing into the shared main tree. Nothing stops an orchestrator from putting two writers in that tree to begin with.
+
+### Rule D1: Give Every File-Writing Agent Its Own Worktree
+
+Dispatch any agent that writes files with `isolation: "worktree"` when you also run git commands in the main tree, or when another writing agent is already running there. Agents that only read are safe to run concurrently in the main tree.
+
+Two writers in one tree contend for `HEAD` and the index. Observed damage: a `git reset --hard` during one agent's rebase dropped a sibling agent's committed branch, recoverable only through the reflog.
+
+When agents must share a tree, sequence their git index operations and record a recovery ref before any rebase:
+
+```bash
+git branch backup/$(git branch --show-current)-$(date +%s)
+```
+
+### Rule D2: Validate an Agent's PR Against origin, Not Your Working Tree
+
+Reset the branch to its pushed state before you grep or test a background agent's work locally:
+
+```bash
+git fetch origin
+git reset --hard origin/<branch>
+```
+
+The main tree can carry staged files left over from earlier worktree juggling. Those files silently revert the agent's commit, so local greps and test runs read code the agent never wrote — and a correct agent looks broken. The committed blob is the authority. Read it directly when you need one file:
+
+```bash
+git show <sha>:<path>
+```
+
 ## Failure Modes This Prevents
 
 | Failure | Rule | Without It |
 |---------|------|-----------|
 | Agent edits main repo files | 1, 6 | Changes leak to main, get stashed/lost |
+| Two agents corrupt each other's branches | D1 | A rebase drops a sibling's commits; reflog is the only recovery |
+| Local validation reads stale staged files | D2 | The agent's correct work is reported as broken |
 | Context wasted on task_plan.md | 4 | Implementation budget consumed by planning |
 | Commit on wrong branch | 2 | Orchestrator merges wrong content |
 | PR has changes from 2 ADRs | 5, 6 | Cross-contamination between agents |

--- a/skills/process/pr-workflow/references/ci-check.md
+++ b/skills/process/pr-workflow/references/ci-check.md
@@ -133,6 +133,15 @@ Future extension point: if `skills/process/pr-workflow/references/pr-risk-policy
 ### Conflicting PR: "no checks reported"
 A same-repo PR in `mergeable=CONFLICTING` state fires no workflow run on push, so `gh pr checks` shows "no checks reported" — a missing run, not a failure. Merge `origin/main` into the branch first; CI triggers on that push. (Evidence: PRs #789/#791/#797, 2026-06-11.)
 
+### Fork PR: "no checks reported"
+A fork PR is silent for two independent reasons, and approval alone fixes only one. Workflow runs from a fork wait for maintainer approval, and GitHub cannot build `refs/pull/N/merge` while the PR conflicts — so a conflicting fork PR reports nothing even after you approve it. Read both fields before you conclude CI is broken:
+
+```bash
+gh pr view "$PR" --json mergeable,mergeStateStatus,headRepositoryOwner,isCrossRepository
+```
+
+Resolve the conflict first (`mergeStateStatus: DIRTY`), then approve the pending run. Approving a conflicting fork PR leaves it silent and looks like an approval that did not take.
+
 ### Error: "No workflow runs found"
 **Cause**: Workflow not triggered, branch has no workflows, or checked too early
 **Solution**:

--- a/skills/process/verification-before-completion/references/checklist.md
+++ b/skills/process/verification-before-completion/references/checklist.md
@@ -263,6 +263,23 @@ Use this when running language-specific quality gates:
 
 ---
 
+## Tuned-Threshold Feature Checklist
+
+Use this when a feature is correct only if a user actually reaches something during normal use: a progress meter, an unlock, a rate limit, a difficulty curve, an onboarding funnel.
+
+### Reachability Verification
+- [ ] **Threshold reached live**: Drive the real app and hit the threshold through normal use
+- [ ] **Turn or step count recorded**: Note how long it took, not just that it happened
+- [ ] **Opposing forces modeled**: Decay, cooldowns, costs, and timeouts included in the check
+- [ ] **Representative input used**: An average case, not a best-case deck, dataset, or profile
+- [ ] **Regression test locks the result**: Encode the reached threshold as a test
+
+**Why**: unit and integration gates assert that the mechanics compute correctly. They say nothing about whether the value ever climbs high enough. A meter mechanic once passed every unit and integration gate and three review workflows; driving the real app showed the charge thresholds were unreachable in normal play, because flat decay outran the gains. Simulation modeled the mechanic and under-modeled the economy around it.
+
+**Measure before you tune**: check reachability first. If the threshold is already reached, the fix is a regression test that locks the behavior, not an economy change.
+
+---
+
 ## Hotfix/Emergency Change Checklist
 
 ### Minimal Viable Verification (Emergency Only)

--- a/skills/review/security-review/SKILL.md
+++ b/skills/review/security-review/SKILL.md
@@ -178,7 +178,7 @@ This skill is the on-demand (PULL) path. The same review also runs automatically
 | Event | Behavior |
 |-------|----------|
 | **PreToolUse** (Bash `git commit`) | Scans STAGED files with the same scanner. A HIGH/CRITICAL finding blocks the commit (deny). Clean commits pass. |
-| **Stop** | Re-wakes the session with the working-tree diff and an instruction to run this pipeline. Advisory — never blocks. |
+| **Stop** | Re-wakes the session with the working-tree diff and an instruction to run this pipeline. Advisory — never blocks. Fires only when a source file gained at least one line. Pure deletions, doc-only diffs (`.md`, `.txt`, `.rst`, `.json`, `.mdx`), mode-only, and rename-only diffs carry no new code for the deep pass, so silence there is the hook working; the edit-time and commit-block gates still scan docs for secrets. |
 
 **Bypass / kill switches** (commit-time block only, deliberate overrides):
 


### PR DESCRIPTION
## Summary
Adds a `dedupe` subcommand to `learning-db.py` and moves 21 triaged learnings out of runtime injection into skill references. Collapsed 21 near-duplicate clusters (220 rows) in the live DB; injectable pool drops from 27 to 6.

## Changes
- `scripts/learning-db.py` — add `dedupe`: clusters rows on normalized value prefix, dry-run default, `--apply` collapses to the highest-confidence survivor and re-points its `activations`.
- `scripts/tests/test_learning_db_dedupe.py` — 15 tests: cluster detection, dry-run inertness, survivor choice, first_seen/observation_count merge, activations re-pointing, FTS integrity, graduated-row protection.
- `skills/meta/do/references/worktree-rules.md` — add dispatcher-side Rules D1/D2: worktree-isolate concurrent writers; validate an agent's PR against `origin`, not the local tree.
- `skills/process/pr-workflow/references/ci-check.md` — add the fork-PR case of "no checks reported".
- `agents/base-instructions.md` — run test suites in the foreground.
- `agents/toolkit-governance-engineer/references/routing-table-patterns.md` — add the four registration invariants a skill+hook PR must move together.
- `skills/meta/do/references/hooks-guide.md` — document `async_rewake`.
- `skills/review/security-review/SKILL.md` — state when the Stop rewake stays silent.
- `skills/process/verification-before-completion/references/checklist.md` — add a tuned-threshold reachability checklist.
- `docs/what-didnt-work.md` — record the parity audit that cited values present in no source file.

## Notes
The DB changes are local-only and already applied; this PR carries the tool and the documentation. Backups taken via SQLite's online backup API at `learning.db.bak-dedupe-20260828-063318` and `learning.db.bak-graduate-20260828-064335`.
`dedupe` skips graduated rows and `topic='routing'` effectiveness rows, reusing the same protection clause as `prune` — 11 further clusters were left intact for that reason.
6 of 27 candidates were declined: 2 documented only in `~/private-skills`, 1 an n=1 inference, 1 a session log, 2 partly obsolete. They remain injectable.
