### PR TITLE
docs(do): hand reviewers, fix agent, and escalation re-dispatch the Task Spec

### DIFF
--- a/docs/for-ai-wizards.md
+++ b/docs/for-ai-wizards.md
@@ -147,16 +147,17 @@ Hooks are Python scripts registered in `~/.claude/settings.json` under event typ
 
 ### Event Types
 
-Nine event types, registered in settings.json:
+Ten event types, registered in settings.json:
 
 | Event | When | Hooks Registered |
 |-------|------|-----------------|
 | `SessionStart` | Session begins | sync-to-user-claude, afk-mode, session-context, cross-repo-agents, fish-shell-detector, zsh-shell-detector, sapcc-go-detector, operator-context-detector, session-github-briefing, session-adr-health-check, team-config-loader, rules-distill-injector, hook-version-parity-check, session-manifest-cache |
 | `UserPromptSubmit` | Before processing each prompt | pipeline-context-detector, review-false-positive-capture, codex-auto-review, prompt-capture, routing-outcome-finalizer |
-| `PreToolUse` | Before tool execution | suggest-compact, pretool-unified-gate, pretool-worktree-edit-guard, pretool-branch-safety, ci-merge-gate, pretool-ruff-format-gate, pretool-private-name-leak-gate, security-review-hook, pretool-synthesis-gate, pretool-plan-gate, pretool-prompt-injection-scanner, pipeline-phase-gate, pretool-adr-creation-gate, pretool-file-backup, reference-loading-enforcer, pretool-subagent-warmstart, creation-protocol-enforcer, pretool-section-integrity-validator |
+| `PreToolUse` | Before tool execution | suggest-compact, pretool-unified-gate, pretool-worktree-edit-guard, pretool-branch-safety, ci-merge-gate, pretool-ruff-format-gate, pretool-private-name-leak-gate, security-review-hook, pretool-synthesis-gate, pretool-plan-gate, pretool-prompt-injection-scanner, pipeline-phase-gate, pretool-adr-creation-gate, pretool-file-backup, reference-loading-enforcer, creation-protocol-enforcer, pretool-section-integrity-validator |
 | `PostToolUse` | After tool execution | posttool-lint-hint, agent-grade-on-change, adr-enforcement, posttool-security-scan, posttool-skill-frontmatter-check, posttooluse-joy-check-warn, posttooluse-sync-skill-index, posttooluse-sync-agent-index, posttool-docs-drift-alert, security-review-hook, adr-lifecycle-on-merge, posttool-rename-sweep, posttool-bash-injection-scan, posttool-session-reads, usage-tracker, review-capture, routing-decision-recorder, posttool-auto-test |
 | `PreCompact` | Before context compression | precompact-archive |
 | `PostCompact` | After context compression | postcompact-handler |
+| `SubagentStart` | When a subagent starts | subagent-start-warmstart |
 | `SubagentStop` | When a subagent exits | subagent-completion-guard, routing-outcome-recorder |
 | `Stop` | Session ends | session-summary, routing-outcome-stop-fallback, rules-distill-trigger, stop-drift-guard |
 | `StopFailure` | Session ends abnormally | stop-failure-handler |

--- a/skills/meta/do/references/progressive-depth.md
+++ b/skills/meta/do/references/progressive-depth.md
@@ -61,7 +61,7 @@ Recommended level: 2 (Methodical)
 Work completed so far: Fixed the primary file (docs/router-ab-runbook.md), discovered 6 other references that need matching updates
 ```
 
-The router receives this signal, preserves the work completed so far, and re-dispatches at the recommended level with context about what was already done.
+The router receives this signal and re-dispatches at the recommended level. The block becomes the `prior_results` field of the new Task Spec. The router copies these fields into it: current level, reason, work completed so far, and files touched.
 
 ---
 

--- a/skills/meta/do/references/quality-loop.md
+++ b/skills/meta/do/references/quality-loop.md
@@ -128,6 +128,8 @@ Dispatch 3 parallel review agents against the diff (feature branch vs main):
 2. **Business logic reviewer** (reviewer-domain) — correctness, edge cases, domain rules, error handling
 3. **Architecture reviewer** (reviewer-perspectives) — design patterns, coupling, API contracts, performance
 
+Give each reviewer the diff plus the `request_verbatim` and `acceptance` fields of the Task Spec, read from the PHASE 2 state artifact. Reviewers judge the diff against what the user asked for, not against the diff alone.
+
 Each reviewer produces findings as:
 - CRITICAL: Must fix before merge
 - IMPROVEMENT: Should fix, not blocking
@@ -174,7 +176,7 @@ For each CRITICAL finding, dispatch a fresh domain agent to fix it.
 - Each fix is a separate commit with a message referencing the finding
 - Read `quality-loop-state.md` to determine which domain agent PHASE 2 used — do not rely on session memory
 - Fresh agent context — not the same agent that made the mistake — because the original agent has anchoring bias toward its own implementation
-- Include the specific CRITICAL finding text in the agent prompt
+- Give the fix agent the full Task Spec (`request_verbatim`, `acceptance`, `files`, `decisions`, `prior_results`) plus the specific CRITICAL finding text. The finding alone is not enough context.
 
 **Gate:** All CRITICAL findings addressed with commits. Proceed to PHASE 8.
 


### PR DESCRIPTION
quality-loop PHASE 4/7 and progressive-depth escalation name the Task Spec fields they receive; for-ai-wizards hook table drops the retired PreToolUse warmstart and adds the SubagentStart row.
Validators: references, do-references, routing-map, doc-links, doc-counts all exit 0.
https://claude.ai/code/session_011xLnFyWR9mHmyXHoHLxte9