### PR TITLE
hooks: port warmstart to SubagentStart, record Bash reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AI agents skip steps.
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
 <!-- Counts here must match the Four Layers table (~line 143). Verify both: python3 scripts/validate-doc-counts.py -->
-44 domain agents, 122 workflow skills, 76 hooks, 136 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 122 workflow skills, 77 hooks, 136 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 
@@ -149,7 +149,7 @@ Strips built-in tool-use instructions. The toolkit's agents, skills, hooks, and 
 |---|---|---|
 | Agents | 44 | Domain knowledge: idiom tables, failure mode catalogs, error-to-fix mappings |
 | Skills | 122 | Phased methodology with gates. Can't skip steps. Each phase has exit criteria requiring evidence. |
-| Hooks | 76 | Fire on lifecycle events. Block incomplete work. Zero LLM cost. |
+| Hooks | 77 | Fire on lifecycle events. Block incomplete work. Zero LLM cost. |
 | Scripts | 136 | Determinism: test runners, linters, validators. No LLM judgment. |
 
 Full skill catalog: [docs/skills.md](docs/skills.md).

--- a/docs/injected-context-contracts.md
+++ b/docs/injected-context-contracts.md
@@ -110,6 +110,14 @@ Source: `hooks/session-manifest-cache.py`.
 Meaning: The /do routing-manifest cache at the given path is verified against current INDEX inputs (`fresh`) or was just rebuilt (`refreshed`).
 Action: None required now. When /do Phase 2 Step 0 runs, its cache-first block reads this file instead of running `routing-manifest.py`; the bash sha256 check re-proves freshness at read time.
 
+## Subagent-Start Tags (injected into a subagent before its first prompt)
+
+### `[warmstart] Parent session context for {agent_type}:` (plus `[warmstart] …` lines)
+
+Source: `hooks/subagent-start-warmstart.py` (SubagentStart; builder in `hooks/lib/warmstart_lib.py`). The superseded `hooks/pretool-subagent-warmstart.py` emits the same block on PreToolUse:Agent, which lands in the parent, not the subagent.
+Meaning: What the parent session already has: files seen this session (Read tool and read-only Bash commands, from `.claude/session-reads.txt`), task plan goal and status, ADR session pointer, decisions, and discovery briefs. Only current-session entries within 24 hours are included; credential-shaped paths are never listed. Capped at 4000 chars.
+Action: Skip re-reading files the block lists unless the task needs their content. Treat listed decisions and the ADR pointer as settled parent state. `Files seen (0): none` means no parent read state exists; discover from scratch.
+
 ## Prompt-Signal Tags (emitted mid-conversation, require routing action)
 
 ### `[pipeline-creator]` plus `[auto-skill] pipeline-scaffolder` (plus JSON snapshot)

--- a/docs/injected-context-contracts.md
+++ b/docs/injected-context-contracts.md
@@ -115,7 +115,7 @@ Action: None required now. When /do Phase 2 Step 0 runs, its cache-first block r
 ### `[warmstart] Parent session context for {agent_type}:` (plus `[warmstart] …` lines)
 
 Source: `hooks/subagent-start-warmstart.py` (SubagentStart; builder in `hooks/lib/warmstart_lib.py`). The superseded `hooks/pretool-subagent-warmstart.py` emits the same block on PreToolUse:Agent, which lands in the parent, not the subagent.
-Meaning: What the parent session already has: files seen this session (Read tool and read-only Bash commands, from `.claude/session-reads.txt`), task plan goal and status, ADR session pointer, decisions, and discovery briefs. Only current-session entries within 24 hours are included; credential-shaped paths are never listed. Capped at 4000 chars.
+Meaning: What the parent session already has: files seen this session (Read tool and read-only Bash commands, from the `session-reads.txt` file under `.claude/`), task plan goal and status, ADR session pointer, decisions, and discovery briefs. Only current-session entries within 24 hours are included; credential-shaped paths are never listed. Capped at 4000 chars.
 Action: Skip re-reading files the block lists unless the task needs their content. Treat listed decisions and the ADR pointer as settled parent state. `Files seen (0): none` means no parent read state exists; discover from scratch.
 
 ## Prompt-Signal Tags (emitted mid-conversation, require routing action)

--- a/hooks/lib/warmstart_lib.py
+++ b/hooks/lib/warmstart_lib.py
@@ -1,0 +1,285 @@
+"""
+Shared warm-start context builder.
+
+Used by hooks/subagent-start-warmstart.py (SubagentStart, lands in the
+subagent) and the superseded hooks/pretool-subagent-warmstart.py
+(PreToolUse:Agent, lands in the parent). Both read the same on-disk
+parent-session state: session-reads JSONL, task_plan.md, .adr-session.json,
+and .planning/discoveries/.
+
+Session scoping: files-seen entries come from the v2 JSONL session-reads
+format and are filtered to the given session id and the freshness window;
+v1 legacy plain-path lines are ignored. Credential-shaped paths are filtered
+out. task_plan.md, .adr-session.json, and discovery briefs are only used when
+modified within the freshness window.
+"""
+
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from hook_utils import is_sensitive_path
+
+SESSION_READS_FILE = ".claude/session-reads.txt"
+TASK_PLAN_FILE = "task_plan.md"
+ADR_SESSION_FILE = ".adr-session.json"
+DISCOVERIES_DIR = ".planning/discoveries"
+
+MAX_OUTPUT_CHARS = 4000
+MAX_FILES_SHOWN = 10
+
+# Context older than this is treated as belonging to a previous task.
+FRESHNESS_HOURS = 24
+
+
+def is_fresh_file(path: Path, hours: int = FRESHNESS_HOURS) -> bool:
+    """True when path exists and was modified within the freshness window."""
+    try:
+        return (time.time() - path.stat().st_mtime) <= hours * 3600
+    except OSError:
+        return False
+
+
+def load_recent_reads(
+    reads_path: Path,
+    session_id: str,
+    max_count: int = MAX_FILES_SHOWN,
+) -> list[str]:
+    """Load up to max_count recent file paths for the current session.
+
+    Reads the v2 JSONL format ({"ts", "session", "path"}). Entries from other
+    sessions, entries older than FRESHNESS_HOURS, credential-shaped paths, and
+    v1 legacy plain-path lines are all skipped.
+
+    Args:
+        reads_path: Path to the session-reads.txt file.
+        session_id: Current session id; only matching entries are returned.
+        max_count: Maximum number of paths to return.
+
+    Returns:
+        List of file path strings, most recent last (tail of file).
+    """
+    if not reads_path.is_file():
+        return []
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=FRESHNESS_HOURS)
+    paths: list[str] = []
+    try:
+        for line in reads_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # v1 legacy plain-path line — no session id, skip
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("session", "")) != session_id:
+                continue
+            try:
+                ts = datetime.fromisoformat(entry["ts"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            if ts < cutoff:
+                continue
+            path = str(entry.get("path", ""))
+            if not path or is_sensitive_path(path):
+                continue
+            paths.append(path)
+        return paths[-max_count:]
+    except OSError:
+        return []
+
+
+def extract_task_plan(plan_path: Path) -> dict[str, str]:
+    """Extract Goal and Status lines from task_plan.md.
+
+    Args:
+        plan_path: Path to task_plan.md.
+
+    Returns:
+        Dict with 'goal' and 'status' keys (empty strings if not found).
+    """
+    result = {"goal": "", "status": ""}
+
+    if not plan_path.is_file() or not is_fresh_file(plan_path):
+        return result
+
+    try:
+        content = plan_path.read_text(encoding="utf-8")
+    except OSError:
+        return result
+
+    lines = content.splitlines()
+    in_goal_section = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "## Goal":
+            in_goal_section = True
+            continue
+        if in_goal_section:
+            if stripped.startswith("## "):
+                # Hit next section heading, goal section is over
+                in_goal_section = False
+            elif stripped:
+                result["goal"] = stripped[:200]
+                in_goal_section = False
+        if stripped.startswith("**Currently in Phase") or stripped.startswith("**Status"):
+            result["status"] = stripped[:200]
+
+    return result
+
+
+def extract_decisions(plan_path: Path) -> list[str]:
+    """Extract decisions from the 'Decisions Made' section of task_plan.md.
+
+    Args:
+        plan_path: Path to task_plan.md.
+
+    Returns:
+        List of decision strings.
+    """
+    if not plan_path.is_file() or not is_fresh_file(plan_path):
+        return []
+
+    try:
+        content = plan_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    decisions: list[str] = []
+    in_decisions = False
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped == "## Decisions Made":
+            in_decisions = True
+            continue
+        if in_decisions:
+            if stripped.startswith("## "):
+                break  # Next section
+            if stripped.startswith("- "):
+                decisions.append(stripped[2:].strip()[:200])
+
+    return decisions
+
+
+def load_adr_session(session_path: Path) -> dict[str, str]:
+    """Load ADR session metadata from .adr-session.json.
+
+    Args:
+        session_path: Path to .adr-session.json.
+
+    Returns:
+        Dict with 'adr_path' and 'domain' keys (empty strings if not found).
+    """
+    result = {"adr_path": "", "domain": ""}
+
+    if not session_path.is_file() or not is_fresh_file(session_path):
+        return result
+
+    try:
+        content = session_path.read_text(encoding="utf-8")
+        data = json.loads(content)
+        result["adr_path"] = data.get("adr_path", "")
+        result["domain"] = data.get("domain", "")
+    except (OSError, json.JSONDecodeError):
+        pass
+
+    return result
+
+
+def list_discoveries(discoveries_dir: Path) -> list[str]:
+    """List discovery brief filenames from .planning/discoveries/.
+
+    Args:
+        discoveries_dir: Path to the discoveries directory.
+
+    Returns:
+        List of filenames (not full paths).
+    """
+    if not discoveries_dir.is_dir():
+        return []
+
+    try:
+        return sorted(f.name for f in discoveries_dir.iterdir() if f.is_file() and is_fresh_file(f))
+    except OSError:
+        return []
+
+
+def build_context_block(
+    files: list[str],
+    task_plan: dict[str, str],
+    decisions: list[str],
+    adr_session: dict[str, str],
+    discoveries: list[str],
+    agent_type: str = "subagent",
+) -> str:
+    """Build the parent-context block for subagent injection.
+
+    Args:
+        files: List of file paths seen in the session.
+        task_plan: Dict with 'goal' and 'status' from task_plan.md.
+        decisions: List of decisions from task_plan.md.
+        adr_session: Dict with 'adr_path' and 'domain'.
+        discoveries: List of discovery brief filenames.
+        agent_type: Name of the dispatched agent for the header line.
+
+    Returns:
+        Formatted context block string, capped at MAX_OUTPUT_CHARS.
+    """
+    parts: list[str] = []
+
+    # Files seen
+    if files:
+        file_list = ", ".join(files)
+        parts.append(f"[warmstart] Files seen ({len(files)}): {file_list}")
+    else:
+        parts.append("[warmstart] Files seen (0): none")
+
+    # Task plan
+    if task_plan["goal"]:
+        parts.append(f"[warmstart] Task: {task_plan['goal']}")
+    if task_plan["status"]:
+        parts.append(f"[warmstart] Status: {task_plan['status']}")
+
+    # ADR session
+    if adr_session["adr_path"]:
+        parts.append(f"[warmstart] ADR session: {adr_session['adr_path']} (domain: {adr_session['domain']})")
+
+    # Decisions
+    if decisions:
+        decision_text = "; ".join(decisions)
+        parts.append(f"[warmstart] Decisions: {decision_text}")
+
+    # Discoveries
+    if discoveries:
+        disc_text = ", ".join(discoveries)
+        parts.append(f"[warmstart] Discovery briefs: {disc_text}")
+
+    header = f"[warmstart] Parent session context for {agent_type or 'subagent'}:"
+    body = "\n".join(parts)
+    full_output = f"{header}\n{body}"
+
+    # Cap at MAX_OUTPUT_CHARS
+    if len(full_output) > MAX_OUTPUT_CHARS:
+        full_output = full_output[: MAX_OUTPUT_CHARS - 3] + "..."
+
+    return full_output
+
+
+def gather_context_block(session_id: str, agent_type: str = "subagent") -> str:
+    """Read every parent-session source from cwd and build the block."""
+    task_plan_path = Path(TASK_PLAN_FILE)
+    return build_context_block(
+        files=load_recent_reads(Path(SESSION_READS_FILE), session_id),
+        task_plan=extract_task_plan(task_plan_path),
+        decisions=extract_decisions(task_plan_path),
+        adr_session=load_adr_session(Path(ADR_SESSION_FILE)),
+        discoveries=list_discoveries(Path(DISCOVERIES_DIR)),
+        agent_type=agent_type,
+    )

--- a/hooks/posttool-session-reads.py
+++ b/hooks/posttool-session-reads.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 2.0.0
+# hook-version: 2.1.0
 """
 PostToolUse Hook: Session Read Tracker
 
@@ -14,14 +14,22 @@ prune entries older than RETENTION_DAYS and drop v1 legacy plain-path
 lines, so the file cannot accumulate cross-session state indefinitely.
 Credential-shaped paths (.ssh/, .env, *.pem, ...) are never recorded.
 
+v2.1 (Bash reads): a Bash command that starts with a read-only pager
+(cat, sed, head, tail, less, bat) also records every argument that resolves
+to an existing file under cwd, capped at MAX_BASH_PATHS. Codex cannot
+intercept the built-in Read tool, so this keeps the warm-start file list
+populated there. Commands containing rm, mv, cp, or a redirect are ignored.
+
 Design Principles:
 - SILENT output (no context injection)
 - Non-blocking (always exits 0)
-- Only processes Read tool results
+- Processes Read tool results and read-only Bash commands
 - Deduplicates (session, path) pairs
 """
 
 import json
+import re
+import shlex
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -38,6 +46,68 @@ SESSION_READS_FILE = ".claude/session-reads.txt"
 
 # Entries older than this are pruned on every write.
 RETENTION_DAYS = 7
+
+# Bash commands that read files without changing them.
+_READ_CMD_RE = re.compile(r"^\s*(cat|sed|head|tail|less|bat)\b")
+# Any of these anywhere in the command means it may write or move; skip it.
+_MUTATING_RE = re.compile(r"(^|[\s;&|])(rm|mv|cp)\b|>")
+MAX_BASH_PATHS = 20
+
+
+def bash_read_paths(command: str, cwd: Path | None = None) -> list[str]:
+    """Return file paths a read-only Bash command touches, in argument order.
+
+    Only commands that open with cat/sed/head/tail/less/bat qualify. Commands
+    that mention rm, mv, cp, or a `>` redirect return nothing. Each argument
+    is kept when it names an existing file under cwd; the result is capped
+    at MAX_BASH_PATHS. Credential-shaped paths are dropped.
+    """
+    if not isinstance(command, str) or not _READ_CMD_RE.match(command):
+        return []
+    if _MUTATING_RE.search(command):
+        return []
+    try:
+        args = shlex.split(command)
+    except ValueError:
+        return []
+    if args and args[0] == "sed" and any(a.startswith("-i") or a == "--in-place" for a in args[1:]):
+        return []  # in-place edit, not a read
+    base = (cwd or Path.cwd()).resolve()
+    paths: list[str] = []
+    for arg in args[1:]:
+        if not arg or arg.startswith("-"):
+            continue
+        try:
+            candidate = (base / arg).resolve()
+            if not candidate.is_file() or not candidate.is_relative_to(base):
+                continue
+        except (OSError, ValueError):
+            continue
+        rel = str(candidate.relative_to(base))
+        if is_sensitive_path(rel) or rel in paths:
+            continue
+        paths.append(rel)
+        if len(paths) >= MAX_BASH_PATHS:
+            break
+    return paths
+
+
+def event_paths(event: dict) -> list[str]:
+    """Paths to record for one event: Read file_path, or read-only Bash args."""
+    tool_input = event.get("tool_input", {})
+    if isinstance(tool_input, str):
+        try:
+            tool_input = json.loads(tool_input)
+        except (json.JSONDecodeError, TypeError):
+            return []
+    if not isinstance(tool_input, dict):
+        return []
+    if event.get("tool_name") == "Bash":
+        return bash_read_paths(str(tool_input.get("command", "")))
+    file_path = tool_input.get("file_path", "")
+    if not file_path or is_sensitive_path(file_path):
+        return []
+    return [str(file_path)]
 
 
 def _parse_entry(line: str) -> dict | None:
@@ -66,10 +136,10 @@ def _fresh(entry: dict, cutoff: datetime) -> bool:
 
 
 def main() -> None:
-    """Record a Read tool file path for the current session.
+    """Record Read tool file paths and read-only Bash paths for this session.
 
     Flow:
-    1. Read stdin JSON; extract file_path from tool_input
+    1. Read stdin JSON; extract file_path (Read) or command paths (Bash)
     2. Skip credential-shaped paths entirely
     3. Rewrite .claude/session-reads.txt: fresh entries + the new one,
        deduplicated on (session, path)
@@ -82,20 +152,12 @@ def main() -> None:
 
         event = json.loads(event_data)
 
-        # tool_name filter removed — matcher "Read" in settings.json prevents
-        # this hook from spawning for non-Read tools.
-
-        tool_input = event.get("tool_input", {})
-        if isinstance(tool_input, str):
-            try:
-                tool_input = json.loads(tool_input)
-            except (json.JSONDecodeError, TypeError):
-                return
-        if not isinstance(tool_input, dict):
+        # The settings.json matcher ("Read" or "Bash") limits which tools
+        # spawn this hook; event_paths() decides what each event records.
+        if not isinstance(event, dict):
             return
-
-        file_path = tool_input.get("file_path", "")
-        if not file_path or is_sensitive_path(file_path):
+        new_paths = event_paths(event)
+        if not new_paths:
             return
 
         session_id = event.get("session_id") or get_session_id()
@@ -121,8 +183,10 @@ def main() -> None:
             except OSError:
                 pass
 
-        if (session_id, file_path) not in seen:
-            entries.append({"ts": now.isoformat(), "session": session_id, "path": file_path})
+        for file_path in new_paths:
+            if (session_id, file_path) not in seen:
+                seen.add((session_id, file_path))
+                entries.append({"ts": now.isoformat(), "session": session_id, "path": file_path})
 
         tmp_path = reads_path.with_suffix(".tmp")
         tmp_path.write_text("".join(json.dumps(e) + "\n" for e in entries), encoding="utf-8")

--- a/hooks/pretool-subagent-warmstart.py
+++ b/hooks/pretool-subagent-warmstart.py
@@ -1,332 +1,60 @@
 #!/usr/bin/env python3
-# hook-version: 2.0.0
+# hook-version: 2.1.0
 """
-PreToolUse Hook: Subagent Warm Start
+PreToolUse Hook: Subagent Warm Start (superseded)
 
-Enriches subagent (Agent tool) prompts with parent session context.
-Injects a <parent-context> block containing files seen, task plan
-status, ADR session info, key decisions, and discovery briefs.
-
-This gives subagents immediate awareness of the parent session's
-state without needing to re-discover context from scratch.
-
-v2 (session scoping): warmstart context is bound to the CURRENT session.
-Files-seen entries come from the v2 JSONL session-reads format and are
-filtered to this session id and the freshness window; v1 legacy plain-path
-lines are ignored. Credential-shaped paths (.ssh/, .env, *.pem, ...) are
-filtered out. task_plan.md, .adr-session.json, and discovery briefs are
-only injected when modified within the freshness window, so a stale plan
-or ADR pointer from a previous task cannot leak into new dispatches.
+Superseded by hooks/subagent-start-warmstart.py. PreToolUse:Agent
+`additionalContext` lands in the PARENT session, not the subagent, so this
+hook never reached a subagent. It stays registered for one release so
+deregistration is a separate owner step. Context building lives in
+hooks/lib/warmstart_lib.py and is shared with the SubagentStart hook.
 
 Design Principles:
 - Non-blocking (always exits 0)
 - Sub-50ms execution (file reads only, no subprocess)
 - Graceful degradation on missing files
-- Caps output at ~4000 chars (~1000 tokens)
 """
 
 import json
 import sys
-import time
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import context_output, empty_output, get_session_id, is_sensitive_path
+from hook_utils import context_output, empty_output, get_session_id
 from stdin_timeout import read_stdin
+from warmstart_lib import (  # re-exported for tests and callers
+    ADR_SESSION_FILE,
+    DISCOVERIES_DIR,
+    FRESHNESS_HOURS,
+    MAX_FILES_SHOWN,
+    MAX_OUTPUT_CHARS,
+    SESSION_READS_FILE,
+    TASK_PLAN_FILE,
+    build_context_block,
+    extract_decisions,
+    extract_task_plan,
+    gather_context_block,
+    is_fresh_file,
+    list_discoveries,
+    load_adr_session,
+    load_recent_reads,
+)
 
 EVENT_NAME = "PreToolUse"
 
-SESSION_READS_FILE = ".claude/session-reads.txt"
-TASK_PLAN_FILE = "task_plan.md"
-ADR_SESSION_FILE = ".adr-session.json"
-DISCOVERIES_DIR = ".planning/discoveries"
-
-MAX_OUTPUT_CHARS = 4000
-MAX_FILES_SHOWN = 10
-
-# Context older than this is treated as belonging to a previous task.
-FRESHNESS_HOURS = 24
-
-
-def is_fresh_file(path: Path, hours: int = FRESHNESS_HOURS) -> bool:
-    """True when path exists and was modified within the freshness window."""
-    try:
-        return (time.time() - path.stat().st_mtime) <= hours * 3600
-    except OSError:
-        return False
-
-
-def load_recent_reads(
-    reads_path: Path,
-    session_id: str,
-    max_count: int = MAX_FILES_SHOWN,
-) -> list[str]:
-    """Load up to max_count recent file paths for the current session.
-
-    Reads the v2 JSONL format ({"ts", "session", "path"}). Entries from other
-    sessions, entries older than FRESHNESS_HOURS, credential-shaped paths, and
-    v1 legacy plain-path lines are all skipped.
-
-    Args:
-        reads_path: Path to the session-reads.txt file.
-        session_id: Current session id; only matching entries are returned.
-        max_count: Maximum number of paths to return.
-
-    Returns:
-        List of file path strings, most recent last (tail of file).
-    """
-    if not reads_path.is_file():
-        return []
-
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=FRESHNESS_HOURS)
-    paths: list[str] = []
-    try:
-        for line in reads_path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue  # v1 legacy plain-path line — no session id, skip
-            if not isinstance(entry, dict):
-                continue
-            if str(entry.get("session", "")) != session_id:
-                continue
-            try:
-                ts = datetime.fromisoformat(entry["ts"])
-            except (KeyError, TypeError, ValueError):
-                continue
-            if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
-            if ts < cutoff:
-                continue
-            path = str(entry.get("path", ""))
-            if not path or is_sensitive_path(path):
-                continue
-            paths.append(path)
-        return paths[-max_count:]
-    except OSError:
-        return []
-
-
-def extract_task_plan(plan_path: Path) -> dict[str, str]:
-    """Extract Goal and Status lines from task_plan.md.
-
-    Args:
-        plan_path: Path to task_plan.md.
-
-    Returns:
-        Dict with 'goal' and 'status' keys (empty strings if not found).
-    """
-    result = {"goal": "", "status": ""}
-
-    if not plan_path.is_file() or not is_fresh_file(plan_path):
-        return result
-
-    try:
-        content = plan_path.read_text(encoding="utf-8")
-    except OSError:
-        return result
-
-    lines = content.splitlines()
-    in_goal_section = False
-    for line in lines:
-        stripped = line.strip()
-        if stripped == "## Goal":
-            in_goal_section = True
-            continue
-        if in_goal_section:
-            if stripped.startswith("## "):
-                # Hit next section heading, goal section is over
-                in_goal_section = False
-            elif stripped:
-                result["goal"] = stripped[:200]
-                in_goal_section = False
-        if stripped.startswith("**Currently in Phase") or stripped.startswith("**Status"):
-            result["status"] = stripped[:200]
-
-    return result
-
-
-def extract_decisions(plan_path: Path) -> list[str]:
-    """Extract decisions from the 'Decisions Made' section of task_plan.md.
-
-    Args:
-        plan_path: Path to task_plan.md.
-
-    Returns:
-        List of decision strings.
-    """
-    if not plan_path.is_file() or not is_fresh_file(plan_path):
-        return []
-
-    try:
-        content = plan_path.read_text(encoding="utf-8")
-    except OSError:
-        return []
-
-    decisions: list[str] = []
-    in_decisions = False
-
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped == "## Decisions Made":
-            in_decisions = True
-            continue
-        if in_decisions:
-            if stripped.startswith("## "):
-                break  # Next section
-            if stripped.startswith("- "):
-                decisions.append(stripped[2:].strip()[:200])
-
-    return decisions
-
-
-def load_adr_session(session_path: Path) -> dict[str, str]:
-    """Load ADR session metadata from .adr-session.json.
-
-    Args:
-        session_path: Path to .adr-session.json.
-
-    Returns:
-        Dict with 'adr_path' and 'domain' keys (empty strings if not found).
-    """
-    result = {"adr_path": "", "domain": ""}
-
-    if not session_path.is_file() or not is_fresh_file(session_path):
-        return result
-
-    try:
-        content = session_path.read_text(encoding="utf-8")
-        data = json.loads(content)
-        result["adr_path"] = data.get("adr_path", "")
-        result["domain"] = data.get("domain", "")
-    except (OSError, json.JSONDecodeError):
-        pass
-
-    return result
-
-
-def list_discoveries(discoveries_dir: Path) -> list[str]:
-    """List discovery brief filenames from .planning/discoveries/.
-
-    Args:
-        discoveries_dir: Path to the discoveries directory.
-
-    Returns:
-        List of filenames (not full paths).
-    """
-    if not discoveries_dir.is_dir():
-        return []
-
-    try:
-        return sorted(f.name for f in discoveries_dir.iterdir() if f.is_file() and is_fresh_file(f))
-    except OSError:
-        return []
-
-
-def build_context_block(
-    files: list[str],
-    task_plan: dict[str, str],
-    decisions: list[str],
-    adr_session: dict[str, str],
-    discoveries: list[str],
-) -> str:
-    """Build the parent-context block for subagent injection.
-
-    Args:
-        files: List of file paths seen in the session.
-        task_plan: Dict with 'goal' and 'status' from task_plan.md.
-        decisions: List of decisions from task_plan.md.
-        adr_session: Dict with 'adr_path' and 'domain'.
-        discoveries: List of discovery brief filenames.
-
-    Returns:
-        Formatted context block string, capped at MAX_OUTPUT_CHARS.
-    """
-    parts: list[str] = []
-
-    # Files seen
-    if files:
-        file_list = ", ".join(files)
-        parts.append(f"[warmstart] Files seen ({len(files)}): {file_list}")
-    else:
-        parts.append("[warmstart] Files seen (0): none")
-
-    # Task plan
-    if task_plan["goal"]:
-        parts.append(f"[warmstart] Task: {task_plan['goal']}")
-    if task_plan["status"]:
-        parts.append(f"[warmstart] Status: {task_plan['status']}")
-
-    # ADR session
-    if adr_session["adr_path"]:
-        parts.append(f"[warmstart] ADR session: {adr_session['adr_path']} (domain: {adr_session['domain']})")
-
-    # Decisions
-    if decisions:
-        decision_text = "; ".join(decisions)
-        parts.append(f"[warmstart] Decisions: {decision_text}")
-
-    # Discoveries
-    if discoveries:
-        disc_text = ", ".join(discoveries)
-        parts.append(f"[warmstart] Discovery briefs: {disc_text}")
-
-    header = "[warmstart] Parent session context for subagent:"
-    body = "\n".join(parts)
-    full_output = f"{header}\n{body}"
-
-    # Cap at MAX_OUTPUT_CHARS
-    if len(full_output) > MAX_OUTPUT_CHARS:
-        full_output = full_output[: MAX_OUTPUT_CHARS - 3] + "..."
-
-    return full_output
-
 
 def main() -> None:
-    """Process PreToolUse events for Agent tool warm start injection.
-
-    Flow:
-    1. Read stdin JSON, check tool_name == "Agent"
-    2. Gather parent session context from various files
-    3. Build <parent-context> block
-    4. Inject via context_output
-    """
+    """Emit the parent-context block on PreToolUse:Agent (lands in the parent)."""
     try:
         event_data = read_stdin(timeout=2)
         if not event_data:
             return
 
         event = json.loads(event_data)
-
-        # tool_name filter removed — matcher "Agent" in settings.json prevents
-        # this hook from spawning for non-Agent tools.
-
         session_id = event.get("session_id") or get_session_id()
-
-        # Gather context from various sources
-        files = load_recent_reads(Path(SESSION_READS_FILE), session_id)
-        task_plan = extract_task_plan(Path(TASK_PLAN_FILE))
-        decisions = extract_decisions(Path(TASK_PLAN_FILE))
-        adr_session = load_adr_session(Path(ADR_SESSION_FILE))
-        discoveries = list_discoveries(Path(DISCOVERIES_DIR))
-
-        # Build context block
-        context_block = build_context_block(
-            files=files,
-            task_plan=task_plan,
-            decisions=decisions,
-            adr_session=adr_session,
-            discoveries=discoveries,
-        )
-
-        # Inject context
-        context_output(EVENT_NAME, context_block).print_and_exit()
+        context_output(EVENT_NAME, gather_context_block(session_id)).print_and_exit()
 
     except Exception as e:
         print(f"[warmstart] error: {e}", file=sys.stderr)

--- a/hooks/subagent-start-warmstart.py
+++ b/hooks/subagent-start-warmstart.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+SubagentStart Hook: Subagent Warm Start
+
+Injects a `[warmstart]` parent-context block into the SUBAGENT at the start
+of its conversation. SubagentStart `additionalContext` is "added to the
+subagent's context at the start of its conversation, before its first
+prompt" (https://code.claude.com/docs/en/hooks). The earlier PreToolUse:Agent
+variant landed in the parent instead.
+
+Stdin (documented): session_id, transcript_path, cwd, hook_event_name,
+agent_id, agent_type. No prompt, no tool_input. The block is built from
+on-disk parent-session state only (see hooks/lib/warmstart_lib.py), so the
+Codex adapter can run this hook unchanged.
+
+Design Principles:
+- Non-blocking (always exits 0)
+- Sub-50ms execution (file reads only, no subprocess)
+- Graceful degradation on missing files
+- Caps output at ~4000 chars (~1000 tokens)
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Add lib directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+
+from hook_utils import context_output, empty_output, get_session_id
+from stdin_timeout import read_stdin
+from warmstart_lib import gather_context_block
+
+EVENT_NAME = "SubagentStart"
+
+
+def main() -> None:
+    """Build the parent-context block and inject it into the subagent.
+
+    Flow:
+    1. Read stdin JSON; take session_id and agent_type
+    2. Gather parent session context from on-disk state
+    3. Inject via context_output(SubagentStart, ...)
+    """
+    try:
+        event_data = read_stdin(timeout=2)
+        if not event_data:
+            return
+
+        event = json.loads(event_data)
+        if not isinstance(event, dict):
+            empty_output(EVENT_NAME).print_and_exit()
+
+        session_id = event.get("session_id") or get_session_id()
+        agent_type = str(event.get("agent_type") or "subagent").strip() or "subagent"
+
+        context_output(EVENT_NAME, gather_context_block(session_id, agent_type)).print_and_exit()
+
+    except Exception as e:
+        print(f"[warmstart] error: {e}", file=sys.stderr)
+        empty_output(EVENT_NAME).print_and_exit()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"[warmstart] Fatal: {e}", file=sys.stderr)
+    finally:
+        sys.exit(0)

--- a/hooks/tests/test_posttool_session_reads.py
+++ b/hooks/tests/test_posttool_session_reads.py
@@ -78,17 +78,105 @@ class TestToolNameFiltering:
             stdout, stderr, code = run_hook(event)
             assert code == 0
 
-    def test_ignores_bash_tool(self, tmp_path, monkeypatch):
-        """Bash tool events should be ignored (no file_path to extract)."""
+    def test_ignores_non_read_bash_command(self, tmp_path, monkeypatch):
+        """A Bash command that is not a read-only pager records nothing."""
         monkeypatch.chdir(tmp_path)
         stdout, stderr, code = run_hook({"tool_name": "Bash", "tool_input": {"command": "ls"}})
         assert code == 0
+        assert load_entries(tmp_path) == []
 
     def test_ignores_agent_tool(self, tmp_path, monkeypatch):
         """Agent tool events should be ignored."""
         monkeypatch.chdir(tmp_path)
         stdout, stderr, code = run_hook({"tool_name": "Agent", "tool_input": {"prompt": "do something"}})
         assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Bash Read Recording (Codex cannot intercept the built-in Read tool)
+# ---------------------------------------------------------------------------
+
+
+def bash_event(command: str, session: str = "sess-1") -> dict:
+    return {"tool_name": "Bash", "session_id": session, "tool_input": {"command": command}}
+
+
+class TestBashReadRecording:
+    """Read-only Bash commands record the existing files they name."""
+
+    def test_cat_records_existing_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "hooks").mkdir()
+        (tmp_path / "hooks" / "afk-mode.py").write_text("x")
+        _, _, code = run_hook(bash_event("cat hooks/afk-mode.py"))
+        assert code == 0
+        assert [e["path"] for e in load_entries(tmp_path)] == ["hooks/afk-mode.py"]
+
+    def test_rm_records_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "hooks").mkdir()
+        (tmp_path / "hooks" / "x.py").write_text("x")
+        _, _, code = run_hook(bash_event("rm hooks/x.py"))
+        assert code == 0
+        assert load_entries(tmp_path) == []
+
+    def test_mutating_and_redirect_commands_record_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "a.py").write_text("x")
+        for command in (
+            "cat a.py > b.py",
+            "cat a.py && rm a.py",
+            "cat a.py; mv a.py c.py",
+            "cat a.py | cp /dev/stdin d.py",
+            "sed -i s/x/y/ a.py",
+        ):
+            _, _, code = run_hook(bash_event(command))
+            assert code == 0
+            assert load_entries(tmp_path) == [], command
+
+    def test_every_read_verb_qualifies(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "a.py").write_text("x")
+        for verb in ("cat", "sed -n 1,5p", "head -20", "tail -n 5", "less", "bat"):
+            paths = mod.bash_read_paths(f"{verb} a.py", cwd=tmp_path)
+            assert paths == ["a.py"], verb
+
+    def test_missing_files_and_flags_are_skipped(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "real.py").write_text("x")
+        assert mod.bash_read_paths("cat -n real.py missing.py", cwd=tmp_path) == ["real.py"]
+
+    def test_paths_outside_cwd_are_skipped(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        outside = tmp_path.parent / "outside-session-reads.txt"
+        outside.write_text("x")
+        try:
+            assert mod.bash_read_paths(f"cat {outside}", cwd=tmp_path) == []
+            assert mod.bash_read_paths("cat ../outside-session-reads.txt", cwd=tmp_path) == []
+        finally:
+            outside.unlink()
+
+    def test_credential_paths_are_never_recorded(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("x")
+        (tmp_path / "ok.py").write_text("x")
+        assert mod.bash_read_paths("cat .env ok.py", cwd=tmp_path) == ["ok.py"]
+
+    def test_cap_at_max_bash_paths(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        names = [f"f{i:02d}.py" for i in range(mod.MAX_BASH_PATHS + 5)]
+        for name in names:
+            (tmp_path / name).write_text("x")
+        paths = mod.bash_read_paths("cat " + " ".join(names), cwd=tmp_path)
+        assert len(paths) == mod.MAX_BASH_PATHS
+        assert paths == names[: mod.MAX_BASH_PATHS]
+
+    def test_bash_and_read_entries_share_one_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "a.py").write_text("x")
+        run_hook(read_event("/abs/b.py"))
+        run_hook(bash_event("cat a.py"))
+        assert [e["path"] for e in load_entries(tmp_path)] == ["/abs/b.py", "a.py"]
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/tests/test_subagent_start_warmstart.py
+++ b/hooks/tests/test_subagent_start_warmstart.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Tests for the subagent-start-warmstart hook (SubagentStart event).
+
+Run with: python3 -m pytest hooks/tests/test_subagent_start_warmstart.py -v
+"""
+
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).parent.parent / "subagent-start-warmstart.py"
+LIB_PATH = Path(__file__).parent.parent / "lib"
+
+sys.path.insert(0, str(LIB_PATH))
+import warmstart_lib
+
+SUBAGENT_START_EVENT = {
+    "session_id": "sess-1",
+    "transcript_path": "/tmp/transcript.jsonl",
+    "cwd": "/tmp",
+    "hook_event_name": "SubagentStart",
+    "agent_id": "agent-1",
+    "agent_type": "Explore",
+}
+
+
+def run_hook(stdin: str) -> tuple[str, str, int]:
+    """Run the hook with raw stdin and return (stdout, stderr, exit_code)."""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def run_event(event: dict) -> tuple[str, str, int]:
+    return run_hook(json.dumps(event))
+
+
+def _jsonl(paths: list[str], session: str = "sess-1") -> str:
+    now = datetime.now(timezone.utc).isoformat()
+    return "".join(json.dumps({"ts": now, "session": session, "path": p}) + "\n" for p in paths)
+
+
+class TestEventContract:
+    def test_documented_subagent_start_event_emits_subagent_start_output(self, tmp_path, monkeypatch):
+        """hookEventName is SubagentStart so the block lands in the subagent."""
+        monkeypatch.chdir(tmp_path)
+        stdout, stderr, code = run_event(SUBAGENT_START_EVENT)
+        assert code == 0
+        output = json.loads(stdout)
+        inner = output["hookSpecificOutput"]
+        assert inner["hookEventName"] == "SubagentStart"
+        assert "[warmstart]" in inner["additionalContext"]
+
+    def test_first_line_names_agent_type(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        stdout, _, code = run_event(SUBAGENT_START_EVENT)
+        assert code == 0
+        context = json.loads(stdout)["hookSpecificOutput"]["additionalContext"]
+        assert context.splitlines()[0] == "[warmstart] Parent session context for Explore:"
+
+    def test_missing_agent_type_falls_back_to_subagent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        event = {k: v for k, v in SUBAGENT_START_EVENT.items() if k != "agent_type"}
+        stdout, _, code = run_event(event)
+        assert code == 0
+        context = json.loads(stdout)["hookSpecificOutput"]["additionalContext"]
+        assert context.splitlines()[0] == "[warmstart] Parent session context for subagent:"
+
+    def test_no_prompt_or_tool_input_needed(self, tmp_path, monkeypatch):
+        """The documented SubagentStart stdin carries no prompt; the hook must not need one."""
+        monkeypatch.chdir(tmp_path)
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "session-reads.txt").write_text(_jsonl(["/proj/a.py", "/proj/b.py"]))
+        stdout, _, code = run_event(SUBAGENT_START_EVENT)
+        assert code == 0
+        context = json.loads(stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "[warmstart] Files seen (2): /proj/a.py, /proj/b.py" in context
+
+
+class TestNonBlocking:
+    def test_empty_stdin_exits_zero(self):
+        """`< /dev/null` must exit 0 or the registration bricks every dispatch."""
+        stdout, _, code = run_hook("")
+        assert code == 0
+
+    def test_malformed_json_exits_zero_with_empty_output(self):
+        stdout, _, code = run_hook("{not json")
+        assert code == 0
+        assert json.loads(stdout)["hookSpecificOutput"]["hookEventName"] == "SubagentStart"
+
+    def test_non_dict_json_exits_zero(self):
+        stdout, _, code = run_hook("[1, 2, 3]")
+        assert code == 0
+        assert json.loads(stdout)["hookSpecificOutput"] == {"hookEventName": "SubagentStart"}
+
+
+class TestSessionScoping:
+    def test_other_session_reads_are_excluded(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "session-reads.txt").write_text(_jsonl(["/old/a.py"], session="sess-OLD"))
+        stdout, _, code = run_event(SUBAGENT_START_EVENT)
+        assert code == 0
+        context = json.loads(stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "Files seen (0): none" in context
+        assert "/old/a.py" not in context
+
+
+class TestSharedBuilder:
+    def test_gather_context_block_in_process_is_fast(self, tmp_path, monkeypatch):
+        """Hook body budget: the on-disk gather stays well under 50 ms."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "task_plan.md").write_text("## Goal\nShip it\n\n## Decisions Made\n- use lib\n")
+        start = time.perf_counter()
+        block = warmstart_lib.gather_context_block("sess-1", "Explore")
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        assert elapsed_ms < 50, f"gather took {elapsed_ms:.1f} ms"
+        assert block.startswith("[warmstart] Parent session context for Explore:")
+        assert "[warmstart] Task: Ship it" in block
+        assert "[warmstart] Decisions: use lib" in block
+
+    def test_both_hooks_share_one_builder(self):
+        """The superseded PreToolUse hook re-exports the lib builder, not a copy."""
+        src = (Path(__file__).parent.parent / "pretool-subagent-warmstart.py").read_text(encoding="utf-8")
+        assert "from warmstart_lib import" in src
+        assert "def build_context_block" not in src

--- a/scripts/generate-codex-hooks-json.py
+++ b/scripts/generate-codex-hooks-json.py
@@ -74,7 +74,7 @@ UNSUPPORTED_REGISTRATIONS = {
         "Codex SubagentStart omits the Agent task prompt and tool input this reference injector requires."
     ),
     ("PreToolUse", "pretool-subagent-warmstart.py"): (
-        "Codex SubagentStart omits the dispatched Agent prompt needed to build the warm-start payload."
+        "Codex has no PreToolUse Agent event; the warm-start block moved to SubagentStart:subagent-start-warmstart.py."
     ),
     ("PreToolUse", "creation-protocol-enforcer.py"): (
         "Codex SubagentStart does not expose the Agent task text used to detect creation requests."

--- a/scripts/hook-health-allowlist.txt
+++ b/scripts/hook-health-allowlist.txt
@@ -28,3 +28,6 @@ pretool-config-protection.py               # deferred (ADR-115): denies ANY Writ
 voice-output-gate.py                       # superseded: voice-writer skill internalizes output gating (HOOK-GATE/CLOSE-GATE phases); private-skills install registers it separately when voice stack is active
 posttool-voice-quality-check.py            # superseded: voice-writer ANTI-AI phase covers AI-pattern checks; advisory-only, not needed default-on
 pretool-voice-publish-gate.py              # superseded: voice-writer pipeline phases enforce publish-readiness; dispatches voice-pipeline-tracker.py; private voice-stack installer registers it when active
+
+# --- Pending owner registration (persistence change approved separately) ---
+subagent-start-warmstart.py               # pending: register on SubagentStart in .claude/settings.json, then add SubagentStart:subagent-start-warmstart.py to scripts/codex-hooks-allowlist.txt; replaces PreToolUse:pretool-subagent-warmstart.py, whose additionalContext lands in the parent

--- a/scripts/tests/test_generate_codex_hooks_json.py
+++ b/scripts/tests/test_generate_codex_hooks_json.py
@@ -474,3 +474,16 @@ def test_cli_rejects_allowlist_with_missing_target_hook(tmp_path):
     assert result.returncode == 1
     assert "missing-hook.py" in result.stderr
     assert not output.exists()
+
+
+def test_subagent_start_warmstart_builds_a_subagent_start_block():
+    """The SubagentStart warm-start hook mirrors to Codex once the owner adds this line."""
+    line = "SubagentStart:subagent-start-warmstart.py matcher=* class=native mode=native failure=open"
+    entries = parse_allowlist(line)
+    result = build_hooks_json(entries, codex_hooks_dir="/codex/hooks")
+    assert list(result["hooks"]) == ["SubagentStart"]
+    block = result["hooks"]["SubagentStart"][0]
+    assert block["matcher"] == "*"
+    command = block["hooks"][0]["command"]
+    assert "--hook /codex/hooks/subagent-start-warmstart.py" in command
+    assert "--event SubagentStart" in command


### PR DESCRIPTION
PreToolUse:Agent additionalContext lands in the parent; SubagentStart lands in the subagent (docs confirmed), so warmstart never reached a subagent. New `subagent-start-warmstart.py` works on Claude and Codex; `posttool-session-reads.py` now records Bash cat/sed/head reads so Codex has a file list too.
Not registered yet — settings.json and codex allowlist entries need owner approval. Supersedes #936 (auto-closed by stack base deletion).

https://claude.ai/code/session_011xLnFyWR9mHmyXHoHLxte9