### PR TITLE
refactor(go): load style references by task

### DIFF
--- a/agents/golang-general-engineer.md
+++ b/agents/golang-general-engineer.md
@@ -66,7 +66,7 @@ You are an **operator** for Go software development, configuring Claude's behavi
 This agent operates as an operator for Go software development, configuring Claude's behavior for idiomatic, production-ready Go code following modern patterns (Go 1.26+).
 
 ### Hardcoded Behaviors (Always Apply)
-- **Load Google Go style**: Call the Skill tool with `go-patterns`. Complete its mandatory four-document Google style baseline before reading, writing, changing, generating, debugging, or reviewing Go code.
+- **Load Go guidance**: Call the Skill tool with `go-patterns` for the task-specific references.
 - **Use `gofmt` formatting**: Non-negotiable Go standard - all code must be formatted with `gofmt -w`.
 - **Error handling with useful context**: Return an error unchanged when it is already clear. Add actionable context when it helps. Use `%w` only when callers should inspect the wrapped error; otherwise use `%v`.
 - **Use `any` not `interface{}`**: Modern Go requires `any` keyword (Go 1.18+).

--- a/agents/golang-general-engineer.md
+++ b/agents/golang-general-engineer.md
@@ -66,7 +66,7 @@ You are an **operator** for Go software development, configuring Claude's behavi
 This agent operates as an operator for Go software development, configuring Claude's behavior for idiomatic, production-ready Go code following modern patterns (Go 1.26+).
 
 ### Hardcoded Behaviors (Always Apply)
-- **Load Go guidance**: Call the Skill tool with `go-patterns` for the task-specific references.
+- **Load Go guidance**: Call the Skill tool with `go-patterns`. Load its task-specific references.
 - **Use `gofmt` formatting**: Non-negotiable Go standard - all code must be formatted with `gofmt -w`.
 - **Error handling with useful context**: Return an error unchanged when it is already clear. Add actionable context when it helps. Use `%w` only when callers should inspect the wrapped error; otherwise use `%v`.
 - **Use `any` not `interface{}`**: Modern Go requires `any` keyword (Go 1.18+).

--- a/scripts/tests/test_go_patterns_google_style.py
+++ b/scripts/tests/test_go_patterns_google_style.py
@@ -1,4 +1,4 @@
-"""Contracts for the always-loaded Google Go style guide snapshot."""
+"""Contracts for the pinned Google Go style guide snapshot and routing."""
 
 from __future__ import annotations
 
@@ -42,13 +42,7 @@ def test_complete_snapshot_matches_recorded_checksums() -> None:
         assert hashlib.sha256(content).hexdigest() == recorded[name]
 
 
-def test_go_skill_requires_every_google_document_for_every_task() -> None:
-    skill = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
-    marker = "## Mandatory Google Style Baseline (Every Go Task)"
-    section = skill.split(marker, 1)[1].split("## ", 1)[0]
-
-    assert "Read every file it lists, in order" in section
-    assert "references/google-style-guide/LOAD_ORDER.md" in section
+def test_do_preserves_go_guidance_for_protected_pr_security_intent() -> None:
     do_skill = (ROOT / "skills" / "meta" / "do" / "SKILL.md").read_text(encoding="utf-8")
     assert "Protected PR/security intent with a Go source operand" in do_skill
     assert "stack `go-patterns`" in do_skill
@@ -72,7 +66,7 @@ def test_snapshot_parts_fit_reference_size_limit() -> None:
 
 def test_go_agents_require_the_companion_skill() -> None:
     agent = (ROOT / "agents" / "golang-general-engineer.md").read_text(encoding="utf-8")
-    assert "Call the Skill tool with `go-patterns`." in agent
+    assert "Call the Skill tool with `go-patterns`" in agent
     frontmatter = yaml.safe_load(agent.split("---", 2)[1])
     assert "Skill" in frontmatter["allowed-tools"]
 

--- a/scripts/tests/test_go_patterns_google_style.py
+++ b/scripts/tests/test_go_patterns_google_style.py
@@ -66,7 +66,7 @@ def test_snapshot_parts_fit_reference_size_limit() -> None:
 
 def test_go_agents_require_the_companion_skill() -> None:
     agent = (ROOT / "agents" / "golang-general-engineer.md").read_text(encoding="utf-8")
-    assert "Call the Skill tool with `go-patterns`" in agent
+    assert "Call the Skill tool with `go-patterns`." in agent
     frontmatter = yaml.safe_load(agent.split("---", 2)[1])
     assert "Skill" in frontmatter["allowed-tools"]
 

--- a/skills/engineering/go-patterns/SKILL.md
+++ b/skills/engineering/go-patterns/SKILL.md
@@ -65,20 +65,10 @@ routing:
 # Go Patterns Skill
 
 Umbrella skill for Go development: Google style, testing, concurrency, error handling,
-failure modes, code review, SAP CC conventions, and quality gates. Every Go task starts
-with the complete Google Go style baseline, then loads task-specific references.
+failure modes, code review, SAP CC conventions, and quality gates. Load the references
+relevant to the task.
 
-## Mandatory Google Style Baseline (Every Go Task)
-
-Before reading, writing, changing, generating, debugging, or reviewing Go code:
-
-1. Read `${CLAUDE_SKILL_DIR}/references/google-style-guide/LOAD_ORDER.md`.
-2. Read every file it lists, in order. Do not omit or sample parts.
-
-Do not skip this baseline for small changes, tight context budgets, reviews, tests, or
-generated code. The ordered files reconstruct all four complete pinned upstream
-documents—overview, guide, decisions, and best practices—without excerpts.
-Apply their guidance to all Go code produced by the agent.
+## Google Style Precedence
 
 Use this precedence when guidance differs:
 
@@ -97,7 +87,7 @@ generated-code constraints, or compatibility requirements require one.
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| Every Go task | `google-style-guide/LOAD_ORDER.md`, then every file it lists | Complete Google style baseline; always load every part of all four upstream documents |
+| Google-specific style decisions | Relevant sections under `google-style-guide/` | Check the pinned conventions needed for the task |
 | Testing | `testing.md` | Writing, fixing, or reviewing Go tests |
 | Concurrency | `concurrency.md` | Goroutines, channels, sync primitives, race conditions |
 | Error handling | `error-handling.md` | Error wrapping, sentinels, custom types, errors.Is/As |
@@ -108,12 +98,7 @@ generated-code constraints, or compatibility requirements require one.
 
 ## Instructions
 
-### Step 1: Load the Google Style Baseline
-
-Read the load-order manifest and every file it names. This gate is complete only after
-every part of all four upstream documents has been read in the current task.
-
-### Step 2: Identify the Go Domain
+### Step 1: Identify the Go Domain
 
 Classify the task into one or more domains, then load the corresponding reference files.
 Only load what is needed -- do not load all references for every task.
@@ -131,14 +116,14 @@ Only load what is needed -- do not load all references for every task.
 Multiple domains may apply. For example, reviewing a PR that includes concurrency code
 should load both `code-review.md` and `concurrency.md`.
 
-### Step 3: Load and Follow the Reference
+### Step 2: Load and Follow the Reference
 
 Read the selected reference file(s) using `${CLAUDE_SKILL_DIR}/references/<name>.md`.
 Each reference contains the full methodology, phases, code examples, and error handling
 for that domain. Follow the instructions in the reference as if they were this skill's
 instructions.
 
-### Step 4: Use Domain-Specific Sub-References
+### Step 3: Use Domain-Specific Sub-References
 
 Some references point to their own sub-reference files for extended patterns:
 
@@ -173,7 +158,7 @@ Some references point to their own sub-reference files for extended patterns:
 - `${CLAUDE_SKILL_DIR}/references/quality-gate/expert-review-patterns.md` -- Manual review patterns
 - `${CLAUDE_SKILL_DIR}/references/quality-gate/examples.md` -- Detailed usage examples
 
-### Step 5: Execute
+### Step 4: Execute
 
 Follow the loaded reference methodology. Each reference has its own phases, gates,
 and completion criteria. Apply them as written.


### PR DESCRIPTION
## Summary
Load Go references according to the task instead of requiring the complete style corpus for every Go request.

## Changes
- Keep the Go companion skill, pinned references, Google precedence and repository exceptions.
- Remove the unconditional 23-file style read and its repeated instructions.
- Retain snapshot integrity and protected routing tests; retire the old blanket-loading assertion.

## Notes
Changes the loading policy introduced in #908. The user approved direct review and existing checks in place of further model A/B testing. No behavioral or token-saving experiment is claimed: calibration stopped before candidate trials.
