### PR TITLE
test: handle ESRCH during process status reads

### DIFF
--- a/scripts/router_ab/test_process_control.py
+++ b/scripts/router_ab/test_process_control.py
@@ -1,5 +1,6 @@
 """Trusted fake-CLI regression: wrapper timeout must not orphan its child."""
 
+import errno
 import json
 import os
 import signal
@@ -55,16 +56,17 @@ def running(pid):
         return True
     try:
         return status.read_text().split(") ", 1)[1][0] != "Z"
-    except FileNotFoundError:
+    except (FileNotFoundError, ProcessLookupError):
         return False
 
 
-def test_running_accepts_exit_between_pid_probe_and_status_read(monkeypatch):
+@pytest.mark.parametrize("error_number", [errno.ENOENT, errno.ESRCH])
+def test_running_accepts_exit_between_pid_probe_and_status_read(monkeypatch, error_number):
     monkeypatch.setattr(os, "kill", lambda *_: None)
     monkeypatch.setattr(Path, "exists", lambda _: True)
 
     def exited(_):
-        raise FileNotFoundError("process exited")
+        raise OSError(error_number, "process exited")
 
     monkeypatch.setattr(Path, "read_text", exited)
     assert not running(12345)


### PR DESCRIPTION
When a child exits during the test helper’s `/proc/<pid>/stat` read, Linux can raise either ENOENT or ESRCH. Accept both specific process-disappearance exceptions so successful cleanup does not produce a false test failure. Runtime cleanup and experiment sources are unchanged.

Validation: the parametrized regression reproduces ESRCH failure against the old helper while ENOENT passes; both pass with the fix. Full focused evaluation suite and Ruff check/format pass. Independent review cleared the test-only change.
