### PR TITLE
fix(build-dispatch): resolve symlinked script root, gather from cwd's git toplevel, name each unavailable reason

### DIFF
--- a/scripts/build-dispatch.py
+++ b/scripts/build-dispatch.py
@@ -86,10 +86,13 @@ import sys
 from functools import lru_cache
 from pathlib import Path
 
-# Resolve symlinks: /do invokes this script through ~/.claude/scripts ->
-# <repo>/scripts, and the unresolved parent (~/.claude) is not a git repo.
+# INSTALL_ROOT keeps the invoked path: through ~/.claude/scripts -> <repo>/scripts,
+# inventories (INDEX.json, settings, hook_utils) must come from the install dir,
+# which a profile filter may have shaped. REPO_ROOT resolves the symlink; it is
+# the gather/validation fallback only, since ~/.claude is not a git repo.
+INSTALL_ROOT = Path(__file__).absolute().parent.parent
 REPO_ROOT = Path(__file__).resolve().parent.parent
-SETTINGS_PATH = REPO_ROOT / ".claude" / "settings.json"
+SETTINGS_PATH = INSTALL_ROOT / ".claude" / "settings.json"
 DEFAULT_TOKEN_BUDGET = 500000
 
 # ---------------------------------------------------------------------------
@@ -219,12 +222,12 @@ _KEY_RE = re.compile(r"^[a-z0-9:_-]+$")  # alts= / stack= items (comma is the se
 # general-purpose with no recorded reason, so the regression was invisible for
 # six weeks. Every fallback now carries a reason token on the marker line.
 FALLBACK_AGENT = "general-purpose"
-AGENT_INDEX_PATH = REPO_ROOT / "agents" / "INDEX.json"
+AGENT_INDEX_PATH = INSTALL_ROOT / "agents" / "INDEX.json"
 AGENT_INDEX_LOCAL = "INDEX.local.json"
-SKILL_INDEX_PATH = REPO_ROOT / "skills" / "INDEX.json"
+SKILL_INDEX_PATH = INSTALL_ROOT / "skills" / "INDEX.json"
 SKILL_INDEX_LOCAL = "INDEX.local.json"
-PIPELINE_INDEX_PATH = REPO_ROOT / "skills" / "workflow" / "references" / "pipeline-index.json"
-SHARED_PATTERNS_DIR = REPO_ROOT / "skills" / "shared-patterns"
+PIPELINE_INDEX_PATH = INSTALL_ROOT / "skills" / "workflow" / "references" / "pipeline-index.json"
+SHARED_PATTERNS_DIR = INSTALL_ROOT / "skills" / "shared-patterns"
 # Harness-provided agents that exist outside agents/INDEX.json. Superset of
 # validate-do-references.py's set: the Agent tool accepts these names, so
 # coercing them would MANUFACTURE fallbacks instead of catching them.
@@ -767,7 +770,9 @@ def _sensitive_path_checker():
     try:
         import importlib.util
 
-        spec = importlib.util.spec_from_file_location("_bd_hook_utils", REPO_ROOT / "hooks" / "lib" / "hook_utils.py")
+        spec = importlib.util.spec_from_file_location(
+            "_bd_hook_utils", INSTALL_ROOT / "hooks" / "lib" / "hook_utils.py"
+        )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         checker = module.is_sensitive_path

--- a/scripts/build-dispatch.py
+++ b/scripts/build-dispatch.py
@@ -65,6 +65,9 @@ Usage:
     python3 scripts/build-dispatch.py --json '...' --no-gather        # skip repo state
     python3 scripts/build-dispatch.py --json '...' --repo-root /path  # gather elsewhere
 
+Repo root: `--repo-root` when given; else the git toplevel of the caller's
+cwd; else this script's own repo. Path validation and gathering share it.
+
 Exit codes:
     0 — preamble printed to stdout
     2 — invalid input (message on stderr, nothing on stdout)
@@ -83,11 +86,9 @@ import sys
 from functools import lru_cache
 from pathlib import Path
 
-# Preserve the invoked runtime path when scripts/ is itself a symlink. Resolving
-# __file__ would jump back to the source checkout and validate against its
-# unfiltered inventories instead of ~/.claude, ~/.codex, or another deployed
-# harness root.
-REPO_ROOT = Path(__file__).absolute().parent.parent
+# Resolve symlinks: /do invokes this script through ~/.claude/scripts ->
+# <repo>/scripts, and the unresolved parent (~/.claude) is not a git repo.
+REPO_ROOT = Path(__file__).resolve().parent.parent
 SETTINGS_PATH = REPO_ROOT / ".claude" / "settings.json"
 DEFAULT_TOKEN_BUDGET = 500000
 
@@ -745,7 +746,7 @@ _GATHER_MAX_FILES = 6
 _GATHER_HEAD_LINES = 30
 _GATHER_STATUS_LINES = 40
 _GATHER_DIFF_LINES = 20
-_GATHER_TIMEOUT_SECONDS = 2
+_GATHER_TIMEOUT_SECONDS = 5
 _GATHER_BLOCK_CAP = 12000
 _GATHER_HEADING = "## Repo state (auto-gathered)"
 _GATHER_SECURITY = (
@@ -818,12 +819,22 @@ def _resolve_under(repo_root: Path, token: str) -> Path:
     return path if path.is_absolute() else repo_root / path
 
 
-def validate_spec_paths(decision: dict, repo_root: Path = REPO_ROOT) -> list[str]:
+@lru_cache(maxsize=1)
+def default_repo_root() -> Path:
+    """Git toplevel of the caller's cwd; REPO_ROOT when cwd is not in a repo."""
+    lines, _reason = _run_git(Path.cwd(), ["rev-parse", "--show-toplevel"], None)
+    if lines and lines[0]:
+        return Path(lines[0])
+    return REPO_ROOT
+
+
+def validate_spec_paths(decision: dict, repo_root: Path | None = None) -> list[str]:
     """Existing, non-sensitive paths from `task_spec.files`; raise on a missing one.
 
     `new:` marks a file the task will create; it is allowed and not returned.
     Sensitive paths are neither checked nor returned.
     """
+    repo_root = repo_root or default_repo_root()
     spec = decision.get("task_spec") or {}
     if not isinstance(spec, dict):
         return []
@@ -840,8 +851,13 @@ def validate_spec_paths(decision: dict, repo_root: Path = REPO_ROOT) -> list[str
     return existing
 
 
-def _run_git(repo_root: Path, args: list[str], cap: int | None) -> list[str] | None:
-    """Lines of `git <args>` in repo_root, capped; None on any failure."""
+def _run_git(repo_root: Path, args: list[str], cap: int | None) -> tuple[list[str] | None, str]:
+    """(capped lines of `git <args>` in repo_root, "") or (None, reason) on failure.
+
+    Reasons: `not a git repository`, `timeout after Ns`, `exit N`, `git not found`.
+    """
+    if not repo_root.is_dir():
+        return None, "not a git repository"
     try:
         result = subprocess.run(
             ["git", *args],
@@ -851,14 +867,20 @@ def _run_git(repo_root: Path, args: list[str], cap: int | None) -> list[str] | N
             timeout=_GATHER_TIMEOUT_SECONDS,
             check=False,
         )
-    except (OSError, subprocess.SubprocessError):
-        return None
+    except subprocess.TimeoutExpired:
+        return None, f"timeout after {_GATHER_TIMEOUT_SECONDS}s"
+    except FileNotFoundError:
+        return None, "git not found"
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"exit {getattr(exc, 'returncode', 1)}"
     if result.returncode != 0:
-        return None
+        if "not a git repository" in result.stderr:
+            return None, "not a git repository"
+        return None, f"exit {result.returncode}"
     lines = result.stdout.rstrip("\n").split("\n") if result.stdout.strip() else []
     if cap is not None and len(lines) > cap:
         lines = [*lines[:cap], f"[{len(lines) - cap} more lines]"]
-    return lines
+    return lines, ""
 
 
 def _outline_python(text: str) -> list[str] | None:
@@ -884,8 +906,8 @@ def _gather_file(repo_root: Path, token: str) -> list[str]:
             names = sorted(child.name for child in path.iterdir())
             return [f"### {token}/ ({len(names)} entries)", *names[:_GATHER_HEAD_LINES]]
         text = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return [f"gather: {token} unavailable"]
+    except OSError as exc:
+        return [f"gather: {token} unavailable ({exc.strerror or 'read error'})"]
     if path.suffix == ".py":
         outline = _outline_python(text)
         if outline is not None:
@@ -907,12 +929,13 @@ def _cap_block(text: str, cap: int = _GATHER_BLOCK_CAP) -> str:
     return f"{body[: cap - len(note) - len(tail)]}{note}{tail}"
 
 
-def build_gather_block(decision: dict, repo_root: Path = REPO_ROOT) -> str:
+def build_gather_block(decision: dict, repo_root: Path | None = None) -> str:
     """Repo state block: git status, diff stat, recent log, then per-file outlines.
 
-    Every item degrades to one `gather: <item> unavailable` line on failure.
-    Deterministic for a fixed repo state.
+    Every item degrades to one `gather: <item> unavailable (<reason>)` line on
+    failure. Deterministic for a fixed repo state.
     """
+    repo_root = repo_root or default_repo_root()
     spec = decision.get("task_spec") or {}
     tokens = _path_candidates(spec.get("files")) if isinstance(spec, dict) else []
     sections: list[str] = []
@@ -921,9 +944,9 @@ def build_gather_block(decision: dict, repo_root: Path = REPO_ROOT) -> str:
         ("git diff --stat", ["diff", "--stat"], _GATHER_DIFF_LINES),
         ("git log -5", ["log", "-5", "--oneline"], None),
     ):
-        lines = _run_git(repo_root, args, cap)
+        lines, reason = _run_git(repo_root, args, cap)
         if lines is None:
-            sections.append(f"gather: {label} unavailable")
+            sections.append(f"gather: {label} unavailable ({reason})")
         else:
             sections.append("\n".join([f"### {label}", *(lines or ["(empty)"])]))
     gathered = 0
@@ -937,7 +960,7 @@ def build_gather_block(decision: dict, repo_root: Path = REPO_ROOT) -> str:
             sections.append(f"gather: {token} skipped (sensitive path)")
             continue
         if not _resolve_under(repo_root, token).exists():
-            sections.append(f"gather: {token} unavailable")
+            sections.append(f"gather: {token} unavailable (not found under {repo_root})")
             continue
         sections.append("\n".join(_gather_file(repo_root, token)))
         gathered += 1
@@ -951,13 +974,14 @@ def build_preamble(
     settings_path: Path = SETTINGS_PATH,
     *,
     gather: bool = True,
-    repo_root: Path = REPO_ROOT,
+    repo_root: Path | None = None,
 ) -> str:
     """Complete dispatch preamble, blocks in dispatch order, blank-line separated.
 
     `gather=False` omits the repo-state block and leaves every other byte unchanged.
-    Path validation runs either way.
+    Path validation runs either way. `repo_root=None` means `default_repo_root()`.
     """
+    repo_root = repo_root or default_repo_root()
     if not isinstance(decision, dict):
         raise InputError("routing decision must be a JSON object")
     flags = decision.get("flags") or {}
@@ -998,8 +1022,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--repo-root",
         type=Path,
-        default=REPO_ROOT,
-        help="Root for path validation and repo-state gathering (default: this script's repo)",
+        default=None,
+        help="Root for path validation and repo-state gathering (default: cwd's git toplevel, else this script's repo)",
     )
     args = parser.parse_args(argv)
 

--- a/scripts/tests/test_build_dispatch.py
+++ b/scripts/tests/test_build_dispatch.py
@@ -1079,8 +1079,10 @@ def _git_repo(root: Path) -> Path:
 
 
 def test_symlinked_script_from_non_repo_cwd_gathers_real_git_output(tmp_path):
+    # Mirror the deployed layout: ~/.claude/{scripts,agents,skills,hooks} -> <repo>/...
+    for name in ("scripts", "agents", "skills", "hooks"):
+        (tmp_path / name).symlink_to(REPO_ROOT / name)
     link = tmp_path / "scripts"
-    link.symlink_to(SCRIPT_PATH.parent)
     result = _run_cli_from(
         tmp_path, link / "build-dispatch.py", "--json", json.dumps(_decision(task_spec=_SOURCE_DECISION))
     )
@@ -1088,7 +1090,7 @@ def test_symlinked_script_from_non_repo_cwd_gathers_real_git_output(tmp_path):
     assert "### git status" in result.stdout
     assert "### git log -5" in result.stdout
     assert "def build_task_spec" in result.stdout
-    assert "unavailable" not in result.stdout
+    assert "gather:" not in result.stdout
 
 
 def test_cwd_inside_a_git_repo_picks_that_repo(tmp_path):
@@ -1098,14 +1100,14 @@ def test_cwd_inside_a_git_repo_picks_that_repo(tmp_path):
     assert result.returncode == 0, result.stderr
     assert "### tracked.md" in result.stdout
     assert "init" in result.stdout.split("### git log -5", 1)[1]
-    assert "unavailable" not in result.stdout
+    assert "gather:" not in result.stdout
 
 
 def test_cwd_outside_any_repo_falls_back_to_the_script_repo(tmp_path):
     result = _run_cli_from(tmp_path, None, "--json", json.dumps(_decision(task_spec=_SOURCE_DECISION)))
     assert result.returncode == 0, result.stderr
     assert "def build_task_spec" in result.stdout
-    assert "unavailable" not in result.stdout
+    assert "gather:" not in result.stdout
 
 
 def test_repo_root_flag_overrides_the_cwd_repo(tmp_path):

--- a/scripts/tests/test_build_dispatch.py
+++ b/scripts/tests/test_build_dispatch.py
@@ -1052,6 +1052,113 @@ def test_gather_is_deterministic_for_a_fixed_repo_state():
     assert bd.build_preamble(decision) == bd.build_preamble(decision)
 
 
+# ---------------------------------------------------------------------------
+# Repo-root resolution: --repo-root > cwd git toplevel > the script's own repo.
+# Every test pins cwd; none depends on the machine's cwd or on ~/.claude.
+# ---------------------------------------------------------------------------
+
+_SOURCE_DECISION = {"intent": "x", "files": "scripts/build-dispatch.py"}
+
+
+def _run_cli_from(cwd, script=None, *args):
+    return subprocess.run(
+        [sys.executable, str(script or SCRIPT_PATH), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_repo(root: Path) -> Path:
+    """A tmp git repo with one committed file, `tracked.md`."""
+    root.mkdir()
+    (root / "tracked.md").write_text("tracked\n")
+    for args in (["init", "-q"], ["add", "."], ["-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "init"]):
+        subprocess.run(["git", *args], cwd=root, capture_output=True, check=True)
+    return root
+
+
+def test_symlinked_script_from_non_repo_cwd_gathers_real_git_output(tmp_path):
+    link = tmp_path / "scripts"
+    link.symlink_to(SCRIPT_PATH.parent)
+    result = _run_cli_from(
+        tmp_path, link / "build-dispatch.py", "--json", json.dumps(_decision(task_spec=_SOURCE_DECISION))
+    )
+    assert result.returncode == 0, result.stderr
+    assert "### git status" in result.stdout
+    assert "### git log -5" in result.stdout
+    assert "def build_task_spec" in result.stdout
+    assert "unavailable" not in result.stdout
+
+
+def test_cwd_inside_a_git_repo_picks_that_repo(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    decision = _decision(task_spec={"intent": "x", "files": "tracked.md"})
+    result = _run_cli_from(repo, None, "--json", json.dumps(decision))
+    assert result.returncode == 0, result.stderr
+    assert "### tracked.md" in result.stdout
+    assert "init" in result.stdout.split("### git log -5", 1)[1]
+    assert "unavailable" not in result.stdout
+
+
+def test_cwd_outside_any_repo_falls_back_to_the_script_repo(tmp_path):
+    result = _run_cli_from(tmp_path, None, "--json", json.dumps(_decision(task_spec=_SOURCE_DECISION)))
+    assert result.returncode == 0, result.stderr
+    assert "def build_task_spec" in result.stdout
+    assert "unavailable" not in result.stdout
+
+
+def test_repo_root_flag_overrides_the_cwd_repo(tmp_path):
+    cwd_repo = _git_repo(tmp_path / "cwd")
+    other = _git_repo(tmp_path / "other")
+    (other / "only-here.md").write_text("here\n")
+    decision = _decision(task_spec={"intent": "x", "files": "only-here.md"})
+    without = _run_cli_from(cwd_repo, None, "--json", json.dumps(decision))
+    assert without.returncode == 2
+    assert f"does not exist under {cwd_repo}" in without.stderr
+    with_flag = _run_cli_from(cwd_repo, None, "--json", json.dumps(decision), "--repo-root", str(other))
+    assert with_flag.returncode == 0, with_flag.stderr
+    assert "### only-here.md" in with_flag.stdout
+
+
+def test_missing_file_names_the_root_it_was_checked_under(tmp_path):
+    block = bd.build_gather_block(_decision(task_spec={"intent": "x", "files": "absent.md"}), repo_root=tmp_path)
+    assert f"gather: absent.md unavailable (not found under {tmp_path})" in block
+
+
+def test_non_repo_dir_reports_not_a_git_repository(tmp_path):
+    lines, reason = bd._run_git(tmp_path, ["status"], None)
+    assert lines is None and reason == "not a git repository"
+    lines, reason = bd._run_git(tmp_path / "absent", ["status"], None)
+    assert lines is None and reason == "not a git repository"
+
+
+@pytest.mark.parametrize(
+    ("effect", "reason"),
+    [
+        (
+            subprocess.TimeoutExpired(["git"], bd._GATHER_TIMEOUT_SECONDS),
+            f"timeout after {bd._GATHER_TIMEOUT_SECONDS}s",
+        ),
+        (FileNotFoundError(2, "No such file", "git"), "git not found"),
+        (subprocess.CompletedProcess(["git"], 128, "", "fatal: not a git repository"), "not a git repository"),
+        (subprocess.CompletedProcess(["git"], 129, "", "usage"), "exit 129"),
+    ],
+)
+def test_run_git_reports_each_failure_reason(tmp_path, effect, reason):
+    kwargs = {"side_effect": effect} if isinstance(effect, Exception) else {"return_value": effect}
+    with patch.object(bd.subprocess, "run", **kwargs):
+        lines, got = bd._run_git(tmp_path, ["status"], None)
+    assert lines is None and got == reason
+    with patch.object(bd.subprocess, "run", **kwargs):
+        block = bd.build_gather_block(_decision(task_spec={"intent": "x", "files": "new:x.py"}), repo_root=tmp_path)
+    assert f"gather: git status unavailable ({reason})" in block
+
+
+def test_gather_timeout_is_five_seconds():
+    assert bd._GATHER_TIMEOUT_SECONDS == 5
+
+
 def test_cli_with_gather_runs_under_300ms():
     decision = _decision()
     start = time.perf_counter()


### PR DESCRIPTION
REPO_ROOT resolves the ~/.claude/scripts symlink; gather and files validation default to the caller's cwd git toplevel (fallback: script repo; --repo-root overrides); timeout 2s -> 5s and every 'unavailable' line names its reason. 158 tests pass (147 + 11 new).
https://claude.ai/code/session_011xLnFyWR9mHmyXHoHLxte9