### PR TITLE
Clean up four low-confidence audit flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The toolkit uses **agents, skills, hooks, and scripts** to absorb complexity tha
 
 ## Communication Standard
 
-The Dense-Complete Writing standard is the structural guide for everything we do. It governs **every** generation — every part of every agent and every thinking turn: replies to the user, plain text, the model's own thinking, skill and instruction files, and code comments.
+The Dense-Complete Writing standard is the structural guide for everything we do. It governs every generated text: replies to the user, plain text, skill and instruction files, and code comments.
 
 1. Shortest accurate word; never a long word where a short one serves.
 2. Cut every word that carries no instruction, rule, or decision.

--- a/agents/reviewer-system.md
+++ b/agents/reviewer-system.md
@@ -84,7 +84,7 @@ Based on the review request, load the appropriate reference(s):
 
 ### Phase 3: Analyze and Find
 
-6. Apply each loaded domain reference's methodology. Report at most 3 findings per domain dimension because more than 3 per dimension produces noise that buries the critical issues across 9 possible domains.
+6. Apply each loaded domain reference's methodology. Report only the findings that matter most in each domain dimension; a long list per dimension buries the critical issues across 9 possible domains.
 7. Each finding MUST include all 4 fields: **component** (service/file/module), **severity** (CRITICAL / HIGH / MEDIUM / LOW), **evidence command** (the Grep/Glob/Read invocation that proves the finding), and **one-sentence fix**. Do not describe findings without these four fields because findings without actionable specifics get ignored.
 8. Lead each finding with the actionable content; add context only where the fix depends on it, because reviewers read findings across multiple domains.
 9. Cross-reference findings across loaded domains. A silent failure in error handling that also creates an observability gap is one finding with two domain tags, not two separate findings.

--- a/agents/system-upgrade-engineer/references/upgrade-signal-parsing.md
+++ b/agents/system-upgrade-engineer/references/upgrade-signal-parsing.md
@@ -52,7 +52,7 @@ Parse each actionable item as a triple: (what changed, which component types are
 |--------|----------------|--------------|------|
 | New `Write` tool event type in PostToolUse | Hooks with PostToolUse | Upgrade event schema | Critical |
 | Deprecated `--json` flag in bash | Scripts using bash --json | Upgrade call sites | Important |
-| New `claude-opus-4-6` model available | Agents with model: sonnet | Review model field | Minor |
+| New Claude model released (e.g. `claude-<family>-<version>`) | Agents with model: sonnet | Review model field | Minor |
 ```
 
 **Why**: A manifest without the component-type column causes the AUDIT phase to scan everything.

--- a/scripts/rules-distill.py
+++ b/scripts/rules-distill.py
@@ -372,15 +372,16 @@ Extract up to 10 behavioral principles from this skill that:
 2. Would be useful as shared rules for ALL Claude Code agents
 3. Have a clear violation risk (what breaks if ignored)
 
-Return ONLY a JSON array of strings. Each string is one principle (1-2 sentences max).
+Return the principles as a JSON array of strings, one principle per string (1-2 sentences each).
 Example: ["Always exit 0 from hooks regardless of errors", "Never auto-apply changes without explicit user approval"]
 
 Return [] if no universal principles are found."""
 
         raw, _ = _run_claude_code(prompt, model="sonnet")
         raw = raw.strip()
-        # Parse JSON
-        principles = json.loads(raw)
+        # Parse the first JSON array in the reply; tolerate surrounding prose or fences.
+        match = re.search(r"\[.*\]", raw, re.DOTALL)
+        principles = json.loads(match.group(0) if match else raw)
         if not isinstance(principles, list):
             return None
         return [


### PR DESCRIPTION
Drops the thinking-style clause from CLAUDE.md, makes rules-distill parse the JSON array from prose instead of demanding JSON-only, replaces the reviewer-system 3-findings cap with a qualitative rule, and un-pins the model name in an upgrade-signal example.
No routing or gate behavior changes.

https://claude.ai/code/session_01AmUwNrpH5VVsFNxnToAsyn