### PR TITLE
fix(eval): prevent float rounding from inventing score regressions

### DIFF
--- a/docs/evaluations/exact-router-scores-2026-09-04.json
+++ b/docs/evaluations/exact-router-scores-2026-09-04.json
@@ -1,0 +1,86 @@
+{
+  "baseline_commit": "0d8a98f10146b08a64a7b0855c54e096f6c6c134",
+  "baseline_assessor_sha256": "d35ad8fbf45d1a7e4ac087f3f5cbb117491f26bf2270d2312324cf8c768d829f",
+  "candidate_assessor_sha256": "0315a71ad78045c57cacd2b2aae165aa2a4b2ef4a9da63eab028fd9d1b4a1a9a",
+  "method": "Identical synthetic raw worker/judge artifacts through full assessor; 30 cases, 5 repeats, 2 arms. Only case-0 varies, with 3 checks. No model calls.",
+  "cases": {
+    "equal_total": {
+      "baseline_earned_counts": [
+        0,
+        0,
+        0,
+        0,
+        3
+      ],
+      "challenger_earned_counts": [
+        0,
+        0,
+        0,
+        1,
+        2
+      ],
+      "before": {
+        "status": "REJECT",
+        "regressions": [
+          "case-0"
+        ],
+        "case_utility": {
+          "baseline": 0.2,
+          "challenger": 0.19999999999999998
+        },
+        "runs": 300,
+        "failures": 0
+      },
+      "after": {
+        "status": "REVIEW_READY",
+        "regressions": [],
+        "case_utility": {
+          "baseline": 0.2,
+          "challenger": 0.2
+        },
+        "runs": 300,
+        "failures": 0
+      }
+    },
+    "one_point_loss": {
+      "baseline_earned_counts": [
+        0,
+        0,
+        0,
+        0,
+        3
+      ],
+      "challenger_earned_counts": [
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      "before": {
+        "status": "REJECT",
+        "regressions": [
+          "case-0"
+        ],
+        "case_utility": {
+          "baseline": 0.2,
+          "challenger": 0.13333333333333333
+        },
+        "runs": 300,
+        "failures": 0
+      },
+      "after": {
+        "status": "REJECT",
+        "regressions": [
+          "case-0"
+        ],
+        "case_utility": {
+          "baseline": 0.2,
+          "challenger": 0.13333333333333333
+        },
+        "runs": 300,
+        "failures": 0
+      }
+    }
+  }
+}

--- a/scripts/router_ab/assess.py
+++ b/scripts/router_ab/assess.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import random
 from collections import defaultdict
+from fractions import Fraction
 from pathlib import Path
 from statistics import mean, median
 
@@ -269,7 +270,8 @@ def assess(routing, judge_dir, map_path):
         if signatures[0] != signatures[1]:
             disagreement.append(identifier)
         key = (assignment["case_id"], assignment["arm"])
-        utility[key].append(mean(c["score"] for c in rows[0]["checks"]))
+        checks = rows[0]["checks"]
+        utility[key].append(Fraction(sum(c["score"] for c in checks), len(checks)))
         critical[key] += sum(c["violated"] for c in rows[0]["critical_violations"])
         failures += not result["success"]
         require(result["usage_known"], "Unknown usage invalidates measured denominator")
@@ -328,7 +330,7 @@ def assess(routing, judge_dir, map_path):
             for case in sorted({a["case_id"] for a, _, _ in results})
         },
         "case_utility": {
-            case: {arm: mean(utility[(case, arm)]) for arm in ("baseline", "challenger")}
+            case: {arm: float(mean(utility[(case, arm)])) for arm in ("baseline", "challenger")}
             for case in sorted({a["case_id"] for a, _, _ in results})
         },
     }

--- a/scripts/router_ab/test_assess.py
+++ b/scripts/router_ab/test_assess.py
@@ -246,6 +246,48 @@ class AssessmentTests(unittest.TestCase):
         self.assertEqual(self.result()["status"], "REJECT")
         self.assertEqual(len(self.result()["regressions"]), 1)
 
+    def assess_three_check_distributions(self, baseline, challenger):
+        rubrics = assess.lines(self.rubrics / "synthetic-rubrics.jsonl")
+        for rubric in rubrics:
+            rubric["checks"] = [{"id": f"check-{i}", "criterion": f"Synthetic requirement {i}"} for i in range(3)]
+        (self.rubrics / "synthetic-rubrics.jsonl").write_text("".join(json.dumps(r) + "\n" for r in rubrics))
+        self.prepare()
+        mapping = assess.read(self.mapping)["packets"]
+        rows = []
+        for packet in assess.lines(self.packets):
+            assignment = mapping[packet["id"]]["assignment"]
+            counts = baseline if assignment["arm"] == "baseline" else challenger
+            earned = counts[assignment["repeat"]] if assignment["case_id"] == "case-0" else 3
+            for number in (1, 2):
+                rows.append(
+                    {
+                        "id": packet["id"],
+                        "pass": number,
+                        "checks": [
+                            {"id": f"check-{i}", "score": int(i < earned), "evidence": "synthetic evidence"}
+                            for i in range(3)
+                        ],
+                        "critical_violations": [
+                            {"criterion": "Unsafe action", "violated": False, "evidence": "No unsafe action proposed"}
+                        ],
+                    }
+                )
+        self.write_scores(rows)
+        return self.result()
+
+    def test_equal_totals_across_different_trial_distributions_do_not_regress(self):
+        result = self.assess_three_check_distributions((0, 0, 0, 0, 3), (0, 0, 0, 1, 2))
+        self.assertEqual(result["regressions"], [])
+        self.assertEqual(result["status"], "REVIEW_READY")
+        self.assertEqual(result["case_utility"]["case-0"], {"baseline": 0.2, "challenger": 0.2})
+        self.assertEqual(json.loads(json.dumps(result)), result)
+
+    def test_one_point_loss_still_regresses_with_fractional_trial_scores(self):
+        result = self.assess_three_check_distributions((0, 0, 0, 0, 3), (0, 0, 0, 0, 2))
+        self.assertEqual(result["regressions"], ["case-0"])
+        self.assertEqual(result["status"], "REJECT")
+        self.assertEqual(result["case_utility"]["case-0"], {"baseline": 0.2, "challenger": 2 / 15})
+
     def test_additional_critical_failure_rejects(self):
         self.prepare()
         rows = self.scores()


### PR DESCRIPTION
## Summary

Equal rubric totals can falsely fail the no-regression gate when their per-trial distributions differ. Five three-check trials scoring `(0, 0, 0, 0, 3)` average to `0.2`, while `(0, 0, 0, 1, 2)` previously averaged to `0.19999999999999998` and were rejected despite the same 3/15 total.

## Changes

Keep rubric utility as exact fractions through per-case comparisons and convert only the JSON report values to floats. Thresholds, rubrics, token accounting, and critical-failure rules are unchanged.

Deterministic A/B evidence uses the original and patched full assessors with identical synthetic raw worker/judge artifacts: 30 cases, five repeats, two arms, and two judge passes. No model calls were needed. Source hashes and results are recorded in `docs/evaluations/exact-router-scores-2026-09-04.json`.

| Scenario | Before | After |
| --- | --- | --- |
| Equal 3/15 totals, different trial distributions | REJECT: false case regression | REVIEW_READY: no regression |
| Genuine 3/15 to 2/15 loss | REJECT | REJECT |

## Notes

The equal-total regression test failed against the original assessor and passes with the fix; the genuine-loss control passes with both. Full harness validation: `python3 -m pytest scripts/router_ab -q` passed 49 tests and 24 subtests. Required whole-repository Ruff lint and format checks and `git diff --check` passed. Independent review found no blockers.

This corrects evaluator arithmetic; it does not establish a winner for any toolkit experiment. No frozen trial artifacts or policies changed. Draft pending all GitHub Actions; do not merge before they pass.
