### PR TITLE
refactor(skills): condense verification instructions by 62%

### DIFF
--- a/skills/code-quality/code-linting/SKILL.md
+++ b/skills/code-quality/code-linting/SKILL.md
@@ -23,151 +23,38 @@ routing:
     - python-quality-gate
 ---
 
-# Code Linting Skill
+# Code linting
 
-Unified linting workflow for Python (ruff) and JavaScript (Biome). Covers check, format, and auto-fix for both languages. Only handles Python and JavaScript/TypeScript -- complex logic issues and other languages are out of scope.
+Check or fix Python with Ruff and JavaScript/TypeScript with Biome. Use repository commands and configuration before these defaults. Read project instructions, `pyproject.toml`, and `biome.json`; preserve configured rules and line width.
 
-## Reference Loading Table
+## Check and fix
 
-| Signal | Load These Files | Why |
+Use the project virtual environment (`./venv/bin/ruff` or `./env/bin/ruff`) and installed JavaScript tooling. For mixed projects, check both languages unless the task selects one. Adapt `src/` to the actual source directory.
+
+| Task | Python | JavaScript/TypeScript |
 |---|---|---|
-| Python violations, ruff rules, F401/E711/B006/UP errors | `ruff-rules-reference.md` | Routes to the matching deep reference |
-| ruff not found, pyproject.toml config, ruff version differences | `ruff-rules-reference.md` | Routes to the matching deep reference |
-| JavaScript/TypeScript violations, Biome rules, noVar/useConst/noDoubleEquals | `biome-rules-reference.md` | Routes to the matching deep reference |
-| biome not found, biome.json config, migrating from ESLint | `biome-rules-reference.md` | Routes to the matching deep reference |
-| Linting CI failures, format check vs lint check differences | `biome-rules-reference.md` | Routes to the matching deep reference |
+| Check | `ruff check .` | `npx @biomejs/biome check src/` |
+| Format check | `ruff format --check .` | Included in Biome check |
+| Fix lint | `ruff check --fix .` | `npx @biomejs/biome check --write src/` |
+| Format | `ruff format .` | `npx @biomejs/biome format --write src/` |
 
-## Instructions
+If configured, use `make lint` or `make lint-fix`. Check first; apply fixes only within the requested work. Review `git diff`, undo incorrect fixes, then rerun lint and format checks. Do not change rules, install new tooling, or expand cleanup scope merely to get a pass.
 
-### 1. Read Project Configuration
+For remaining issues: F401 means remove or use the import; I001 needs import sorting; E501 needs shorter lines within existing settings. Biome `noVar` uses `let`/`const`, `useConst` marks unchanged bindings, and `noDoubleEquals` uses strict equality where semantics allow.
 
-Before running any linter, read the repository's CLAUDE.md for project-specific linting rules -- those override every default below. Then locate the project's linter config files (`pyproject.toml` for ruff, `biome.json` for Biome). All linter invocations must use these configs as-is; never override line width, rule sets, or other project settings.
+Report commands, exit status, and actionable rule/file:line diagnostics. Keep full logs available; summarize passing checks. Remove only temporary files created for this run, preserving useful failure logs.
 
-### 2. Detect Languages and Run Checks
+## Recovery and optional modes
 
-When a project contains both Python and JavaScript/TypeScript, lint both unless the user explicitly requests a single language. Run the check command first to see what violations exist:
+- **Ruff missing:** check the project virtual environment. Installation options are `pip install ruff` or `pipx run ruff check .`; install only within authorized dependency work.
+- **Biome missing:** check package dependencies before npx execution; do not let a read-only check download tooling unexpectedly.
+- **Config missing:** verify project root before running defaults.
+- **Strict warnings, format-only, or rule exceptions:** use only when requested; do not weaken repository requirements.
 
-```bash
-# Python -- use project venv when available
-ruff check .
-# or: ./venv/bin/ruff check .
+## Reference loading table
 
-# JavaScript/TypeScript
-npx @biomejs/biome check src/
-```
-
-**Always display the complete linter output.** Never summarize results as "no issues found" or describe output secondhand -- show the actual command output so the user can see every error, warning, and style issue together.
-
-### 3. Review Output Before Fixing
-
-Read the full output and understand what violations exist and their severity before applying any fixes. Jumping straight to `--fix` without reviewing risks auto-removing imports that are still needed or making changes that reduce readability.
-
-### 4. Apply Auto-Fixes
-
-Apply `--fix` for safe categories: formatting, import ordering, and style issues that the linter can correct mechanically.
-
-```bash
-# Python
-ruff check --fix .
-ruff format .
-
-# JavaScript/TypeScript
-npx @biomejs/biome check --write src/
-npx @biomejs/biome format --write src/
-```
-
-Only run the linters and fixes that were requested. Do not add custom rules, configuration changes, or additional tooling unless the user explicitly asks.
-
-### 5. Review the Diff
-
-After auto-fix, review the diff to verify changes are correct and safe:
-
-```bash
-git diff
-```
-
-Auto-fixes can occasionally remove imports that are still needed, reformat code in ways that hurt readability, or introduce subtle bugs through variable shadowing changes. Revert any problematic auto-fixes before proceeding.
-
-### 6. Fix Remaining Issues Manually
-
-For violations that cannot be auto-fixed, explain each one and how to resolve it:
-
-**Python common fixes:**
-- Unused import (F401): Remove or use the import
-- Import order (I001): Run `ruff check --fix`
-- Line too long (E501): Break into multiple lines or adjust line-length config
-
-**JavaScript common fixes:**
-- noVar: Replace `var` with `let`/`const`
-- useConst: Use `const` for unchanging values
-- noDoubleEquals: Use `===` instead of `==`
-
-### 7. Verify Before Commit
-
-Run the linter one final time to confirm zero violations before suggesting a commit:
-
-```bash
-ruff check .
-ruff format --check .
-npx @biomejs/biome check src/
-```
-
-Report output factually -- no self-congratulation, just the command results.
-
-### 8. Clean Up
-
-Remove any temporary lint report files or cache files created during execution.
-
-### Combined Commands (if Makefile configured)
-
-```bash
-make lint       # Check both Python and JS
-make lint-fix   # Fix both Python and JS
-```
-
-### Configuration Reference
-
-| Tool | Config | Typical Line Width |
-|------|--------|-------------------|
-| ruff | pyproject.toml | 88-120 |
-| biome | biome.json | 80-120 |
-
-### Optional Modes
-
-- **Strict mode**: Treat warnings as errors (fail on any issue) -- enable when requested
-- **Format only**: Skip linting, only run formatting -- enable when requested
-- **Ignore specific rules**: Disable particular lint rules for edge cases -- enable when requested
-
-## Error Handling
-
-### Error: "ruff not found"
-**Cause**: Virtual environment not activated or ruff not installed
-**Solution**:
-- Use virtual environment path: `./venv/bin/ruff` or `./env/bin/ruff`
-- Or install globally: `pip install ruff`
-- Or use pipx: `pipx run ruff check .`
-
-### Error: "biome not found"
-**Cause**: Biome not installed in project
-**Solution**: Run `npx @biomejs/biome` to use npx-based execution
-
-### Error: "Configuration file not found"
-**Cause**: Running from wrong directory
-**Solution**: cd to project root where pyproject.toml/biome.json exist
-
-## Reference Loading
-
-Load these files when the task involves the corresponding domain:
-
-| Task type | Reference file |
-|-----------|---------------|
-| Python violations, ruff rules, F401/E711/B006/UP errors | `references/ruff-rules-reference.md` |
-| ruff not found, pyproject.toml config, ruff version differences | `references/ruff-rules-reference.md` |
-| JavaScript/TypeScript violations, Biome rules, noVar/useConst/noDoubleEquals | `references/biome-rules-reference.md` |
-| biome not found, biome.json config, migrating from ESLint | `references/biome-rules-reference.md` |
-| Linting CI failures, format check vs lint check differences | `references/ruff-rules-reference.md` + `references/biome-rules-reference.md` |
-
-## References
-
-- [ruff documentation](https://docs.astral.sh/ruff/)
-- [Biome documentation](https://biomejs.dev/)
+| Signal | Reference |
+|---|---|
+| Ruff rules, configuration, versions, or F401/E711/B006/UP errors | `references/ruff-rules-reference.md` |
+| Biome rules, configuration, ESLint migration, or noVar/useConst/noDoubleEquals | `references/biome-rules-reference.md` |
+| Lint versus format CI failure | Relevant tool reference above |

--- a/skills/code-quality/python-quality-gate/SKILL.md
+++ b/skills/code-quality/python-quality-gate/SKILL.md
@@ -30,209 +30,48 @@ routing:
     - test-driven-development
 ---
 
-# Python Quality Gate Skill
+# Python quality gate
 
-Run four quality tools in deterministic order -- ruff, pytest, mypy, bandit -- and produce a structured pass/fail report with severity-categorized issues and auto-fix commands.
+Run Python checks in order: Ruff lint, Ruff format, mypy, pytest, Bandit. Read repository instructions and configuration first; project commands and thresholds override defaults.
 
-## Reference Loading Table
+## Detect
 
-| Signal | Load These Files | Why |
+Find `pyproject.toml`, `setup.py`, `setup.cfg`, `mypy.ini`, and `.python-version`. Identify the Python target, tool settings, source directories (`src/`, `app/`, `lib/`, or root), and test discovery configuration.
+
+Use the project environment. Check `ruff --version`, `pytest --version`, `mypy --version`, and `bandit --version`. Ruff and pytest are required; missing tools block execution (status 2). Mypy and Bandit are optional unless the project requires them. Report unavailable tools as skipped. Do not install tools or alter configuration for a check-only request; setup may require `pip install ruff pytest pytest-cov`.
+
+## Execute
+
+Capture each command's output and exit status. Use configured paths; replace `src` below with the actual source path. Preserve stricter project settings rather than overriding them with defaults.
+
+| Order | Default command | Condition |
 |---|---|---|
-| writing the quality gate report | `report-template.md` | Loads detailed guidance from `report-template.md`. |
-| invoking ruff/mypy/pytest; severity classification and pass/fail thresholds | `tool-commands.md` | Loads detailed guidance from `tool-commands.md`. |
+| 1 | `ruff check . --output-format=grouped` | Required |
+| 2 | `ruff format --check .` | Required |
+| 3 | `mypy . --ignore-missing-imports --show-error-codes` | If available; omit `--ignore-missing-imports` when it weakens project policy |
+| 4 | `pytest -v --tb=short --cov=src --cov-report=term-missing` | Use coverage only when configured/requested and pytest-cov is installed |
+| 5 | `bandit -r src/ -ll --format=screen` | If available |
 
-## Instructions
+Run all available checks even after one fails; a test failure is a result, not a tool crash. Do not skip tests to get a pass. If there are no discovered tests, report that coverage gap; tests may live outside a `tests/` directory.
 
-### Phase 1: Detection and Setup
+## Assess and report
 
-**Step 1: Read CLAUDE.md and detect project configuration.**
+Repository gates take precedence. Legacy default failure thresholds are Ruff F errors, test failures, high-severity Bandit issues, more than 10 mypy errors, and coverage below 80% when enabled. Always report each nonzero tool result separately; an aggregate threshold must not be described as every tool passing. Formatting failures and repository-required checks remain failures.
 
-Read and follow the repository's CLAUDE.md before any execution. Then detect project configuration:
+Prioritize syntax/undefined-name errors, failing tests, and security findings before style. `ruff check . --statistics` identifies counts and `[*]` fixable rules. Report overall result, per-tool status, actionable file:line diagnostics, coverage when measured, skipped checks, and suggested fixes. Preserve full logs rather than pasting every result. Write a full report when requested, including to `--output {file}` when supplied.
 
-```bash
-ls -la pyproject.toml setup.py setup.cfg mypy.ini .python-version 2>/dev/null
-```
+## Fix and recover
 
-Identify Python version target, ruff config, pytest config, mypy config from pyproject.toml. Only validate code -- never add tools, features, or flexibility not requested.
+When fixes are authorized, check first, run `ruff check . --fix` and `ruff format .`, inspect `git diff`, then rerun affected checks. Do not widen cleanup scope or change settings to hide failures.
 
-**Step 2: Detect source and test directories.**
+- **Wrong directory/no Python files:** verify project root and configured source paths.
+- **Mypy cache corruption:** confirm the project cache, remove `.mypy_cache`, and retry once. If it still fails, report an incomplete type check; do not call it passed.
+- **Missing required tool:** report its name and setup command; do not continue as though the gate passed.
 
-```bash
-ls -d src/ app/ lib/ 2>/dev/null || echo "Source: current directory"
-ls -d tests/ test/ 2>/dev/null || echo "Tests: not found"
-```
+## Reference loading table
 
-**Step 3: Verify tool availability.**
-
-```bash
-ruff --version
-pytest --version
-mypy --version || echo "mypy not installed (optional)"
-bandit --version || echo "bandit not installed (optional)"
-```
-
-If ruff or pytest are missing, STOP. These are required:
-```
-ERROR: Required tool not found: {tool_name}
-Install with: pip install ruff pytest pytest-cov
-```
-
-Do not install missing tools automatically unless the user explicitly requests it. Do not modify pyproject.toml or configuration files unless explicitly asked.
-
-**Gate**: ruff and pytest available. Project structure identified. Proceed only when gate passes.
-
-### Phase 2: Execute Quality Checks
-
-Run all checks in fixed order, capturing full output for each. Show complete command output with exact file paths and line numbers -- never summarize or paraphrase tool output, because summarization hides the details engineers need to locate and fix issues.
-
-**Step 1: Ruff linting.**
-
-```bash
-ruff check . --output-format=grouped
-```
-
-**Step 2: Ruff formatting check.**
-
-```bash
-ruff format --check .
-```
-
-**Step 3: Type checking with mypy** (if installed).
-
-```bash
-mypy . --ignore-missing-imports --show-error-codes
-```
-
-Skip and note in report if mypy is not installed. Even if tests pass, still run mypy when available -- tests check behavior while types check contracts, and passing one does not make the other redundant.
-
-**Step 4: Run test suite.**
-
-```bash
-pytest -v --tb=short --cov=src --cov-report=term-missing
-```
-
-If no tests directory exists, skip and note in report. Never skip tests to make the gate pass -- tests verify functionality, and skipping them hides broken code. Only skip optional tools (mypy, bandit) if genuinely unavailable, not to manufacture a passing status.
-
-**Step 5: Security scanning with bandit** (if installed).
-
-```bash
-bandit -r src/ -ll --format=screen
-```
-
-Skip and note in report if bandit is not installed. Linting passing does not mean code is correct -- linting finds style issues, not logic or security bugs. Run every available tool.
-
-**Gate**: All available tools have been run. Full output captured. Proceed to analysis.
-
-### Phase 3: Categorize and Analyze
-
-**Step 1: Categorize issues by severity.**
-
-See `references/tool-commands.md` for complete severity classification tables.
-
-Summary of severity levels:
-- **Critical**: F errors (pyflakes), E9xx (syntax), undefined names, test failures, high-severity security
-- **High**: E501, E711/E712, F841, N8xx, arg-type/assignment mypy errors
-- **Medium**: W warnings, C4xx, no-untyped-def mypy errors
-- **Low**: SIM suggestions, UP upgrade suggestions
-
-Always prioritize critical issues over style fixes -- critical issues (F errors, test failures) break functionality while style issues do not. Fix critical first, high second; use auto-fix for bulk style cleanup only after critical issues are resolved.
-
-**Step 2: Count auto-fixable issues.**
-
-```bash
-ruff check . --statistics
-```
-
-Issues marked with `[*]` are auto-fixable. Show suggested auto-fix commands for these issues so users know what can be fixed automatically.
-
-**Step 3: Determine overall status.**
-
-FAIL if:
-- Any ruff F errors or test failures
-- Any high-severity bandit issues
-- Mypy errors exceed 10 (configurable)
-- Test coverage below 80% (if coverage enabled)
-
-PASS otherwise. Exit with non-zero status if any critical check fails.
-
-**Gate**: All issues categorized. Pass/fail determined. Proceed to report.
-
-### Phase 4: Generate Report
-
-Format a structured markdown report. See `references/report-template.md` for the full template.
-
-The report MUST include:
-1. Overall PASS/FAIL status
-2. Summary table (each tool's status and issue count)
-3. Total issues and auto-fixable count
-4. Detailed results per tool (issues grouped by severity, then grouped by type and file for readability)
-5. Critical issues requiring attention with file:line references
-6. Auto-fix commands section
-7. Quality metrics: error counts and coverage percentages
-
-Report facts -- show raw command output rather than describing it. No self-congratulation ("great job", "looking good"). Generate the full report even when only style issues are found, because style issues can hide real problems in noise and a full severity-prioritized report surfaces them.
-
-Print the complete report to stdout. Never summarize or truncate. If `--output {file}` flag was provided, also write report to file. Remove any intermediate temporary files at completion -- keep the final report only if the user requested file output.
-
-**Gate**: Report generated and displayed. Task complete.
-
-### Auto-Fix Mode (only when explicitly requested)
-
-Auto-fix modifies files in place -- never run it without explicit user confirmation. Running `ruff --fix` blindly can change code semantics (import removal, reformatting), so always run check-only first, review issues, confirm auto-fix intent, then verify changes.
-
-When user explicitly requests auto-fix:
-
-```bash
-ruff check . --fix
-ruff format .
-```
-
-After auto-fix, show the diff so changes can be reviewed, then re-run the quality gate to verify:
-```bash
-git diff
-```
-
-## Examples
-
-### Example 1: Pre-Merge Quality Check
-User says: "Run quality checks before I merge this PR"
-Actions:
-1. Detect project config and available tools (Phase 1)
-2. Run ruff check, ruff format, mypy, pytest, bandit in order (Phase 2)
-3. Categorize 12 issues: 0 critical, 3 high, 9 medium (Phase 3)
-4. Generate report showing PASSED with 3 high-priority suggestions (Phase 4)
-Result: Structured report with actionable fix commands
-
-### Example 2: Quality Gate Failure
-User says: "Check code quality on the payments module"
-Actions:
-1. Detect config, find src/payments/ directory (Phase 1)
-2. Run all tools -- pytest shows 2 failures, ruff finds F401 errors (Phase 2)
-3. Categorize: 2 critical (test failures), 1 critical (undefined name), 5 medium (Phase 3)
-4. Generate FAILED report with critical issues listed first (Phase 4)
-Result: FAILED status with prioritized fix list, auto-fix commands for 5 medium issues
-
-## Error Handling
-
-### Error: "ruff: command not found"
-**Cause**: Ruff is not installed in the current environment
-**Solution**: Install with `pip install ruff`. Do not proceed without ruff -- exit with status 2.
-
-### Error: "Tests failed with exit code 1"
-**Cause**: pytest found test failures
-**Solution**: This is expected behavior, not a tool error. Parse output, include failure details in report, mark overall status as FAILED, continue with remaining checks.
-
-### Error: "No Python files found"
-**Cause**: Running from wrong directory or not a Python project
-**Solution**: Verify location with `ls pyproject.toml src/ tests/`. Run from project root.
-
-### Error: "Mypy cache corruption"
-**Cause**: Stale or corrupted .mypy_cache directory
-**Solution**: Clear cache with `rm -rf .mypy_cache` and retry. If mypy continues to fail, skip type checking and note in report.
-
-## References
-
-### Reference Files
-- `${CLAUDE_SKILL_DIR}/references/tool-commands.md`: Severity classifications, expected output formats, CLI flags
-- `${CLAUDE_SKILL_DIR}/references/report-template.md`: Full structured report template
-- `${CLAUDE_SKILL_DIR}/references/pyproject-template.toml`: Complete ruff, pytest, mypy, bandit configuration
+| Signal | Reference |
+|---|---|
+| Detailed rule severity, command options, output parsing | `references/tool-commands.md` |
+| Full structured report requested | `references/report-template.md` |
+| Tool configuration setup requested | `references/pyproject-template.toml` |

--- a/skills/code-quality/typescript-check/SKILL.md
+++ b/skills/code-quality/typescript-check/SKILL.md
@@ -21,149 +21,25 @@ routing:
     - code-linting
 ---
 
-# TypeScript Type Check Skill
+# TypeScript check
 
-## Overview
+Read-only type validation. Follow repository instructions and package scripts; preserve project compiler settings. Do not fix code, change configuration, or install dependencies for a check-only request.
 
-This skill validates TypeScript code by running `tsc --noEmit` and parsing errors into structured, actionable reports organized by file. It is a **read-only validation** step (does not modify code) that implements a linear workflow: locate config → execute compiler → parse output → present results.
+## Run
 
-Use this skill when validating TypeScript code before commits, after refactors, or checking for type regressions. Do not use for linting, test execution, runtime errors, or projects without tsconfig.json.
+1. Locate `tsconfig.json`, including `src/`, `app/`, and `packages/`. In a monorepo, use the package affected by the task or the repository's aggregate check. Ask only when the target cannot be inferred. If no config exists, report the missing configuration and stop.
+2. Confirm TypeScript is installed locally before using npx; do not allow an implicit package download.
+3. Run `npx tsc --noEmit 2>&1`, or `npx tsc --noEmit --project path/to/tsconfig.json 2>&1` for a selected config. Capture output and exit code. Zero means pass; nonzero may mean type errors or a tool/configuration failure—report which.
+4. Report status and error count. Group diagnostics by file and line, retaining `file:line:column`, `TS####`, and the message. Retain complete logs; show useful failure details instead of all successful output.
 
----
+## Recovery and flags
 
-## Instructions
+- **TypeScript missing:** report it; suggest `npm install typescript --save-dev` within dependency setup.
+- **npx missing:** check `node --version`; when Node/npm and local TypeScript exist, use `npm exec tsc -- --noEmit`. Otherwise report the missing toolchain.
+- **Multiple configs:** list the checked configs and any omitted packages. A single-package pass is not a whole-repository pass.
+- **`--skipLibCheck`:** skips declaration-file checking; use only when configured or requested, not to hide failures.
+- **`--strict`:** adds strict checks; enable only when requested or configured.
+- **`--incremental`:** may write build-info cache files; enable only when permitted, not for a strictly read-only run.
+- **Named files:** passing files directly bypasses project config. Prefer `--project`; do not claim equivalent coverage from a narrower check.
 
-### Step 1: Verify TypeScript Project
-
-Locate tsconfig.json in the project. This step is mandatory—never skip it. tsc without a tsconfig.json falls back to default settings, missing project-specific configuration like paths, strict mode, and compiler targets.
-
-```bash
-ls tsconfig.json 2>/dev/null || ls */tsconfig.json 2>/dev/null
-```
-
-If no tsconfig.json exists, stop and inform the user. Do not proceed without configuration.
-
-**Why**: Running without tsconfig.json produces unreliable results that don't match the project's actual settings.
-
-### Step 2: Run Type Check
-
-Execute the TypeScript compiler in type-check-only mode using `--noEmit`:
-
-```bash
-npx tsc --noEmit 2>&1
-```
-
-Capture the exit code:
-- **Exit 0**: No type errors found. Report PASS.
-- **Exit 1+**: Type errors detected. Continue to Step 3.
-
-Do not install TypeScript or dependencies. If TypeScript is not installed, inform the user and suggest `npm install typescript --save-dev`. This is a read-only skill—never modify package.json or run installation commands.
-
-**Why**: `--noEmit` prevents generating .js files and gives you a clean type-only report. The exit code tells you definitively whether compilation succeeded.
-
-### Step 3: Parse Output
-
-For each error line in the tsc output, extract:
-- **File path**: The .ts/.tsx file containing the error (use absolute paths for direct navigation)
-- **Line:Column**: Exact location in the file
-- **Error code**: TS#### identifier (e.g., TS2322, TS7006)
-- **Message**: Human-readable error description
-
-Group errors by source file and sort by line number. This helps users fix issues systematically rather than jumping randomly through the codebase.
-
-**Why**: Users need actual file paths, line numbers, and error codes to fix issues. Suppressing or summarizing this information (e.g., "5 errors found") makes errors unsolvable.
-
-### Step 4: Present Results
-
-Format output using this structure. Always show the full exit code and complete error details:
-
-```
-=== TypeScript Type Check ===
-
-Status: PASS / FAIL (N errors)
-
-Errors by File:
----------------
-
-src/components/Button.tsx
-  Line 15:3  TS2322  Type 'string' is not assignable to type 'number'
-  Line 28:10 TS2339  Property 'foo' does not exist on type 'Props'
-
-src/utils/helpers.ts
-  Line 5:1   TS7006  Parameter 'x' implicitly has an 'any' type
-
-Summary: N files, M errors
-```
-
-Never present type errors as context for auto-fixing without explicit user request. Type check is a validation step—the user may want to review errors, may disagree with a fix approach, or may have a different solution in mind.
-
-**Why**: Including the exit code and full output gives users all the context they need to make informed decisions about fixes.
-
----
-
-## Error Handling
-
-### Error: "Cannot find tsconfig.json"
-
-Cause: No TypeScript configuration in the project root or specified path.
-
-Solution:
-1. Search for tsconfig.json in common locations (src/, app/, packages/)
-2. If found elsewhere, re-run with `--project path/to/tsconfig.json`
-3. If not found anywhere, inform user this requires a TypeScript project with a tsconfig.json file
-
-### Error: "Cannot find module 'typescript'"
-
-Cause: TypeScript is not installed as a project dependency.
-
-Solution:
-1. Inform user that TypeScript must be installed first
-2. Suggest `npm install typescript --save-dev`
-3. Do not install it automatically—this is a read-only skill
-
-### Error: "npx: command not found"
-
-Cause: Node.js toolchain is not installed or not in PATH.
-
-Solution:
-1. Verify Node.js is installed: `node --version`
-2. If Node.js is present but npx missing, try `npm exec tsc -- --noEmit`
-3. If Node.js is missing, inform user to install Node.js
-
-### Error: "Multiple tsconfig.json files found"
-
-Cause: Project has nested or monorepo structure with multiple TypeScript configurations.
-
-Solution:
-1. List all tsconfig.json files and their paths
-2. Ask user which configuration to use
-3. Re-run with `--project path/to/specific/tsconfig.json`
-
-**Why explicit error handling matters**: tsc may fail silently, produce incomplete output, or exit unexpectedly. Capturing and reporting the actual error lets the user understand what went wrong and how to fix it.
-
----
-
-## References
-
-### Common tsc Flags
-
-| Flag | Purpose |
-|------|---------|
-| `--noEmit` | Type check only, do not generate .js files |
-| `--project path` | Use specific tsconfig.json |
-| `--skipLibCheck` | Skip type checking .d.ts files (faster on large projects) |
-| `--incremental` | Use incremental compilation (faster for repeat runs) |
-| `--strict` | Enable all strict type checks |
-
-### Integration Points
-
-- **Before pr-workflow commit**: Run type check before committing TypeScript changes
-- **With vitest-runner**: Run type check first, then tests
-- **With code-linting**: Run lint first, then type check
-
-### Optional Behaviors (OFF unless enabled)
-
-- **--strict mode**: Run with additional strict flags beyond tsconfig settings
-- **--project path**: Use a specific tsconfig.json when multiple exist
-- **--skipLibCheck**: Add --skipLibCheck to speed up checking on large projects
-- **Specific files**: Check only named files instead of entire project
+When running the full JavaScript/TypeScript check sequence, lint first, type-check next, then run tests with `vitest-runner` or the repository test command.

--- a/skills/code-quality/universal-quality-gate/SKILL.md
+++ b/skills/code-quality/universal-quality-gate/SKILL.md
@@ -20,30 +20,34 @@ routing:
     - verification-before-completion
 ---
 
-# Universal Quality Gate Skill
+# Universal quality gate
 
-Language-agnostic code quality checking system. Automatically detects project languages via marker files and runs appropriate linters, formatters, and static analysis tools for each detected language.
+Run configured lint, format, type, and security checks across project languages. Tests and builds remain separate checks.
 
-## Overview
+## Run
 
-This skill implements a **Detect, Check, Report** pattern for multi-language code quality enforcement:
-1. Auto-detect languages by scanning for marker files (go.mod, package.json, pyproject.toml, Cargo.toml, etc.)
-2. Run language-specific lint, format, type-check, and security tools
-3. Report complete results with graceful degradation for unavailable tools
+Read repository instructions and configuration first. Use the repository's prescribed checks when present; the adapter below supplies multi-language detection through `hooks/lib/language_registry.json` and `hooks/lib/quality_gate.py`.
 
-**Key Principles:**
-- **Read repository CLAUDE.md files first** — Project instructions override default behaviors
-- **Only run configured tools** — Do not add new tools, languages, or checks unless explicitly requested. Keep quality checks focused on what is already defined in language_registry.json.
-- **Show complete output** — Display full linter output, never summarize as "no issues"
-- **Graceful degradation** — Skip unavailable tools without failing the entire gate
-- **Fail only on required tools** — Only return non-zero exit if required tool failures occur
+```bash
+python3 ~/.claude/skills/code-quality/universal-quality-gate/scripts/run_quality_gate.py
+```
 
----
+| Option | Use |
+|---|---|
+| `--staged` | Check staged files before commit |
+| `--lang python` | Focus on one language |
+| `--fix` | Apply configured fixes within authorized scope |
+| `-v` | Expanded diagnostics |
+| `--no-patterns` | Skip informational pattern scanning |
 
-## Supported Languages
+Check before fixing, review `git diff` afterward, and rerun affected checks. Do not add tools, change rules, or make required tools optional to get a pass.
 
-| Language | Marker Files | Tools |
-|----------|--------------|-------|
+## Detection
+
+The registry is authoritative; these are its language families:
+
+| Language | Markers | Tools |
+|---|---|---|
 | Python | pyproject.toml, requirements.txt | ruff, mypy, bandit |
 | Go | go.mod | gofmt, golangci-lint, go vet |
 | JavaScript | package.json | eslint, biome |
@@ -55,250 +59,14 @@ This skill implements a **Detect, Check, Report** pattern for multi-language cod
 | YAML | *.yml, *.yaml | yamllint |
 | Markdown | *.md | markdownlint |
 
-## Instructions
+## Results and recovery
 
-### Step 1: Execute Quality Gate
+Capture output and exit status. Report checked scope, required failures, optional skips, and useful file:line diagnostics. Keep full logs available without pasting every successful result. A gate pass means required tools passed; it does not prove tests, builds, or business behavior passed.
 
-Run the quality gate check against the current project:
+- **Required tool missing or failed:** report a blocked or failed check. Use the project environment and declared dependency setup; do not downgrade the requirement.
+- **Optional tool unavailable:** report it as skipped, not passed. `[WARNING]` pattern matches are informational; inspect them for actual defects.
+- **No files:** check project root, marker files, and `git diff --cached --name-only` for staged mode. Empty scope is not evidence of code quality; do not stage unrelated work to populate it.
+- **Timeout:** inspect generated or large files and I/O. Use `--staged` or `--lang` for diagnosis, but state reduced coverage and complete required checks before claiming a full pass.
+- **Conflicting configuration:** read project instructions and package scripts to identify the intended tool. Do not silently remove checks or edit the registry.
 
-```bash
-python3 ~/.claude/skills/code-quality/universal-quality-gate/scripts/run_quality_gate.py
-```
-
-This command automatically:
-- Detects all languages in the project by scanning for marker files
-- Runs language-specific tools for each detected language
-- Reports full output with file paths and line numbers
-- Returns zero exit code if all required tools pass
-
-### Step 2: Choose Your Flow
-
-**For pre-commit validation** (fastest):
-```bash
-python3 ~/.claude/skills/code-quality/universal-quality-gate/scripts/run_quality_gate.py --staged
-```
-Checks only git-staged files, enabling rapid feedback on recent changes.
-
-**For auto-fixing** (when issues are found):
-```bash
-python3 ~/.claude/skills/code-quality/universal-quality-gate/scripts/run_quality_gate.py --fix
-```
-Auto-corrects fixable issues (formatting, imports, etc.), then re-run Step 1 to verify.
-
-**For focused checking** (single language):
-```bash
-python3 ~/.claude/skills/code-quality/universal-quality-gate/scripts/run_quality_gate.py --lang python
-```
-Narrows scope when debugging language-specific issues.
-
-**For verbose details**:
-```bash
-python3 ~/.claude/skills/code-quality/universal-quality-gate/scripts/run_quality_gate.py -v
-```
-Shows expanded diagnostic output for troubleshooting.
-
-### Step 3: Interpret Results
-
-**PASSED output:**
-```
-============================================================
- Quality Gate: PASSED
-============================================================
-
-Languages: python, javascript
-Files: 15
-
-Tool Results:
-  [+] python/lint: passed
-  [+] python/format: passed
-  [-] python/typecheck: skipped (Optional tool not installed)
-  [+] javascript/lint: passed
-  [+] javascript/format: passed
-
-Quality gate passed: 4/5 tools OK (1 skipped)
-```
-Gate passes when all required tools succeed. Skipped optional tools do not block.
-
-**FAILED output:**
-```
-============================================================
- Quality Gate: FAILED
-============================================================
-
-Languages: python, go
-Files: 8
-
-Tool Results:
-  [X] python/lint: FAILED
-      hooks/example.py:42:1: F841 local variable 'x' is assigned but never used
-      hooks/example.py:56:1: F401 'os' imported but unused
-  [+] python/format: passed
-  [+] go/format: passed
-  [X] go/lint: FAILED
-      main.go:15:2: S1000: should use for range instead of for select
-
-Pattern Matches:
-  [WARNING] hooks/example.py:78: Silent exception handler - add explanatory comment
-
-Quality gate failed: 2 tool(s) reported issues, 1 error pattern(s)
-```
-Review marked failures [X] first. Pattern matches [WARNING] are informational.
-
-### Step 4: Resolve Issues
-
-**For auto-fixable issues:**
-1. Run `python3 ~/.claude/skills/code-quality/universal-quality-gate/scripts/run_quality_gate.py --fix`
-2. Review changes with `git diff` to verify correctness
-3. Re-run Step 1 to confirm all checks pass
-4. Commit with message documenting the fixes
-
-**For manual fixes:**
-1. Review each issue line-by-line in the output
-2. Edit files to correct the reported problems
-3. Re-run Step 1 to verify fixes
-4. Commit changes
-
-### Step 5: Commit
-
-Once quality gate passes with zero required-tool failures:
-1. Run project tests to catch logic regressions
-2. Commit with descriptive message
-3. Proceed to PR/merge workflow
-
----
-
-## Common Workflows
-
-**Pre-commit validation (fastest path):**
-```bash
-python3 ~/.claude/skills/code-quality/universal-quality-gate/scripts/run_quality_gate.py --staged
-# If fails → fix issues → re-run
-# If passes → git commit
-```
-
-**Full repo audit:**
-```bash
-python3 ~/.claude/skills/code-quality/universal-quality-gate/scripts/run_quality_gate.py
-# Review all findings by language
-# Fix by category: required failures → warnings → patterns
-# Re-run after each batch of fixes
-```
-
-**Language-specific validation:**
-```bash
-python3 ~/.claude/skills/code-quality/universal-quality-gate/scripts/run_quality_gate.py --lang python
-# Use when debugging a specific language's toolchain
-# Narrows output and speeds iteration
-```
-
----
-
-## Extending with New Languages
-
-To add language support without editing the script, modify the language registry:
-
-```json
-// hooks/lib/language_registry.json
-{
-  "new_language": {
-    "extensions": [".ext"],
-    "markers": ["config.file"],
-    "tools": {
-      "lint": {
-        "cmd": "linter {files}",
-        "fix_cmd": "linter --fix {files}",
-        "description": "Language linter",
-        "required": true
-      }
-    }
-  }
-}
-```
-
-The quality gate script automatically detects and uses new registry entries on next run.
-
----
-
-## Error Handling
-
-### Error: "No files to check"
-**Cause**: No changed files detected or no language markers found in project
-**Solution**:
-1. Verify you are in the correct project directory
-2. Check that marker files exist (go.mod, package.json, pyproject.toml, etc.)
-3. If checking staged files with `--staged`, ensure files are staged with `git add`
-4. For empty projects, this is expected behavior — add source files first
-
-### Error: "Tool not found" / "Required tool not installed"
-**Cause**: A required linter tool is not installed on the system
-**Solution**:
-1. Identify which tool is missing from the output (e.g., golangci-lint, ruff)
-2. Install the tool using your package manager:
-   - Python: `pip install ruff mypy bandit`
-   - Go: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
-   - JavaScript: `npm install --save-dev eslint biome`
-   - Rust: `cargo install clippy` (usually pre-installed with rustup)
-3. Re-run the quality gate to verify installation
-4. **Alternative**: Mark the tool as optional in `language_registry.json` if you cannot install it
-
-### Error: "Command timed out"
-**Cause**: Tool taking longer than 60-second timeout (usually large file sets or performance issues)
-**Solution**:
-1. Use `--staged` to check only changed files instead of the entire project
-2. Use `--lang` to check one language at a time
-3. Check for generated files or very large files causing slowdown — add them to .gitignore
-4. Verify your system has adequate disk I/O (slow disks can cause timeouts)
-
-### Error: "Configuration file conflict"
-**Cause**: Multiple conflicting linter configurations in the project (e.g., .eslintrc and biome.json)
-**Solution**:
-1. Check which tools the project actually uses (review package.json, go.mod, etc.)
-2. Identify the unused tool in `language_registry.json`
-3. Mark it as optional or disable it by removing it from the registry
-4. Consult the project's CLAUDE.md for tool preferences — project preferences override defaults
-5. Re-run to confirm conflict is resolved
-
-### Pattern Match Warnings (not failures)
-**Pattern Matches** like "Silent exception handler" or "Debug print" are informational warnings. They do not fail the gate. Review them and decide whether to fix:
-- `[WARNING]` entries identify failure modes but don't block commits
-- Use `--no-patterns` to skip pattern scanning if these are not relevant
-- Manually fix patterns that represent actual problems in your code
-
-### Graceful Degradation (Skipped Tools)
-When a tool is marked optional and not installed:
-- Tool appears as `[-] language/tool: skipped (Optional tool not installed)`
-- Gate still passes because the tool is not required
-- If you need that tool's checks, install it and re-run
-
----
-
-## Architecture
-
-```
-hooks/lib/
-  quality_gate.py        # Shared core library
-  language_registry.json # Language configurations
-
-skills/code-quality/universal-quality-gate/
-  SKILL.md               # This file
-  scripts/
-    run_quality_gate.py  # Skill entry point (thin wrapper)
-```
-
-This skill uses the shared quality gate library from `hooks/lib/` for on-demand code quality checking.
-
----
-
-## References
-
-**Multi-language linting**: Language configurations in `hooks/lib/language_registry.json`
-
-**Related skills**:
-- Use `code-linting` for single-language lint/format tasks
-- Use `systematic-code-review` for comprehensive code review beyond linting
-- Use `test-driven-development` for full validation with tests
-
-**Key principle**: Quality gates catch syntax and style issues. They do not replace:
-- Unit and integration tests (logic errors, race conditions)
-- Code review (architectural problems, API design)
-- Domain-specific validation (business logic, performance)
+When explicitly adding a language, extend `hooks/lib/language_registry.json` with `extensions`, `markers`, and `tools`; each tool declares `cmd`, optional `fix_cmd`, `description`, and `required`. The adapter reads the registry on the next run.

--- a/skills/process/verification-before-completion/SKILL.md
+++ b/skills/process/verification-before-completion/SKILL.md
@@ -3,10 +3,10 @@ name: verification-before-completion
 description: "Defense-in-depth verification before declaring any task complete."
 user-invocable: false
 success-criteria:
-  - "All tests pass (full suite, not just changed files)"
-  - "Build succeeds without errors or warnings"
+  - "Required and relevant tests pass"
+  - "Required build succeeds; new warnings reviewed"
   - "Changed files validated against task requirements"
-  - "No stub patterns (TODO, FIXME, pass, not implemented) in new code"
+  - "No unfinished implementations in requested work"
   - "Artifacts exist at expected paths (4-level verification)"
 allowed-tools:
   - Read
@@ -25,256 +25,45 @@ routing:
     - systematic-code-review
 ---
 
-# Verification Before Completion Skill
+# Verification before completion
 
-## Overview
-
-Enforce rigorous, adversarial verification before declaring any task complete. Implements defense-in-depth validation with multiple independent checks to catch errors before they reach users. The core principle: verify independently rather than trusting executor claims — verify what ACTUALLY exists in the codebase through testing, inspection, and data-flow tracing.
-
-This skill prevents the most common form of premature completion: claiming success without running tests, summarizing results instead of showing evidence, or trusting code that "looks right" without verification.
-
-## Reference Loading Table
-
-| Signal | Load These Files | Why |
-|---|---|---|
-| verifying artifacts are real and substantive, not stubs | `adversarial-methodology.md` | Loads detailed guidance from `adversarial-methodology.md`. |
-| checklist-driven work | `checklist.md` | Loads detailed guidance from `checklist.md`. |
-| diff touches migration files or schema definitions | `checklist.md` (Database Change Checklist → Schema Verification Gate) | Before/after schema state checks (SQLite, Django, Rails, raw SQL), duplicate-table/column check, existing-query compatibility check |
-| good-vs-bad verification walkthroughs: bug fix, refactor, migration, config change | `verification-examples.md` | Loads detailed guidance from `verification-examples.md`. |
-| maximum rigor, anti-rationalization enforcement, pressure resistance, gate checking patterns | `anti-rationalization-enforcement.md` | Domain-specific rationalization detection, 5-signal checklist, pressure resistance framework (from demoted with-anti-rationalization). |
+Verify the requested result using observed commands and actual artifacts. Match checks to the affected behavior and repository requirements.
 
 ## Instructions
 
-**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+1. Inspect `git status --short` and `git diff` to include modified, staged, and untracked files. Read the changed code; check imports, error handling, compatibility, and unintended edits.
+2. Run the repository's required tests, build, lint, and format checks. Start with relevant tests; run the full affected suite when required or when shared behavior changed. Do not substitute syntax checks for behavior tests.
+3. Check generated artifacts at their expected paths. For integrations, verify all four levels: **EXISTS** on disk, **SUBSTANTIVE** implementation, **WIRED** into callers, and real **DATA FLOWS** through it. Trace inputs and results; an unused file or hardcoded empty result is not a working feature.
+4. Inspect the diff for accidental debug code, secrets, placeholders, and unfinished work. Review matches in context: an intentional `pass` or empty result is not automatically a stub. Resolve missing implementations and wiring before claiming completion.
+5. Fix failures within the authorized task and rerun affected checks. A failed required build or test blocks a success claim. Do not repeat unchanged passing checks without a reason.
+6. Report commands, observed status, relevant counts, and remaining limitations. Retain full logs; include actionable failure excerpts and log paths instead of every passing test name. Distinguish automated checks, manual checks, and checks not run.
 
-### Step 1: Identify What Changed
+Use project commands first. Defaults when no project command exists:
 
-Before verification, understand the scope of changes:
-
-```bash
-# For git repositories
-git diff --name-only
-```
-
-**Why:** Use `git status --short` (not just `git diff`) to capture both modified AND untracked (new) files. New files created during the session are easy to miss in status summaries. Over-engineering prevention requires limiting scope to what was actually changed — limit verification to what was actually changed. Focus only on the specific changes made.
-
-For each changed file:
-- Read the file with the Read tool to validate the actual contents
-- Summarize what changed
-- Identify affected systems/modules and dependencies
-
-Report separately:
-- **New files**: [files with `??` or `A` status in git]
-- **Modified files**: [files with `M` status]
-
-### Step 2: Run Domain-Specific Tests
-
-Run the appropriate test suite and show **complete** output (not summaries):
-
-| Language | Test Command | Build Command | Lint Command |
-|----------|-------------|---------------|-------------|
+| Language | Tests | Build or syntax | Lint |
+|---|---|---|---|
 | Python | `pytest -v` | `python -m py_compile {files}` | `ruff check {files}` |
 | Go | `go test ./... -v -race` | `go build ./...` | `golangci-lint run ./...` |
 | JavaScript | `npm test` | `npm run build` | `npm run lint` |
 | TypeScript | `npm test` | `npx tsc --noEmit` | `npm run lint` |
 | Rust | `cargo test` | `cargo build` | `cargo clippy` |
 
-**Why full test suite, not just changed files**: ALWAYS run relevant tests before saying "done". The same agent that writes code has inherent bias toward believing its own output is correct. Running the full suite catches regressions and unintended side effects that focused testing misses.
+## Recovery
 
-**Output Requirements:**
-- Show COMPLETE test output (not "X tests passed")
-- Display all test names that ran
-- Show any warnings or deprecation notices
-- Include execution time
+- **No tests:** perform suitable manual checks and state the coverage gap. Add a regression test when the task warrants one; do not imply manual inspection proves behavior.
+- **Missing dependencies:** use the repository environment; report the missing tool and any narrower checks performed. Unrun checks are not passes.
+- **Build or test failure:** retain the failing command and diagnostic, identify the cause, fix it, and rerun. Separate unrelated failures with evidence.
+- **Missing wiring or data flow:** name the caller or call site where integration stops and repair it.
 
-**Critical constraint**: Show test output when reporting test results. Summary claims document what was SAID, not what IS. Evidence-based reporting is required.
+## Reference loading table
 
-### Step 3: Verify Build/Compilation
+Load only when the signal applies; files are under `references/`.
 
-Run the build command from the table above and show the full output. Confirm:
-- Build completes without errors
-- No new warnings introduced
-- Output artifacts are created (if applicable)
+| Signal | Reference | Purpose |
+|---|---|---|
+| Stub detection or integration evidence | `adversarial-methodology.md` | Four-level checks and goal-backward verification |
+| Domain checklist or database/schema change | `checklist.md` | Before/after schema, duplicate tables/columns, existing-query compatibility |
+| Verification walkthrough needed | `verification-examples.md` | Bug fix, refactor, migration, config examples |
+| Pressure to skip consequential checks | `anti-rationalization-enforcement.md` | Failure patterns and pressure checks |
 
-```bash
-# Example: Go project
-go build ./...
-
-# Example: Python - check syntax of changed files
-python -m py_compile path/to/changed_file.py
-
-# Example: JavaScript/TypeScript
-npm run build
-```
-
-**Critical gate**: If the build fails, stop immediately. Fix build issues before proceeding to any other verification step. A failed build is a blocker that supersedes all other checks. Re-run from Step 1 after fixing. This prevents declaring "done" when the code doesn't compile.
-
-### Step 4: Validate Changed Files
-
-For each changed file, use the Read tool to inspect the actual file contents. **Validate assumptions**: Re-read the file to confirm the actual contents — re-read the file to confirm. Verify that what you think happened actually happened.
-
-For each file verify:
-1. **Syntax** is correct (no unterminated strings, mismatched brackets)
-2. **Logic** makes sense (no inverted conditions, off-by-one errors)
-3. **Formatting** is consistent with surrounding code
-4. **Imports/dependencies** are present and correct
-5. **No leftover artifacts** (commented-out code, placeholder values, TODO markers)
-
-This step counteracts confirmation bias where executors believe their own edits are correct without evidence.
-
-### Step 5: Check for Unintended Changes
-
-```bash
-# Check git diff for unexpected changes
-git diff
-
-# Look for debug code that should be removed
-grep -r "console.log\|print(\|fmt.Println\|debugger\|pdb.set_trace" {changed_files}
-
-# Check for TODO/FIXME comments that should be resolved
-grep -r "TODO\|FIXME\|HACK\|XXX" {changed_files}
-
-# Verify no sensitive data
-grep -r "password\|secret\|api_key\|token" {changed_files}
-```
-
-**Why this matters**: If `git diff` shows changes to files you didn't intend to modify, investigate before proceeding. Unintended changes are a red flag for accidental side effects. Detecting this early prevents silent regressions that reach users.
-
-**Constraint**: No stub patterns (TODO, FIXME, pass, not implemented) should remain in new code created by the task.
-
-### Step 6: Review Verification Checklist
-
-**Core Verification (Required):**
-- [ ] Tests pass (actual output shown)
-- [ ] Build succeeds (actual output shown)
-- [ ] Changed files reviewed (Read tool used)
-- [ ] No unintended changes (diff checked)
-- [ ] No debug/console statements left
-- [ ] No sensitive data exposed
-
-**Extended Verification (Recommended):**
-- [ ] Documentation updated if needed
-- [ ] No new warnings introduced
-- [ ] Error handling adequate
-- [ ] Backwards compatibility maintained
-
-> See `references/checklist.md` for domain-specific checklists (Python, Go, JavaScript, Database, Infrastructure).
-
-### Step 7: Final Verification Statement
-
-**ONLY AFTER all checks pass, provide verification statement:**
-
-```
-Verification Complete
-
-**Tests Run:**
-{paste actual test output}
-
-**Build Status:**
-{paste actual build output}
-
-**Files Verified:**
-- {file1}: Reviewed, syntax valid, logic correct
-- {file2}: Reviewed, syntax valid, logic correct
-
-**Checklist Status:** X/X core checks passed
-
-Test if this addresses the issue.
-```
-
-**Critical constraints on communication:**
-- Show test output when reporting test results. Show complete verification output, not summaries.
-- Report verification results concisely without self-congratulation. Show command output rather than describing it.
-- Verify that what you think happened actually happened. Use Read tool on changed files, not memory.
-
-**Replace with:**
-- "Should be fixed now"
-- "This is working"
-- "All done"
-- "Tests pass" (without showing output)
-
-**ALWAYS say:**
-- "Test if this addresses the issue"
-- "Please verify the changes work for your use case"
-
----
-
-## 4-Level Adversarial Artifact Verification
-
-> See `references/adversarial-methodology.md` for the complete methodology: goal-backward framing, all four verification levels (EXISTS, SUBSTANTIVE, WIRED, DATA FLOWS), stub detection patterns with automated scan command, completion shortcut scan, verification report format, and the "when to apply each level" table.
-
-Steps 1-7 above verify that tests pass, builds succeed, and files contain what you expect. The adversarial methodology goes deeper: it verifies that artifacts are real implementations (not stubs), actually integrated (not orphaned), and processing real data (not hardcoded empties). Apply this methodology after Steps 1-7 pass, focusing on artifacts that are part of the stated goal.
-
-**Summary of levels:**
-- **L1 EXISTS**: File is present on disk (catches forgotten writes)
-- **L2 SUBSTANTIVE**: File contains real logic, not stubs (catches placeholder implementations)
-- **L3 WIRED**: Artifact is imported and used by other code (catches orphaned files)
-- **L4 DATA FLOWS**: Real data reaches the artifact and real results come out (catches dead integration)
-
-## Error Handling
-
-**Error: "Tests failed after changes"**
-- Resolve stubs before declaring task complete
-- Show full test failure output
-- Analyze what went wrong
-- Fix issues and re-run full verification
-
-**Error: "Build failed"**
-- Stop immediately
-- Show complete build error output
-- Fix build issues before proceeding
-- Re-run verification from Step 1
-
-**Error: "No tests exist for changed code"**
-- Acknowledge lack of test coverage
-- Recommend writing tests (but include only if user requests)
-- Perform extra manual validation
-- Document that changes are untested
-
-**Error: "Cannot run tests (missing dependencies)"**
-- Document what's missing
-- Attempt alternative verification (syntax checks, manual review)
-- Be explicit about verification limitations
-
-**Error: "Stub patterns detected in changed files"**
-- Review each match individually — some stubs are intentional (e.g., `return []` when empty list is the correct result)
-- For confirmed stubs: flag as blocker, resolve stubs before declaring task complete
-- For intentional patterns: document in verification report with rationale
-- If unsure: treat as stub (false positive is safer than false negative)
-
-**Error: "Artifact exists but is not wired (Level 3 failure)"**
-- Identify what should import/reference the artifact
-- Check if the wiring was planned but not executed (common in multi-step tasks)
-- Flag as blocker with specific guidance: "File X exists but is not imported by Y"
-
-**Error: "Data flow gap detected (Level 4 failure)"**
-- Trace the call chain to identify where real data stops flowing
-- Common cause: function called with hardcoded `[]` or `{}` instead of computed values
-- Flag as blocker: "Function X is called but receives empty data at call site Y"
-
-## References
-
-**Core Principles**
-- **Adversarial distrust**: Verify independently. The same agent that writes code has inherent bias toward believing its own output is correct. Structural distrust in the verification process counteracts this bias.
-- **Evidence over claims**: Summary claims document what was SAID, not what IS. Always show actual test output, build logs, and file contents. Verification without evidence is unverifiable.
-- **Goal-backward framing**: Derive verification conditions from what must be true for the goal, not from executor task lists. This prevents executors from confirming their own narrative.
-- **4-level artifact verification**: EXISTS → SUBSTANTIVE → WIRED → DATA FLOWS. Each level catches distinct classes of premature-completion failures.
-
-**Key Constraints (Integrated Above)**
-- Run tests before declaring completion
-- Show complete verification output (not summaries or "X tests passed")
-- Check all changed files using Read tool (not memory)
-- Show actual test output when reporting test results
-- Run full test suite for affected domain (not just changed files)
-- Flag any stub patterns as blockers — mark complete only after full verification
-- Build failures are gates that stop all other verification
-- Over-engineering prevention: only verify what was actually changed
-
-**Reference Files**
-- `references/adversarial-methodology.md` — 4-level verification system, stub detection, goal-backward framing
-- `references/checklist.md` — Domain-specific checklists (Python, Go, JS, Database, Infrastructure)
-- `references/verification-examples.md` — Good vs bad verification examples per language
-
-**Schema gate for review artifacts**
-
-When the artifact being verified is a code-review output, prefer a deterministic schema check over reading the prose for completeness: `python3 scripts/validate-review-output.py --type {systematic|parallel|sapcc-review|sapcc-audit} <file.md>` (exit 0 = valid, 1 = schema errors, 2 = unparseable, 3 = `jsonschema` not installed — `pip install jsonschema`). The parallel and systematic review skills wire this as a validate-on-return + retry-once-then-stop gate. This is the L1/L2 EXISTS/SUBSTANTIVE check for review documents: it confirms a verdict, severity buckets, and `file:line` locations are actually present, not just that a file was written.
+For code-review artifacts, use `python3 scripts/validate-review-output.py --type {systematic|parallel|sapcc-review|sapcc-audit} <file.md>`. Exit codes: 0 valid, 1 schema errors, 2 unparseable, 3 missing `jsonschema` (`pip install jsonschema`). Systematic and parallel review validate on return and retry once before stopping. A valid schema verifies structure, not the truth of review findings.

--- a/skills/testing/vitest-runner/SKILL.md
+++ b/skills/testing/vitest-runner/SKILL.md
@@ -21,127 +21,29 @@ routing:
     - e2e-testing
 ---
 
-# Vitest Test Runner Skill
+# Vitest runner
 
-## Overview
+Run existing Vitest tests and report results. A check-only request does not authorize changing tests, assertions, dependencies, or configuration.
 
-This skill runs Vitest tests and parses results into actionable reports. It executes tests in non-interactive mode, extracts failure details (test name, assertion error, stack trace), and organizes results by test file with timing information. Use this skill when tests need to run and results need structured, complete reporting—not when tests need installation, creation, modification, or auto-fixing.
+## Run
 
----
+Read repository instructions and package scripts. Check `package.json`, `vitest.config.*`, and `vite.config.*` to confirm Vitest and its test configuration. Use the installed project version; avoid implicit npx downloads. If Vitest is unavailable, report setup needed rather than installing it.
 
-## Instructions
+Use the repository test command or these defaults. Always use `run`; bare `vitest` can enter watch mode.
 
-### Step 1: Verify Vitest Project
+| Scope | Command |
+|---|---|
+| Whole configured suite | `npx vitest run --reporter=verbose 2>&1` |
+| File or directory | `npx vitest run path/to/test.ts 2>&1` |
+| Test-name pattern | `npx vitest run -t "pattern" 2>&1` |
+| Requested coverage | `npx vitest run --coverage 2>&1` |
 
-Before running tests, confirm Vitest is installed and configured. Why: Running tests in a non-Vitest project wastes time and produces misleading results. This skill is designed only for Vitest—not Jest, Mocha, or Playwright.
+Capture the process exit code and full output. Report pass/fail, checked scope, passed/failed/skipped counts, and duration. For failures retain the file, full test name, assertion difference, and relevant stack location. Keep complete logs available; show useful excerpts instead of every passing test. Nonzero exit is failure, including discovery or tool failures; partial output is not a passing run.
 
-Verify vitest is available:
+## Recovery
 
-```bash
-# Check for vitest configuration
-ls vitest.config.* vite.config.* 2>/dev/null
-grep -q "vitest" package.json && echo "vitest found in package.json"
-```
-
-If no vitest configuration found, stop and inform the user. Do not attempt to install dependencies or configure Vitest—that is outside this skill's scope.
-
-### Step 2: Run Tests in Non-Interactive Mode
-
-Execute Vitest using the `run` subcommand (not bare `npx vitest`, which starts interactive watch mode and will never complete in a non-interactive shell). Why: Watch mode is interactive and incompatible with automation. The `run` mode executes all tests once and exits with a status code reflecting pass/fail.
-
-Default execution:
-
-```bash
-npx vitest run --reporter=verbose 2>&1
-```
-
-For specific files or patterns (optional behavior):
-
-```bash
-npx vitest run path/to/test.ts 2>&1
-npx vitest run --grep "pattern" 2>&1
-```
-
-For coverage reporting (when user requests coverage):
-
-```bash
-npx vitest run --coverage 2>&1
-```
-
-### Step 3: Respect Exit Codes and Parse Complete Output
-
-Capture the full exit code and output. Why: The exit code is the source of truth for pass/fail—code 0 = pass, nonzero = fail. Never assume tests passed based on partial output. Show all failures completely, including test names, assertion errors, and stack traces. Hiding failures prevents users from fixing them.
-
-Extract for each test:
-- **Test file**: Path to the test file
-- **Test name**: Full test path (describe > it)
-- **Status**: PASS / FAIL / SKIP
-- **Duration**: Time taken
-- **Error detail**: Complete assertion error and stack trace for failures (do not abbreviate)
-
-### Step 4: Format Results as Structured Report
-
-Present output in a format that groups failures by test file and includes complete error details. Why: Users need to see which tests failed, why they failed, and where in the code the assertions failed—this prevents wasted debugging time.
-
-Example format:
-
-```
-=== Vitest Test Results ===
-
-Status: PASS / FAIL (X passed, Y failed, Z skipped)
-
-Failures:
----------
-FAIL src/utils/__tests__/helpers.test.ts > parseData > handles null input
-  AssertionError: expected null to equal { data: [] }
-  - Expected: { data: [] }
-  + Received: null
-  at src/utils/__tests__/helpers.test.ts:25:10
-
-Summary:
---------
-Test Files: 12 passed, 2 failed (14 total)
-Tests:      45 passed, 3 failed, 2 skipped (50 total)
-Duration:   4.23s
-```
-
----
-
-## Error Handling
-
-### Error: "Cannot find vitest"
-Cause: Vitest not installed or node_modules missing
-Constraint: This skill does not install dependencies; it assumes a fully configured Vitest project.
-Solution: Advise user to check `grep vitest package.json` for presence, then run `npm install` or `npm install -D vitest`. After installation, re-run this skill.
-
-### Error: "No test files found"
-Cause: Test file patterns don't match vitest.config include/exclude globs
-Constraint: Test discovery is driven by Vitest's configuration; this skill does not modify vitest.config.ts.
-Solution: Verify test files exist with correct naming (*.test.ts, *.spec.ts, *.test.js, etc.) and match the patterns in vitest.config include/exclude. Show user the vitest.config.ts to help them debug the mismatch.
-
-### Error: "Test environment not found"
-Cause: Missing jsdom or happy-dom dependency for DOM tests
-Constraint: This skill does not install dependencies or modify configurations.
-Solution: Check vitest.config.ts environment setting (likely `environment: 'jsdom'` or `'happy-dom'`). Advise user to install the required devDependency: `npm install -D jsdom` or `npm install -D happy-dom`, or `@testing-library/jest-dom` for additional matchers.
-
-### Error: "Out of memory" (large test suites)
-Cause: Too many tests running in shared thread pool
-Constraint: This skill runs all tests in the suite; it does not pre-filter by complexity.
-Solution: When memory errors occur, advise user to split test execution: run tests in batches by directory (e.g., `npx vitest run src/unit/`), use `--pool=forks` for memory isolation, or use `--shard=1/N` to split the suite across N shards. The user controls which tests to run; this skill respects that choice.
-
----
-
-## References
-
-- [Verification Checklist](../shared-patterns/verification-checklist.md) - Pre-completion checks
-- [Anti-Rationalization](../shared-patterns/anti-rationalization-core.md) - Prevents shortcut rationalizations
-
-### Key Constraints (Inline with Workflow)
-
-**Constraint: Do not auto-fix tests.** This skill's role is to report test failures completely, not to fix them. The test may be correct and the implementation wrong—only the user knows. Changing test assertions to make them pass would hide real bugs and violate the skill's scope.
-
-**Constraint: Always use `npx vitest run`, not bare `npx vitest`.** Watch mode is interactive and incompatible with non-interactive execution. The skill must use `run` mode to ensure tests execute once and exit with a status code.
-
-**Constraint: Show all failures completely.** Reporting "3 tests failed" without showing which tests or why wastes user time. Stack traces, assertion details, and test names are essential for debugging. Never abbreviate failure output.
-
-**Constraint: Respect exit codes as source of truth.** The process exit code (0 = pass, nonzero = fail) is the definitive signal. Do not rely on partial output or assumptions about test results.
+- **Vitest missing/node_modules absent:** inspect dependencies. Setup may require `npm install` or `npm install -D vitest`; use the repository package manager during authorized setup.
+- **No test files:** check file naming (`*.test.ts`, `*.spec.ts`, `*.test.js`) and configured include/exclude globs. Report discovery failure; do not change config to mask it.
+- **Missing DOM environment:** inspect `environment` for `jsdom` or `happy-dom`. Suggest the matching devDependency (`npm install -D jsdom` or `npm install -D happy-dom`); `@testing-library/jest-dom` adds matchers, not an environment.
+- **Out of memory:** diagnose with directory batches such as `npx vitest run src/unit/`, `--pool=forks`, or `--shard=1/N` when supported by the installed version. A full-suite claim requires all batches/shards; a diagnostic subset is not full verification.
+- **Failing assertions:** report the mismatch. When fixing is authorized, determine whether implementation or test is wrong; never weaken assertions merely to make the run green.


### PR DESCRIPTION
## Summary
Cut six overlapping verification skills from 7,428 to 2,850 words (62%). Keep practical checks and diagnostics while removing repeated lectures and demands to paste every passing test.

## Changes
- Preserve skill names, routing, tool commands, configuration discovery, recovery steps, and deep references.
- Match completion checks to affected behavior and repository requirements; retain integration and data-flow verification.
- Report concise observed results with full logs available, and distinguish failures, skips, and reduced coverage.
- Keep required tools required; avoid implicit dependency installs and configuration changes during check-only tasks.

## Notes
Direct content review replaces model A/B testing for this change, as requested. No measured runtime token or behavioral improvement is claimed.
