### PR TITLE
Drop anti-rationalization rows that only restate the rule

### DIFF
--- a/agents/github-profile-rules-engineer.md
+++ b/agents/github-profile-rules-engineer.md
@@ -134,7 +134,6 @@ This agent operates as an operator for GitHub profile analysis, configuring Clau
 
 | Rationalization Attempt | Why It's Wrong | Required Action |
 |------------------------|----------------|-----------------|
-| "Cloning would be faster for this repo" | API-only is a hard constraint, not a suggestion | Use API endpoints exclusively |
 | "One repo is enough to establish a pattern" | Single-repo patterns may be project-specific | Cross-reference across 3+ repos for high confidence |
 | "This generic rule probably applies" | Generic rules add no value over existing best practices | Only extract rules with profile-specific evidence |
 | "Rate limits make full analysis impossible" | Sampling + prioritization works within limits | Sample strategically, analyze top repos first |

--- a/agents/research-subagent-executor.md
+++ b/agents/research-subagent-executor.md
@@ -130,8 +130,6 @@ This agent uses the **Analysis Schema**:
 | Rationalization | Why It's Wrong | Required Action |
 |-----------------|----------------|-----------------|
 | "One more search might find it" | Diminishing returns detected | Stop and use complete_task |
-| "This source seems authoritative" | Authority ≠ accuracy | Check for speculation indicators |
-| "The budget is just a guideline" | Hard limit enforced | Strict adherence to 20 call max |
 | "Snippets are enough detail" | Missing critical context | Use web_fetch after web_search |
 
 ## Blocker Criteria

--- a/agents/sqlite-peewee-engineer.md
+++ b/agents/sqlite-peewee-engineer.md
@@ -184,7 +184,6 @@ Peewee/SQLite patterns to follow.
 | "Prefetch makes queries complex" | N+1 kills performance, prefetch is 2 queries | Use prefetch() for related data |
 | "SQLite is fine without indexes" | Queries slow down quickly without indexes | Index foreign keys and query fields |
 | "Transactions are overkill for simple saves" | Multi-step operations need atomicity | Wrap in atomic() |
-| "Manual SQL is faster than ORM" | ORM provides safety, maintainability | Use Peewee queries, optimize if proven slow |
 | "We can skip migrations for small changes" | Manual changes break across environments | Use playhouse.migrate for all schema changes |
 
 ## Hard Gate Patterns

--- a/agents/typescript-debugging-engineer.md
+++ b/agents/typescript-debugging-engineer.md
@@ -187,7 +187,6 @@ Debugging patterns to follow. See [typescript-frontend-engineer/references/engin
 | "It works on my machine" | Environment difference is the clue | Document differences, test in production-like environment |
 | "The type error is TypeScript being wrong" | TypeScript types reflect runtime reality | Compare types to actual data structure, fix mismatch |
 | "We lack time for root cause analysis" | Quick fixes cause future bugs | Invest in reproduction + test case, prevent recurrence |
-| "Adding logging will slow things down" | Observability enables debugging | Add structured logging, use appropriate log levels |
 
 ## Blocker Criteria
 

--- a/agents/ui-design-engineer.md
+++ b/agents/ui-design-engineer.md
@@ -199,10 +199,8 @@ Common UI/UX implementation errors.
 
 | Rationalization Attempt | Why It's Wrong | Required Action |
 |------------------------|----------------|-----------------|
-| "Visual design is good enough" | Accessibility is requirement, not nice-to-have | Validate WCAG 2.1 AA compliance |
 | "Divs with onClick work fine" | Not keyboard accessible | Use semantic button elements |
 | "Focus outlines are ugly" | Required for keyboard navigation | Provide custom focus styles |
-| "Mobile layout can wait" | Mobile-first prevents issues | Design mobile layout first |
 | "Animations enhance every interaction" | Can trigger vestibular disorders | Respect prefers-reduced-motion |
 | "Placeholder text is fine for now" | Placeholder text produces placeholder thinking | Get real content before building |
 | "A card in the hero gives it structure" | Wrapping the hero in a card instantly demotes it to a dashboard tile | Remove the card, let the product speak directly |


### PR DESCRIPTION
Removes 7 table rows across 5 agents whose 'why' column just says the rule exists; rows with a real consequence stay.
Reviewed row by row after an automated first pass.

https://claude.ai/code/session_01AmUwNrpH5VVsFNxnToAsyn