### PR TITLE
fix(sync): mirror new hook and lib files into ~/.codex/hooks

### DIFF
--- a/docs/for-claude-code.md
+++ b/docs/for-claude-code.md
@@ -113,7 +113,7 @@ Trivial = reading a file the user named by exact path. Everything else routes th
 
 ## Sync Lifecycle
 
-`hooks/sync-to-user-claude.py` fires on `SessionStart` when cwd is this repo. Copies into `~/.claude/` so Claude Code in *other* repos gets agents, skills, hooks, scripts.
+`hooks/sync-to-user-claude.py` fires on `SessionStart` when cwd is this repo. Copies into `~/.claude/` so Claude Code in *other* repos gets agents, skills, hooks, scripts. When `~/.codex/hooks/` exists, it also adds per-file symlinks for new `hooks/*.py` and `hooks/lib/*.py` there (never overwrites, never deletes; reported as `.codex/hooks(+N linked, M current)`).
 
 | Source | Destination | Sync Mode |
 |--------|-------------|-----------|

--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -903,6 +903,59 @@ def _sync_skills_flat_symlinks(src: Path, dst: Path, repo_root: "Path | list[Pat
     _clean_codex_orphan_categories(src, dst)
 
 
+def _link_py_files(src_dir: Path, dst_dir: Path) -> tuple[int, int, int]:
+    """Symlink each ``*.py`` in ``src_dir`` into ``dst_dir`` without overwriting.
+
+    Mirrors install.sh's per-file convention (``ln -s src dst/name``; skip when
+    the target exists or is a link). Returns ``(linked, current, kept)``:
+    ``current`` counts links that already resolve to the repo file, ``kept``
+    counts foreign entries left in place. Never deletes, never recurses.
+    """
+    linked = current = kept = 0
+    for item in sorted(src_dir.glob("*.py")):
+        if not item.is_file():
+            continue
+        target = dst_dir / item.name
+        if target.is_symlink() or target.exists():
+            try:
+                same = target.is_symlink() and target.resolve() == item.resolve()
+            except OSError:
+                same = False
+            if same:
+                current += 1
+            else:
+                kept += 1
+            continue
+        target.symlink_to(item)
+        linked += 1
+    return linked, current, kept
+
+
+def _sync_codex_hook_links(repo_hooks: Path, codex_hooks: Path) -> tuple[int, int, int] | None:
+    """Mirror ``hooks/*.py`` and ``hooks/lib/*.py`` into ``~/.codex/hooks/``.
+
+    Only runs when ``codex_hooks`` already exists (Codex installed); returns
+    ``None`` otherwise and creates nothing. Creates ``lib/`` when missing.
+    Skips ``tests/``, ``__pycache__``, and non-``.py`` files by construction:
+    only the two flat globs are read.
+    """
+    if not codex_hooks.is_dir() or not repo_hooks.is_dir():
+        return None
+    if _is_ephemeral_path(repo_hooks):
+        print(f"[sync] BLOCKED: refusing to link Codex hooks to {repo_hooks} (ephemeral path)", file=sys.stderr)
+        return None
+    linked, current, kept = _link_py_files(repo_hooks, codex_hooks)
+    repo_lib = repo_hooks / "lib"
+    if repo_lib.is_dir():
+        codex_lib = codex_hooks / "lib"
+        if not codex_lib.is_symlink() and not codex_lib.exists():
+            codex_lib.mkdir()
+        if codex_lib.is_dir():
+            sub = _link_py_files(repo_lib, codex_lib)
+            linked, current, kept = (linked + sub[0], current + sub[1], kept + sub[2])
+    return linked, current, kept
+
+
 def _is_git_worktree(path: Path) -> bool:
     """Detect if path is inside a git worktree (not the main working tree).
 
@@ -1584,6 +1637,24 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
     elif codex_agents_dst.is_dir():
         total = sum(1 for _ in codex_agents_dst.rglob("*") if _.is_file())
         synced.append(f".codex/agents({total} current)")
+
+    # Sync hook files to ~/.codex/hooks/ as per-file symlinks (install.sh
+    # convention). Without this, hooks and lib modules merged after install
+    # never reach Codex; its adapter then fails the import silently.
+    codex_hooks_dst = Path.home() / ".codex" / "hooks"
+    try:
+        hook_links = _sync_codex_hook_links(repo_root / "hooks", codex_hooks_dst)
+    except Exception as e:
+        errors.append(f"codex-hooks: {e}")
+        hook_links = None
+    if hook_links is None:
+        synced.append(".codex/hooks(absent)")
+    else:
+        linked, current, kept = hook_links
+        parts = [f"+{linked} linked", f"{current} current"]
+        if kept:
+            parts.append(f"{kept} kept")
+        synced.append(f".codex/hooks({', '.join(parts)})")
 
     # Output for hook feedback
     if synced:

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -1403,3 +1403,130 @@ class TestCopyIfChanged:
         assert sync_mod._copy_if_changed(src, dst) is True
         assert not dst.is_symlink()
         assert dst.read_text() == "fresh"
+
+
+class TestSyncCodexHookLinks:
+    """Tests for _sync_codex_hook_links: per-file symlinks into ~/.codex/hooks."""
+
+    @pytest.fixture(autouse=True)
+    def _not_ephemeral(self):
+        # Fixtures live in /tmp/; the guard is exercised by test_ephemeral_repo_blocked.
+        with patch.object(sync_mod, "_is_ephemeral_path", return_value=False):
+            yield
+
+    def test_ephemeral_repo_blocked(self, tmp_path: Path) -> None:
+        repo_hooks = self._repo_hooks(tmp_path)
+        codex = tmp_path / "codex" / "hooks"
+        codex.mkdir(parents=True)
+        with patch.object(sync_mod, "_is_ephemeral_path", return_value=True):
+            assert sync_mod._sync_codex_hook_links(repo_hooks, codex) is None
+        assert list(codex.iterdir()) == []
+
+    @staticmethod
+    def _repo_hooks(tmp_path: Path) -> Path:
+        repo_hooks = tmp_path / "repo" / "hooks"
+        (repo_hooks / "lib").mkdir(parents=True)
+        (repo_hooks / "tests").mkdir()
+        (repo_hooks / "__pycache__").mkdir()
+        (repo_hooks / "a-hook.py").write_text("print('a')\n")
+        (repo_hooks / "b-hook.py").write_text("print('b')\n")
+        (repo_hooks / "README.md").write_text("# not linked\n")
+        (repo_hooks / "lib" / "hook_utils.py").write_text("x = 1\n")
+        (repo_hooks / "lib" / "warmstart_lib.py").write_text("y = 2\n")
+        (repo_hooks / "lib" / "registry.json").write_text("{}\n")
+        (repo_hooks / "tests" / "test_a.py").write_text("")
+        (repo_hooks / "__pycache__" / "a.cpython-312.pyc").write_bytes(b"")
+        return repo_hooks
+
+    @staticmethod
+    def _repo_root(tmp_path: Path) -> Path:
+        repo_root = tmp_path / "repo"
+        for d in ("skills", "agents", "scripts", "commands"):
+            (repo_root / d).mkdir(parents=True, exist_ok=True)
+        return repo_root
+
+    def test_fresh_dirs_get_one_link_per_py_file(self, tmp_path: Path) -> None:
+        repo_hooks = self._repo_hooks(tmp_path)
+        codex = tmp_path / "codex" / "hooks"
+        (codex / "lib").mkdir(parents=True)
+        result = sync_mod._sync_codex_hook_links(repo_hooks, codex)
+        assert result == (4, 0, 0)
+        for name in ("a-hook.py", "b-hook.py"):
+            assert (codex / name).is_symlink()
+            assert (codex / name).resolve() == (repo_hooks / name).resolve()
+        for name in ("hook_utils.py", "warmstart_lib.py"):
+            assert (codex / "lib" / name).is_symlink()
+            assert (codex / "lib" / name).resolve() == (repo_hooks / "lib" / name).resolve()
+
+    def test_creates_lib_when_hooks_dir_exists(self, tmp_path: Path) -> None:
+        repo_hooks = self._repo_hooks(tmp_path)
+        codex = tmp_path / "codex" / "hooks"
+        codex.mkdir(parents=True)
+        result = sync_mod._sync_codex_hook_links(repo_hooks, codex)
+        assert result == (4, 0, 0)
+        assert (codex / "lib").is_dir() and not (codex / "lib").is_symlink()
+        assert (codex / "lib" / "warmstart_lib.py").is_symlink()
+
+    def test_foreign_file_kept_not_replaced(self, tmp_path: Path) -> None:
+        repo_hooks = self._repo_hooks(tmp_path)
+        codex = tmp_path / "codex" / "hooks"
+        (codex / "lib").mkdir(parents=True)
+        (codex / "a-hook.py").write_text("foreign\n")
+        elsewhere = tmp_path / "elsewhere.py"
+        elsewhere.write_text("other\n")
+        (codex / "lib" / "hook_utils.py").symlink_to(elsewhere)
+        result = sync_mod._sync_codex_hook_links(repo_hooks, codex)
+        assert result == (2, 0, 2)
+        assert not (codex / "a-hook.py").is_symlink()
+        assert (codex / "a-hook.py").read_text() == "foreign\n"
+        assert (codex / "lib" / "hook_utils.py").resolve() == elsewhere.resolve()
+
+    def test_absent_codex_hooks_creates_nothing(self, tmp_path: Path) -> None:
+        repo_hooks = self._repo_hooks(tmp_path)
+        codex = tmp_path / "codex" / "hooks"
+        assert sync_mod._sync_codex_hook_links(repo_hooks, codex) is None
+        assert not (tmp_path / "codex").exists()
+
+    def test_tests_pycache_and_non_py_not_linked(self, tmp_path: Path) -> None:
+        repo_hooks = self._repo_hooks(tmp_path)
+        codex = tmp_path / "codex" / "hooks"
+        codex.mkdir(parents=True)
+        sync_mod._sync_codex_hook_links(repo_hooks, codex)
+        assert {p.name for p in codex.iterdir()} == {"a-hook.py", "b-hook.py", "lib"}
+        assert {p.name for p in (codex / "lib").iterdir()} == {"hook_utils.py", "warmstart_lib.py"}
+
+    def test_second_run_links_zero(self, tmp_path: Path) -> None:
+        repo_hooks = self._repo_hooks(tmp_path)
+        codex = tmp_path / "codex" / "hooks"
+        codex.mkdir(parents=True)
+        assert sync_mod._sync_codex_hook_links(repo_hooks, codex) == (4, 0, 0)
+        assert sync_mod._sync_codex_hook_links(repo_hooks, codex) == (0, 4, 0)
+
+    def test_new_repo_file_linked_on_later_run(self, tmp_path: Path) -> None:
+        repo_hooks = self._repo_hooks(tmp_path)
+        codex = tmp_path / "codex" / "hooks"
+        codex.mkdir(parents=True)
+        sync_mod._sync_codex_hook_links(repo_hooks, codex)
+        (repo_hooks / "lib" / "new_lib.py").write_text("z = 3\n")
+        assert sync_mod._sync_codex_hook_links(repo_hooks, codex) == (1, 4, 0)
+        assert (codex / "lib" / "new_lib.py").is_symlink()
+
+    def test_summary_line_reports_codex_hooks(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        self._repo_hooks(tmp_path)
+        repo_root = self._repo_root(tmp_path)
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        (home / ".codex" / "hooks").mkdir(parents=True)
+        with patch.object(sync_mod.Path, "home", return_value=home):
+            sync_mod._main_inner(repo_root, home / ".claude")
+        assert ".codex/hooks(+4 linked, 0 current)" in capsys.readouterr().out
+
+    def test_summary_line_absent(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        self._repo_hooks(tmp_path)
+        repo_root = self._repo_root(tmp_path)
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        with patch.object(sync_mod.Path, "home", return_value=home):
+            sync_mod._main_inner(repo_root, home / ".claude")
+        assert ".codex/hooks(absent)" in capsys.readouterr().out
+        assert not (home / ".codex" / "hooks").exists()


### PR DESCRIPTION
sync-to-user-claude.py now adds per-file symlinks for hooks/*.py and hooks/lib/*.py into ~/.codex/hooks/ (install.sh convention: add missing, keep foreign, never delete; skipped when Codex is absent). Summary line gains .codex/hooks(+N linked, M current).
Fixes the silent Codex adapter import failure after #937/#942 (warmstart_lib.py never reached ~/.codex/hooks/lib).
https://claude.ai/code/session_011xLnFyWR9mHmyXHoHLxte9