### PR TITLE
feat(telemetry): score handoff completeness per /do dispatch

### DIFF
--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 _DEFAULT_DB_DIR = Path.home() / ".claude" / "learning"
 
-_CURRENT_SCHEMA_VERSION = 9
+_CURRENT_SCHEMA_VERSION = 10
 
 CATEGORY_DEFAULTS = {
     "error": 0.55,
@@ -359,6 +359,28 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
             "VALUES (9, 'add directive_expected column to instruction_compliance')"
         )
 
+    if current < 10:
+        # v9 -> v10: handoff-completeness telemetry. spec_score counts the
+        # task-spec labels a [do-route] prompt carries (0-7), spec_missing
+        # names the absent ones, prompt_chars is the prompt length. Rows from
+        # non-/do dispatches and rows older than this migration stay NULL
+        # ("before measurement"). Each column may already exist from an ad-hoc
+        # ALTER on a live DB; the duplicate-column error is the expected no-op.
+        for ddl in (
+            "ALTER TABLE evidence_route_decisions ADD COLUMN spec_score INTEGER",
+            "ALTER TABLE evidence_route_decisions ADD COLUMN spec_missing TEXT",
+            "ALTER TABLE evidence_route_decisions ADD COLUMN prompt_chars INTEGER",
+        ):
+            try:
+                conn.execute(ddl)
+            except sqlite3.OperationalError:
+                pass  # column already present
+        conn.execute("PRAGMA user_version = 10")
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, description) "
+            "VALUES (10, 'add spec_score, spec_missing, prompt_chars columns to evidence_route_decisions')"
+        )
+
     conn.commit()
 
 
@@ -570,6 +592,9 @@ CREATE TABLE IF NOT EXISTS evidence_route_decisions (
     stack                TEXT,
     pipeline             TEXT,
     alternates           TEXT,
+    spec_score           INTEGER,
+    spec_missing         TEXT,
+    prompt_chars         INTEGER,
     created_at           TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at           TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -1230,6 +1255,75 @@ def record_evidence_event(
         return _event_row(row)
 
 
+_ROUTE_DECISION_UPDATE_SET = """
+                session_id = excluded.session_id,
+                route_key = excluded.route_key,
+                agent = excluded.agent,
+                skill = excluded.skill,
+                complexity = excluded.complexity,
+                model = excluded.model,
+                action = excluded.action,
+                health = excluded.health,
+                n = excluded.n,
+                failure = excluded.failure,
+                gate_inputs_present = excluded.gate_inputs_present,
+                outcome = excluded.outcome,
+                outcome_basis = excluded.outcome_basis,
+                request_snippet = excluded.request_snippet,
+                stack = excluded.stack,
+                pipeline = excluded.pipeline,
+                alternates = excluded.alternates,
+"""
+
+# Literal SQL only; both statements are fixed text with `?` placeholders.
+_ROUTE_DECISION_UPSERT_SQL = (
+    """
+            INSERT INTO evidence_route_decisions (
+                decision_id, session_id, route_key, agent, skill, complexity, model, action,
+                health, n, failure, gate_inputs_present, outcome, outcome_basis,
+                request_snippet, stack, pipeline, alternates, spec_score, spec_missing, prompt_chars,
+                created_at, updated_at
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')
+            )
+            ON CONFLICT(decision_id) DO UPDATE SET"""
+    + _ROUTE_DECISION_UPDATE_SET
+    + """                spec_score = excluded.spec_score,
+                spec_missing = excluded.spec_missing,
+                prompt_chars = excluded.prompt_chars,
+                updated_at = datetime('now')
+            """
+)
+
+# Pre-v10 shape: same row without the three spec columns.
+_ROUTE_DECISION_UPSERT_SQL_LEGACY = (
+    """
+            INSERT INTO evidence_route_decisions (
+                decision_id, session_id, route_key, agent, skill, complexity, model, action,
+                health, n, failure, gate_inputs_present, outcome, outcome_basis,
+                request_snippet, stack, pipeline, alternates, created_at, updated_at
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')
+            )
+            ON CONFLICT(decision_id) DO UPDATE SET"""
+    + _ROUTE_DECISION_UPDATE_SET
+    + """                updated_at = datetime('now')
+            """
+)
+_DEBUG_LOG_PATH = "/tmp/claude_hook_debug.log"
+
+
+def _debug_line(message: str) -> None:
+    """Append one line to the hook debug log; never raises."""
+    try:
+        with open(_DEBUG_LOG_PATH, "a", encoding="utf-8") as fh:
+            fh.write(f"[learning_db_v2] {message}\n")
+    except OSError:
+        pass
+
+
 def record_evidence_route_decision(
     *,
     session_id: str | None,
@@ -1249,8 +1343,15 @@ def record_evidence_route_decision(
     decision_id: str | None = None,
     outcome: str | None = None,
     outcome_basis: str | None = None,
+    spec_score: int | None = None,
+    spec_missing: str | None = None,
+    prompt_chars: int | None = None,
 ) -> dict:
-    """Record a route decision plus a companion evidence event."""
+    """Record a route decision plus a companion evidence event.
+
+    spec_score, spec_missing, and prompt_chars carry handoff completeness for
+    /do dispatches; leave them None for anything else.
+    """
     init_db()
     agent = _bounded_text(agent, 160) or "unknown"
     skill = _bounded_text(skill, 160)
@@ -1265,60 +1366,40 @@ def record_evidence_route_decision(
     )
     stack_text = _bounded_text(_json_text(stack), 2000)
     alternates_text = _bounded_text(_json_text(alternates), 2000)
+    base_params = (
+        decision_id,
+        session_id,
+        route_key,
+        agent,
+        skill,
+        _bounded_text(complexity, 80),
+        _bounded_text(model, 160),
+        _bounded_text(action, 80),
+        health,
+        n,
+        None if failure is None else int(bool(failure)),
+        int(bool(gate_inputs_present)),
+        _bounded_text(outcome, 80),
+        _bounded_text(outcome_basis, 120),
+        _bounded_text(request_snippet, 1000),
+        stack_text,
+        _bounded_text(pipeline, 160),
+        alternates_text,
+    )
+    # spec_missing "" means every label present; keep it distinct from NULL.
+    spec_params = (spec_score, spec_missing, prompt_chars)
 
     with get_connection() as conn:
         _record_evidence_session(conn, session_id)
-        conn.execute(
-            """
-            INSERT INTO evidence_route_decisions (
-                decision_id, session_id, route_key, agent, skill, complexity, model, action,
-                health, n, failure, gate_inputs_present, outcome, outcome_basis,
-                request_snippet, stack, pipeline, alternates, created_at, updated_at
-            )
-            VALUES (
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')
-            )
-            ON CONFLICT(decision_id) DO UPDATE SET
-                session_id = excluded.session_id,
-                route_key = excluded.route_key,
-                agent = excluded.agent,
-                skill = excluded.skill,
-                complexity = excluded.complexity,
-                model = excluded.model,
-                action = excluded.action,
-                health = excluded.health,
-                n = excluded.n,
-                failure = excluded.failure,
-                gate_inputs_present = excluded.gate_inputs_present,
-                outcome = excluded.outcome,
-                outcome_basis = excluded.outcome_basis,
-                request_snippet = excluded.request_snippet,
-                stack = excluded.stack,
-                pipeline = excluded.pipeline,
-                alternates = excluded.alternates,
-                updated_at = datetime('now')
-            """,
-            (
-                decision_id,
-                session_id,
-                route_key,
-                agent,
-                skill,
-                _bounded_text(complexity, 80),
-                _bounded_text(model, 160),
-                _bounded_text(action, 80),
-                health,
-                n,
-                None if failure is None else int(bool(failure)),
-                int(bool(gate_inputs_present)),
-                _bounded_text(outcome, 80),
-                _bounded_text(outcome_basis, 120),
-                _bounded_text(request_snippet, 1000),
-                stack_text,
-                _bounded_text(pipeline, 160),
-                alternates_text,
-            ),
-        )
+        try:
+            conn.execute(_ROUTE_DECISION_UPSERT_SQL, base_params + spec_params)
+        except sqlite3.OperationalError as exc:
+            # A DB that has not run the v10 migration lacks the spec columns.
+            # Keep the decision row; drop only the three new fields.
+            if "column" not in str(exc):
+                raise
+            _debug_line(f"evidence_route_decisions lacks spec columns; wrote row without them: {exc}")
+            conn.execute(_ROUTE_DECISION_UPSERT_SQL_LEGACY, base_params)
         conn.commit()
         row = conn.execute("SELECT * FROM evidence_route_decisions WHERE decision_id = ?", (decision_id,)).fetchone()
 

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.4.0
+# hook-version: 1.5.0
 """
 PostToolUse Hook: Routing Decision Recorder (action A, formerly /do Phase 5)
 
@@ -152,6 +152,41 @@ _ALTS_RE = re.compile(r"\balts=([a-z0-9:_,-]+)", re.IGNORECASE)
 # emits it whenever the router picked general-purpose or coerced an unknown agent).
 # Independent \b token, same charset as alts= items. Absent => None.
 _FALLBACK_RE = re.compile(r"\bfallback=([a-z0-9][a-z0-9:_-]*)", re.IGNORECASE)
+
+# Handoff-completeness telemetry. Thin handoffs failed acceptance 3/3 and
+# rich ones passed 3/3 (scripts/routing-ab-results/handoff-context-v1), so
+# every [do-route] Agent dispatch records how many task-spec labels its
+# prompt carries. The seven labels, in report order; scripts/build-dispatch.py
+# emits the first six as `**Label:**` and the last as a section heading. A
+# label counts when its text appears anywhere in the prompt. Substring
+# checks, no regex: this runs on the hot path.
+_SPEC_LABELS = (
+    "Request (verbatim)",
+    "Intent",
+    "Acceptance criteria",
+    "Relevant file locations",
+    "Decisions",
+    "Prior results",
+    "## Repo state",
+)
+_SPEC_SCORE_DISABLE_ENV = "VEXJOY_SPEC_SCORE_DISABLE"
+
+
+def score_handoff_spec(prompt: str) -> tuple[int, str]:
+    """Return (spec_score 0-7, comma-joined absent labels in _SPEC_LABELS order)."""
+    missing = [label for label in _SPEC_LABELS if label not in prompt]
+    return len(_SPEC_LABELS) - len(missing), ",".join(missing)
+
+
+def handoff_spec_fields(prompt: str | None) -> tuple[int | None, str | None, int | None]:
+    """(spec_score, spec_missing, prompt_chars) for one Agent prompt.
+
+    All None when the prompt is absent or VEXJOY_SPEC_SCORE_DISABLE=1.
+    """
+    if prompt is None or os.environ.get(_SPEC_SCORE_DISABLE_ENV) == "1":
+        return None, None, None
+    score, missing = score_handoff_spec(prompt)
+    return score, missing, len(prompt)
 
 
 def _line_containing(text: str, pos: int) -> str:
@@ -679,7 +714,11 @@ def main() -> None:
             if not agent:
                 return  # malformed marker => nothing to key on
             decisions = [(agent, skill, dispatch_signature(agent, skill, description, prompt), prompt)]
+            # Agent path only: a Workflow script packs N prompts, so a per-marker
+            # score is not observable there and the fields stay NULL.
+            spec_score, spec_missing, prompt_chars = handoff_spec_fields(prompt)
         else:
+            spec_score, spec_missing, prompt_chars = None, None, None
             script = tool_input.get("script") or ""
             occurrence: dict[str, int] = {}  # nth sighting of each identical marker line
             decisions = []
@@ -792,6 +831,8 @@ def main() -> None:
             try:
                 from learning_db_v2 import record_evidence_route_decision
 
+                # On a DB that lacks the v10 spec columns the DB layer keeps
+                # the decision row, drops the three fields, and logs one line.
                 record_evidence_route_decision(
                     session_id=session_id or None,
                     agent=agent,
@@ -808,6 +849,9 @@ def main() -> None:
                     alternates=health["alternates"],
                     gate_inputs_present=bool(health["gate_inputs_present"]),
                     decision_id=f"{session_id or 'no-session'}:{sig}",
+                    spec_score=spec_score,
+                    spec_missing=spec_missing,
+                    prompt_chars=prompt_chars,
                 )
             except Exception:
                 pass

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -2523,3 +2523,172 @@ class TestFinalizerOrphanBounded:
             f.main()
         still = ros.peek_pending_outcomes(session)
         assert len(still) == 1 and still[0]["attempts"] == 1, still
+
+
+# ---------------------------------------------------------------------------
+# Handoff-completeness telemetry: spec_score / spec_missing / prompt_chars
+# ---------------------------------------------------------------------------
+
+BUILD_DISPATCH_PATH = HOOKS_DIR.parent / "scripts" / "build-dispatch.py"
+SPEC_LABELS_ALL = (
+    "Request (verbatim),Intent,Acceptance criteria,Relevant file locations,Decisions,Prior results,## Repo state"
+)
+SPEC_COLUMNS = ("spec_score", "spec_missing", "prompt_chars")
+
+
+def _build_preamble_full() -> str:
+    """build_preamble() with every task_spec field filled and the repo-state block on."""
+    mod = _load(BUILD_DISPATCH_PATH, "build_dispatch_for_spec_score")
+    return mod.build_preamble(
+        {
+            "agent": "python-general-engineer",
+            "skill": "test-driven-development",
+            "complexity": "medium",
+            "model": "opus",
+            "task_spec": {
+                "request_verbatim": "score handoff completeness",
+                "intent": "Add telemetry.",
+                "constraints": "No commits.",
+                "acceptance": "Tests pass.",
+                "files": "hooks/routing-decision-recorder.py",
+                "decisions": "Score only [do-route] dispatches.",
+                "prior_results": "pre-route fallthrough.",
+                "gaps": "none",
+                "operator_context": "personal profile",
+            },
+        }
+    )
+
+
+def _spec_row(db_env) -> dict:
+    """The three spec fields of the newest evidence_route_decisions row."""
+    import sqlite3
+
+    import learning_db_v2 as ldb
+
+    conn = sqlite3.connect(ldb.get_db_path())
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT spec_score, spec_missing, prompt_chars FROM evidence_route_decisions ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, "no evidence_route_decisions row recorded"
+    return dict(row)
+
+
+def _run_recorder_prompt(monkeypatch, prompt: str, name: str) -> None:
+    """Run recorder main() in-process on an Agent event whose prompt is exactly `prompt`."""
+    a = _load(A_PATH, f"rdr_spec_{name}")
+    monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+    monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+    event = _agent_event(marker=False, body=prompt)
+    with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+        a.main()
+
+
+class TestSpecScore:
+    def test_full_preamble_scores_seven(self, db_env, monkeypatch):
+        # (a) every task_spec field filled: all seven labels present.
+        prompt = _build_preamble_full()
+        _run_recorder_prompt(monkeypatch, prompt, "full")
+        assert _spec_row(db_env) == {"spec_score": 7, "spec_missing": "", "prompt_chars": len(prompt)}
+
+    def test_marker_only_scores_zero(self, db_env, monkeypatch):
+        # (b) marker alone: every label absent, listed in fixed order.
+        prompt = "[do-route] agent=python-general-engineer skill=test-driven-development complexity=medium\n"
+        _run_recorder_prompt(monkeypatch, prompt, "marker_only")
+        assert _spec_row(db_env) == {"spec_score": 0, "spec_missing": SPEC_LABELS_ALL, "prompt_chars": len(prompt)}
+
+    def test_no_marker_leaves_fields_null(self, db_env, monkeypatch):
+        # (c) no marker: the recorder skips the event, so the only row is the
+        # seeded one and its fields stay NULL.
+        import learning_db_v2 as ldb
+
+        ldb.record_evidence_route_decision(session_id="s1", agent="python-general-engineer", skill="x")
+        _run_recorder_prompt(monkeypatch, "**Intent:** x\n## Repo state\n", "no_marker")
+        assert _spec_row(db_env) == {"spec_score": None, "spec_missing": None, "prompt_chars": None}
+        import sqlite3
+
+        conn = sqlite3.connect(ldb.get_db_path())
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM evidence_route_decisions").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+    def test_disable_env_var_leaves_fields_null(self, db_env, monkeypatch):
+        # (d) VEXJOY_SPEC_SCORE_DISABLE=1 with a full preamble.
+        monkeypatch.setenv("VEXJOY_SPEC_SCORE_DISABLE", "1")
+        _run_recorder_prompt(monkeypatch, _build_preamble_full(), "disabled")
+        assert _spec_row(db_env) == {"spec_score": None, "spec_missing": None, "prompt_chars": None}
+
+    def test_pre_migration_db_degrades_to_decision_row(self, db_env, monkeypatch):
+        # A DB without the spec columns: the decision row is still written and
+        # the hook does not raise.
+        import sqlite3
+
+        import learning_db_v2 as ldb
+
+        conn = sqlite3.connect(ldb.get_db_path())
+        for col in SPEC_COLUMNS:
+            conn.execute(f"ALTER TABLE evidence_route_decisions DROP COLUMN {col}")
+        conn.commit()
+        conn.close()
+        prompt = "[do-route] agent=python-general-engineer skill=- complexity=medium\n**Intent:** x\n"
+        _run_recorder_prompt(monkeypatch, prompt, "pre_migration")
+        conn = sqlite3.connect(ldb.get_db_path())
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM evidence_route_decisions").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+
+class TestSpecScoreMigration:
+    def test_pre_migration_db_gains_columns_once(self, tmp_path, monkeypatch):
+        # (e) a DB at user_version 9 without the columns; migrate twice; each
+        # column exists exactly once and the migration row is recorded once.
+        import sqlite3
+
+        sys.path.insert(0, str(LIB_DIR))
+        import learning_db_v2 as ldb
+
+        db_dir = tmp_path / "learning"
+        db_dir.mkdir()
+        monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+        monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+
+        db_path = db_dir / "learning.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(ldb._SCHEMA)
+        for col in SPEC_COLUMNS:
+            conn.execute(f"ALTER TABLE evidence_route_decisions DROP COLUMN {col}")
+        conn.execute("PRAGMA user_version = 9")
+        conn.commit()
+        conn.close()
+
+        def columns():
+            c = sqlite3.connect(db_path)
+            try:
+                return [r[1] for r in c.execute("PRAGMA table_info(evidence_route_decisions)")]
+            finally:
+                c.close()
+
+        assert not set(SPEC_COLUMNS) & set(columns())
+
+        ldb.init_db()
+        monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+        ldb.init_db()
+
+        after = columns()
+        for col in SPEC_COLUMNS:
+            assert after.count(col) == 1, (col, after)
+
+        c = sqlite3.connect(db_path)
+        try:
+            assert c.execute("PRAGMA user_version").fetchone()[0] == ldb._CURRENT_SCHEMA_VERSION
+            assert c.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+            rows = c.execute("SELECT COUNT(*) FROM schema_migrations WHERE version = 10").fetchone()[0]
+        finally:
+            c.close()
+        assert rows == 1

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -9,6 +9,7 @@ Usage:
     python3 scripts/learning-db.py route-weights --json
     python3 scripts/learning-db.py route-delta --from REF --to REF [--key AGENT:SKILL] [--metric error|tokens] [--json]
     python3 scripts/learning-db.py route-health [--json]
+    python3 scripts/learning-db.py handoff-report [--json]
     python3 scripts/learning-db.py route-failure AGENT:SKILL --reason "re-route after unusable output" --routing-relevant yes [--session SID --marker MK]
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --success
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --failure --reason "user re-routed"
@@ -1166,6 +1167,103 @@ def cmd_route_health(args: argparse.Namespace) -> None:
     _print_routing_shape(shape, fit, misroutes)
 
 
+_SPEC_SCORE_MAX = 7
+_UNDERSPECIFIED_BASIS = "route_fit:underspecified"
+
+
+def _percentile(values: list[int], q: float) -> int | None:
+    """Nearest-rank percentile of `values`; None when empty."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    rank = max(1, round(q * len(ordered)))
+    return ordered[min(rank, len(ordered)) - 1]
+
+
+def _read_handoff_report() -> dict:
+    """Handoff-completeness summary over scored evidence_route_decisions rows.
+
+    Scored means spec_score IS NOT NULL: /do Agent dispatches recorded after the
+    v10 migration with the kill switch off. Read-only.
+    """
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT spec_score, spec_missing, prompt_chars, outcome_basis, created_at "
+            "FROM evidence_route_decisions WHERE spec_score IS NOT NULL"
+        ).fetchall()
+    if not rows:
+        return {"scored": 0}
+    histogram = {score: 0 for score in range(_SPEC_SCORE_MAX + 1)}
+    underspecified: dict[int, dict[str, int]] = {}
+    missing_counts: dict[str, int] = {}
+    chars: list[int] = []
+    dates: list[str] = []
+    for row in rows:
+        score = int(row["spec_score"])
+        histogram[score] = histogram.get(score, 0) + 1
+        bucket = underspecified.setdefault(score, {"n": 0, "underspecified": 0})
+        bucket["n"] += 1
+        if row["outcome_basis"] == _UNDERSPECIFIED_BASIS:
+            bucket["underspecified"] += 1
+        missing = row["spec_missing"] if row["spec_missing"] is not None else ""
+        missing_counts[missing] = missing_counts.get(missing, 0) + 1
+        if row["prompt_chars"] is not None:
+            chars.append(int(row["prompt_chars"]))
+        if row["created_at"]:
+            dates.append(str(row["created_at"])[:10])
+    top_missing = sorted(missing_counts.items(), key=lambda item: (-item[1], item[0]))[:5]
+    return {
+        "scored": len(rows),
+        "first": min(dates) if dates else None,
+        "last": max(dates) if dates else None,
+        "histogram": histogram,
+        "prompt_chars_median": _percentile(chars, 0.5),
+        "prompt_chars_p25": _percentile(chars, 0.25),
+        "underspecified_by_score": {
+            score: {
+                "n": bucket["n"],
+                "underspecified": bucket["underspecified"],
+                "rate_pct": bucket["underspecified"] / bucket["n"] * 100,
+            }
+            for score, bucket in sorted(underspecified.items())
+        },
+        "top_missing": [{"spec_missing": text, "count": count} for text, count in top_missing],
+    }
+
+
+def cmd_handoff_report(args: argparse.Namespace) -> None:
+    """Show how complete /do handoffs are: spec_score, prompt size, underspecified rate.
+
+    Baseline before measurement (scripts/routing-ab-results/handoff-context-v2/VERDICT.md):
+    handoff median 3.7k chars, `path:line` present in 11-28%, verbatim request ~0%.
+    """
+    init_db()
+    report = _read_handoff_report()
+    if getattr(args, "json", False):
+        _print_json(report)
+        return
+    if not report["scored"]:
+        print("no scored dispatches yet")
+        return
+    print(f"Scored dispatches: {report['scored']} ({report['first']} to {report['last']})")
+    print()
+    print("spec_score distribution (0-7):")
+    for score in range(_SPEC_SCORE_MAX + 1):
+        count = report["histogram"][score]
+        print(f"  {score}  {'#' * count:<20} {count}")
+    print()
+    print(f"prompt_chars: median {report['prompt_chars_median']}, p25 {report['prompt_chars_p25']}")
+    print()
+    print("route-fit: underspecified by spec_score:")
+    for score, bucket in report["underspecified_by_score"].items():
+        print(f"  {score}  {bucket['underspecified']}/{bucket['n']} ({bucket['rate_pct']:.1f}%)")
+    print()
+    print("most common spec_missing:")
+    for item in report["top_missing"]:
+        label = item["spec_missing"] or "(none missing)"
+        print(f"  {item['count']:>4}  {label}")
+
+
 def _print_freq_table(records: list[dict[str, str | int]], label: str, key_fn: object) -> None:
     """Print a frequency table sorted by count descending."""
     from collections import Counter
@@ -1539,6 +1637,11 @@ def main():
     p_route_health = subparsers.add_parser("route-health", help="Quick routing feedback loop health check")
     p_route_health.add_argument("--json", action="store_true", help="Output as JSON")
     p_route_health.set_defaults(func=cmd_route_health)
+
+    # handoff-report (spec_score / prompt_chars telemetry from the recorder hook)
+    p_handoff = subparsers.add_parser("handoff-report", help="Handoff completeness of /do dispatches")
+    p_handoff.add_argument("--json", action="store_true", help="Output as JSON")
+    p_handoff.set_defaults(func=cmd_handoff_report)
 
     # record-review-fp (structured review false-positive recording)
     p_rrfp = subparsers.add_parser("record-review-fp", help="Record a review false positive with full metadata")

--- a/scripts/tests/test_learning_db_cli.py
+++ b/scripts/tests/test_learning_db_cli.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for scripts/learning-db.py read-side subcommands.
+
+Covers `handoff-report`:
+- Empty table prints "no scored dispatches yet" and exits 0.
+- Six scored rows produce the 0-7 histogram with the right counts, the
+  prompt_chars median/p25, the underspecified rate per score, and the top
+  spec_missing strings.
+
+Uses a throwaway learning.db via CLAUDE_LEARNING_DIR. Never the real DB.
+
+Run with: python3 -m pytest scripts/tests/test_learning_db_cli.py -v
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_PATH = REPO_ROOT / "scripts" / "learning-db.py"
+LIB_DIR = REPO_ROOT / "hooks" / "lib"
+
+
+@pytest.fixture()
+def db_env(tmp_path, monkeypatch):
+    """Point the learning DB at a throwaway location and init it there."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    return db_dir
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(CLI_PATH), *args],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ),
+    )
+
+
+# (spec_score, spec_missing, prompt_chars, outcome_basis)
+SIX_ROWS = (
+    (7, "", 9000, None),
+    (7, "", 8000, None),
+    (3, "Request (verbatim),Decisions,Prior results,## Repo state", 3000, "route_fit:underspecified"),
+    (3, "Request (verbatim),Decisions,Prior results,## Repo state", 3500, None),
+    (
+        0,
+        "Request (verbatim),Intent,Acceptance criteria,Relevant file locations,Decisions,Prior results,## Repo state",
+        400,
+        "route_fit:underspecified",
+    ),
+    (5, "Request (verbatim),Prior results", 6000, None),
+)
+
+
+def _seed(rows) -> None:
+    import learning_db_v2 as ldb
+
+    for i, (score, missing, chars, basis) in enumerate(rows):
+        ldb.record_evidence_route_decision(
+            session_id="s1",
+            agent="python-general-engineer",
+            skill="test-driven-development",
+            decision_id=f"s1:{i}",
+            outcome="failure" if basis else None,
+            outcome_basis=basis,
+            spec_score=score,
+            spec_missing=missing,
+            prompt_chars=chars,
+        )
+
+
+class TestHandoffReport:
+    def test_empty_table(self, db_env):
+        result = _run_cli("handoff-report")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "no scored dispatches yet"
+
+    def test_unscored_rows_count_as_empty(self, db_env):
+        # A pre-migration or non-/do row has NULL spec_score and is not scored.
+        import learning_db_v2 as ldb
+
+        ldb.record_evidence_route_decision(session_id="s1", agent="claude", skill=None)
+        result = _run_cli("handoff-report")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "no scored dispatches yet"
+
+    def test_six_rows_histogram(self, db_env):
+        _seed(SIX_ROWS)
+        result = _run_cli("handoff-report", "--json")
+        assert result.returncode == 0, result.stderr
+        report = json.loads(result.stdout)
+        assert report["scored"] == 6
+        assert report["first"] and report["last"]
+        assert report["histogram"] == {"0": 1, "1": 0, "2": 0, "3": 2, "4": 0, "5": 1, "6": 0, "7": 2}
+        assert report["prompt_chars_median"] == 3500
+        assert report["prompt_chars_p25"] == 3000
+        by_score = report["underspecified_by_score"]
+        assert by_score["0"] == {"n": 1, "underspecified": 1, "rate_pct": 100.0}
+        assert by_score["3"] == {"n": 2, "underspecified": 1, "rate_pct": 50.0}
+        assert by_score["7"] == {"n": 2, "underspecified": 0, "rate_pct": 0.0}
+        top = report["top_missing"]
+        assert top[0] == {"spec_missing": "", "count": 2}
+        assert top[1] == {
+            "spec_missing": "Request (verbatim),Decisions,Prior results,## Repo state",
+            "count": 2,
+        }
+        assert len(top) == 4
+
+    def test_six_rows_text_output(self, db_env):
+        _seed(SIX_ROWS)
+        result = _run_cli("handoff-report")
+        assert result.returncode == 0, result.stderr
+        out = result.stdout
+        assert "Scored dispatches: 6 (" in out
+        assert "  7  ##                   2" in out
+        assert "  3  ##                   2" in out
+        assert "  0  #                    1" in out
+        assert "  1                       0" in out
+        assert "prompt_chars: median 3500, p25 3000" in out
+        assert "  3  1/2 (50.0%)" in out
+        assert "   2  (none missing)" in out
+        # Read-only: no write left behind for the seeded rows.
+        import sqlite3
+
+        import learning_db_v2 as ldb
+
+        conn = sqlite3.connect(ldb.get_db_path())
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM evidence_route_decisions").fetchone()[0] == 6
+        finally:
+            conn.close()


### PR DESCRIPTION
Records spec_score (0-7), spec_missing, and prompt_chars on every [do-route] Agent dispatch; v10 migration; `learning-db.py handoff-report` read side; kill switch VEXJOY_SPEC_SCORE_DISABLE=1.
Tests: D9 a-e plus a pre-migration degrade case; D10 empty and six-row report cases.
https://claude.ai/code/session_011xLnFyWR9mHmyXHoHLxte9