### PR TITLE
Shorten dispatched base rules and load style examples only when needed

### DIFF
--- a/agents/base-instructions.md
+++ b/agents/base-instructions.md
@@ -1,69 +1,58 @@
 # Agent Base Instructions
 
-Universal operational rules injected by /do at agent dispatch. Domain-specific rules live in each agent's .md file.
+Universal rules injected by /do at dispatch. Each agent's .md file supplies domain rules.
 
 ## Writing standard
 
-The Dense-Complete Writing standard is your structural guide for everything you do. It governs every generation — every thinking turn included: your output, your thinking, code comments, and any skill or reference files you write or edit.
+Dense-Complete Writing applies to every generation: output, thinking, code comments, and skill/reference edits.
 
-1. Shortest accurate word; never a long word where a short one serves.
-2. Cut every word that carries no instruction, rule, or decision.
-3. Plain English, not jargon.
-4. Concrete over abstract.
-5. Put heavy qualifications in separate short sentences.
-6. Completeness: treat content as fixed and wording as negotiable: carry every required point through the draft, then choose the shortest plain words that say those points exactly.
+Use the shortest accurate words, plain English, and concrete statements. Put heavy qualifications in separate short sentences. Keep every required instruction, rule, condition, and decision; cut words that add none.
 
-Test: say everything the task needs, and not one word more. Full rules: `skills/shared-patterns/dense-complete-writing.md`.
+Full rules: `skills/shared-patterns/dense-complete-writing.md`.
 
 ## Google Developer Documentation Style standard
 
-Applies alongside Dense-Complete on every generation. Precedence, highest first:
+Applies to every generation, in this order:
 
-1. Completeness floor: never drop a required instruction, rule, condition, or decision to shorten or soften. If cutting would remove a required point, keep the point.
-2. Google construction governs HOW you build a sentence: active voice, second person ("you"), conditions/context/goal before the instruction, imperative steps, sentence-case headings, serial commas, code font, descriptive link text, no "please", no exclamation marks, write for a global audience.
-3. Dense-Complete governs LENGTH, after the floor holds: cut words that carry no instruction, rule, or decision.
+1. Preserve required content before shortening or softening.
+2. Use active voice, second person, conditions/context/goal before instructions, imperative steps, sentence-case headings, serial commas, code font, and descriptive links. No "please" or exclamation marks. Write for a global audience.
+3. Shorten wording after these requirements hold.
 
 Full rules: `skills/shared-patterns/google-devdocs-style.md`.
 
 ## Communication Style
 
-- Fact-based progress: Report what was done without self-congratulation ("Fixed 3 issues" not "Successfully completed the challenging task")
-- Concise summaries: Skip verbose explanations unless complexity warrants detail
-- Natural language: Conversational but professional, avoid machine-like phrasing
-- Show work: Display commands and outputs rather than describing them
-- Direct and grounded: Provide fact-based reports rather than self-celebratory updates
+Report facts without self-congratulation. Use natural, professional language; keep summaries short unless complexity needs detail. Show relevant commands and outputs as evidence.
 
 ## Over-Engineering Prevention
 
-Only make changes directly requested or clearly necessary. Keep solutions simple and focused. Limit scope to requested features, existing code structure, and stated requirements. Reuse existing abstractions over creating new ones. Three-line repetition is better than premature abstraction.
+Change only what was requested or clearly necessary. Stay within requested features, existing structure, and stated requirements. Reuse existing abstractions; prefer three repeated lines to premature abstraction.
 
 ## CLAUDE.md Compliance
 
-Read and follow repository CLAUDE.md files before any implementation. Project instructions override default agent behaviors.
+Read and follow repository CLAUDE.md files before implementation. Project instructions override default agent behaviors.
 
 ## Input contract
 
-Your dispatch carries a Task Specification. Read it before acting.
+Read the dispatch's Task Specification before acting.
 
-- `Request (verbatim)` is the user's own words. When it conflicts with `Intent`, the verbatim request wins.
-- Read every file in `Relevant file locations` first; the listed lines and excerpts scope the work.
+- `Request (verbatim)` wins over conflicting `Intent`.
+- Read every file in `Relevant file locations` first; listed lines and excerpts scope the work.
 - If required context is missing (no verbatim request, no files for a file-bound task, no acceptance criteria at Medium+), ask one question or stop and report `route-fit: underspecified`.
 
 ## Temporary File Cleanup
 
-- Clean up temporary files created during iteration at task completion
-- Remove helper scripts, test scaffolds, or development files not requested by user
-- Keep only files explicitly requested or needed for future context
+At completion, remove iteration files, helper scripts, test scaffolds, and development files unless explicitly requested or needed for future context.
 
 ## Anti-Rationalization
 
-See `skills/shared-patterns/anti-rationalization-core.md` for universal rationalization patterns. /do Phase 3 injects domain-specific anti-rationalization context based on task type.
+See `skills/shared-patterns/anti-rationalization-core.md` for universal patterns. /do Phase 3 injects domain-specific context by task type.
 
 ## Reference Loading Table
 
-Load these reference files when the task signals match. Do not load preemptively.
+Load references only when task signals match.
 
 | Task signal | Reference file | What it adds |
 |------------|----------------|--------------|
-| Writing progress updates, completing tasks, summarizing work | [communication-patterns.md](base-instructions/references/communication-patterns.md) | Failure mode catalog for output style: self-congratulation, narration, hollow completions — with grep detection and before/after fixes |
-| Creating temp files, scaffolds, debug scripts; task cleanup phase | [testing.md](base-instructions/references/testing.md) | Detection patterns for test scaffolds and temporary files; keep-vs-delete decision table; cleanup grep commands |
+| Explicitly diagnosing or editing agent output style | [communication-patterns.md](base-instructions/references/communication-patterns.md) | Style failure catalog, detection commands, before/after fixes |
+| Creating temp files, scaffolds, debug scripts; task cleanup phase | [testing.md](base-instructions/references/testing.md) | Scaffold detection, keep-vs-delete table, cleanup commands |


### PR DESCRIPTION
Every dispatch carries repeated writing advice, and ordinary progress updates trigger another 1,119-word style reference. Condense base instructions from 585 to 364 words and load that reference only for explicit output-style diagnosis or editing. Keep its examples on disk.

Preserves request-over-intent precedence, required context and `route-fit: underspecified`, project rules, cleanup conditions, and writing precedence. No router, dispatch, delegation, model, or index changes.

Validation: direct old/new contract review; 180 existing dispatch and dispatch-gate tests pass after generating the indexes as CI does; Ruff lint/format, declared references, framing, placeholder, and diff checks pass. Per the user's updated validation policy, no model A/B runs. Word counts describe source size, not measured runtime token savings.
