### PR TITLE
fix(hooks): raise alias lookup timeout to 0.5 s and stop caching timed-out lookups

### DIFF
--- a/hooks/pretool-unified-gate.py
+++ b/hooks/pretool-unified-gate.py
@@ -555,12 +555,13 @@ def _persistent_git_alias_payload(
             cwd=lookup_cwd,
             capture_output=True,
             text=True,
-            timeout=0.05,
+            timeout=0.5,
             check=False,
         )
         expansion = result.stdout.strip() if result.returncode == 0 else ""
     except (subprocess.TimeoutExpired, OSError):
-        expansion = ""
+        # Fail open, but do not cache: a slow git must not pin "no alias".
+        return ""
     payload = (expansion[1:] if expansion.startswith("!") else f"git {expansion}") if expansion else ""
     cache[key] = payload or None
     return payload

--- a/hooks/tests/test_pretool_unified_gate_security.py
+++ b/hooks/tests/test_pretool_unified_gate_security.py
@@ -493,8 +493,17 @@ class TestDestructiveGitOperations:
             run.assert_not_called()
 
     def test_alias_lookup_error_fails_open(self):
-        with patch.object(mod.subprocess, "run", side_effect=subprocess.TimeoutExpired("git", 0.05)):
+        with patch.object(mod.subprocess, "run", side_effect=subprocess.TimeoutExpired("git", 0.5)):
             assert mod._destructive_git_operation("git unknown-alias") is None
+
+    def test_alias_lookup_timeout_is_not_cached(self):
+        cache: dict = {}
+        with patch.object(mod.subprocess, "run", side_effect=subprocess.TimeoutExpired("git", 0.5)):
+            assert mod._persistent_git_alias_payload("nuke", None, cache) == ""
+        assert cache == {}
+        completed = subprocess.CompletedProcess(["git"], 0, stdout="reset --hard\n", stderr="")
+        with patch.object(mod.subprocess, "run", return_value=completed):
+            assert mod._persistent_git_alias_payload("nuke", None, cache) == "git reset --hard"
 
 
 COMPOUND_TOKEN_CASES = [


### PR DESCRIPTION
CI flake: under load git config exceeded the 50 ms bound, the alias read as absent, and the destructive alias was allowed (#944, #946). Raise the bound to 0.5 s; a timed-out lookup is no longer cached, so the next call retries.
https://claude.ai/code/session_011xLnFyWR9mHmyXHoHLxte9