### PR TITLE
refactor: simplify quick task procedure

### DIFF
--- a/skills/process/quick/SKILL.md
+++ b/skills/process/quick/SKILL.md
@@ -75,7 +75,7 @@ All flags default off. Combine discussion, research, and verification as needed.
 
 Read repository `CLAUDE.md` unless already loaded and current. Parse flags; the remaining text is the task. Follow existing authorization and repository constraints throughout.
 
-Before editing, check the branch. Never let `--trivial` or `--no-branch` bypass branch safety. For trivial work on main/master, create `quick/<brief-description>`; for standard work, create `quick/<task-id>-<brief-kebab-description>` unless `--no-branch` is allowed. Preserve unrelated changes.
+Check the branch during setup. Never let `--trivial` or `--no-branch` bypass branch safety. For trivial work on main/master, create `quick/<brief-description>`; for standard work, create `quick/<task-id>-<brief-kebab-description>` after assigning the ID in step 2 and before editing, unless `--no-branch` is allowed. Preserve unrelated changes.
 
 ## Trivial mode
 

--- a/skills/process/quick/SKILL.md
+++ b/skills/process/quick/SKILL.md
@@ -46,223 +46,78 @@ routing:
   category: process
 ---
 
-# /quick - Tracked Lightweight Execution
+# /quick
 
-Quick covers the full lightweight tier from zero-ceremony inline fixes (≤3 edits, `--trivial` mode) through contained multi-file changes. Full-ceremony Simple+ tasks (task_plan.md, agent routing, quality gates) belong in `/do`. The key design principle is **composable rigor**: the base mode is minimal (plan + execute), and users add process incrementally via flags.
+Make contained changes in one execution thread. Use `/do` for multiple components, architectural changes, or parallel work. Keep plans inline; do not create `task_plan.md`.
 
-**Flags** (all OFF by default):
+## Flags
+
+All flags default off. Combine discussion, research, and verification as needed.
 
 | Flag | Effect |
-|------|--------|
-| `--trivial` | Zero-ceremony inline mode for ≤3 file edits: no plan display, no branch, direct commit. Scope-gates strictly — escalates automatically if the task needs more than 3 edits. Use for typo fixes, one-line constant changes, renaming a variable, fixing an import. |
-| `--discuss` | Add a pre-planning discussion phase to resolve ambiguities (breadth-first — surfaces all gray areas at once) |
-| `--interview` | Add a depth-first decision-tree interview before the edit phase. One question at a time with a recommendation per question. Sibling to `--discuss` — pick `--interview` when decisions are interdependent and answer A constrains valid options for B. |
-| `--research` | Add a research phase before planning to build context on unfamiliar code |
-| `--full` | Add plan verification + full quality gates (tests, lint, diff review) |
-| `--no-branch` | Skip feature branch creation, work on current branch |
-| `--no-commit` | Skip the commit step (for batching multiple quick tasks) |
+|---|---|
+| `--trivial` | Mechanical fix: at most 3 edits across at most 3 files; no displayed plan, task ID, or subagents. |
+| `--discuss` | Resolve independent ambiguities together before planning. |
+| `--interview` | Resolve dependent decisions one question at a time, with a recommendation. |
+| `--research` | Investigate unfamiliar code before planning. |
+| `--full` | Verify the plan, then run affected tests, configured lint, and diff review. |
+| `--no-branch` | Stay on the current branch if repository branch rules permit it. |
+| `--no-commit` | Leave edits uncommitted, including in trivial mode. |
 
 ## Reference Loading Table
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| usage examples, task ID format, error handling | `examples.md` | Loads detailed guidance from `examples.md`. |
-| emitting banners, commit format, or STATE.md entries | `templates.md` | Loads detailed guidance from `templates.md`. |
+| usage examples, task ID format, error handling | `examples.md` | Examples and recovery. |
+| emitting banners, commit format, or STATE.md entries | `templates.md` | Output and tracking contracts. |
 
-## Instructions
+## Setup
 
-### Phase --trivial: INLINE EXECUTION (only with --trivial flag)
+Read repository `CLAUDE.md` unless already loaded and current. Parse flags; the remaining text is the task. Follow existing authorization and repository constraints throughout.
 
-When `--trivial` is passed (or the router recognises a clearly one-line mechanical change), execute inline without plan display, without a feature branch, and without spawning subagents — because the overhead of those steps dwarfs the actual work.
+Before editing, check the branch. Never let `--trivial` or `--no-branch` bypass branch safety. For trivial work on main/master, create `quick/<brief-description>`; for standard work, create `quick/<task-id>-<brief-kebab-description>` unless `--no-branch` is allowed. Preserve unrelated changes.
 
-**Step 1: Read CLAUDE.md**
+## Trivial mode
 
-Read repository CLAUDE.md before any edit, because repo-specific constraints affect how even trivial changes should be made.
+Use for `--trivial` or a clearly mechanical one-line change identified by the router.
 
-**Step 2: Scope check**
+1. Read the targets and check scope. Investigation or unfamiliar behavior requires `/quick --research`; more than 3 files, new package imports, or dependency-file changes require standard `/quick`. For ambiguity, ask one clarifying question; if unresolved, use `/quick --discuss`.
+2. Edit directly and count edits. If more than 3 are needed, preserve completed work and continue standard `/quick`. Explain the scope change and carry forward the original request and completed edits.
+3. Review the diff and run applicable repository checks. Stage only intended files with `git add <specific-files>` and commit using `references/templates.md`, unless `--no-commit` applies.
+4. Emit the trivial summary and stop. Report an omitted commit as skipped, never as successful.
 
-| Question | If Yes |
-|----------|--------|
-| Does this need reading docs, investigating behavior, or understanding unfamiliar code? | Drop `--trivial`, redirect to `/quick --research` |
-| Does this touch more than 3 files? | Drop `--trivial`, redirect to standard `/quick` |
-| Does this add imports from new packages or modify dependency files? | Drop `--trivial`, redirect to standard `/quick` |
-| Is the request ambiguous or underspecified? | Ask one clarifying question; if still ambiguous after one round, drop `--trivial` and use `/quick --discuss` |
+## Standard procedure
 
-If redirecting, say: `This task exceeds --trivial scope ([reason]). Continuing as /quick.` Then proceed to Phase 0 with the original request.
+### 1. Resolve decisions and investigate
 
-**Step 3: Locate target files and execute**
+Use discussion for `--discuss` or material uncertainty about the requested change, approach, or acceptance criteria. Batch independent questions using the DISCUSS template. Wait for answers needed to proceed; do not ask again about decisions or actions already authorized.
 
-Read the target file(s). Make edits using the Edit tool. Track edit count. After each edit, check: have we hit 3 edits? If more are needed, stop -- do not rationalize "just one more edit." Say: "Scope exceeded during --trivial execution (3+ edits needed). Preserving work done. Continuing as /quick." Hand off to the standard quick phases with context about what was already done.
+For `--interview`, load `planning/references/depth-first-interview.md`. The explicit flag skips its opt-out question. Follow PRIME → ENUMERATE BRANCHES → TRAVERSE → COMPILE OUTPUT, with at most 5 questions and 3 recursion levels per branch. Keep Resolved Decisions / Carried Forward / Scope Boundary / Mode Used inline for the plan.
 
-**Step 4: Check branch**
+For `--research` or unfamiliar code, read relevant source, tests, and configuration. Establish current behavior, where the change fits, and what could break. Summarize findings and their effect on the plan in 3–5 lines.
 
-If on main/master, create a short-lived branch: `git checkout -b quick/<brief-description>`.
+### 2. Plan and assign an ID
 
-**Step 5: Stage and commit**
-
-Stage specific files with `git add <specific-files>`. Commit using the format from `references/templates.md` (conventional commit, type usually `fix:`, `chore:`, or `refactor:`).
-
-**Step 6: Display summary**
-
-Use the `--trivial` summary banner format from `references/templates.md`.
-
-**GATE**: Edit count is 1-3, commit succeeded. STOP — do not proceed to Phase 0.
-
----
-
-### Phase 0: SETUP
-
-**Step 1: Read CLAUDE.md**
-
-Read and follow the repository's CLAUDE.md before doing anything else, because repo-specific conventions override defaults and skipping this causes style/tooling mismatches.
-
-**Step 2: Parse flags**
-
-Extract `--discuss`, `--interview`, `--research`, `--full`, `--no-branch`, and `--no-commit` from the invocation. Everything remaining after flag extraction is the task description.
-
-**Step 3: Scope check**
-
-If the task involves multiple components, architectural changes, or needs parallel execution, redirect to `/do` instead because quick tasks are single-threaded by design -- parallelism means the task has outgrown this tier.
-
-### Phase 1: DISCUSS (only with --discuss flag)
-
-This phase activates when the user passes `--discuss` or the request contains signals of uncertainty ("not sure", "maybe", "could be", "what do you think").
-
-**Step 1: Identify ambiguities**
-
-Read the request and list specific questions:
-- What exactly should change? (if underspecified)
-- Which approach among alternatives? (if multiple valid paths)
-- What are the acceptance criteria? (if success is unclear)
-
-**Step 2: Present questions**
-
-Use the DISCUSS banner format from `references/templates.md`. Wait for user response. Do not proceed until ambiguities are resolved.
-
-**GATE**: All ambiguities resolved. Proceed to Phase 2 or Phase 3.
-
-### Phase 1.5: INTERVIEW (only with --interview flag)
-
-This phase activates when the user passes `--interview`. It is the depth-first sibling to `--discuss` — pick this mode when decisions are interdependent and answering A would change the valid options for B, so batch-asking forces premature commitments.
-
-**Step 1: Load the depth-first reference**
-
-Load `planning/references/depth-first-interview.md` and follow its phases (PRIME → ENUMERATE BRANCHES → TRAVERSE → COMPILE OUTPUT). The reference enforces a hard cap of 5 total questions and 3-level recursion per branch — these limits are infrastructure, not advisory.
-
-**Step 2: Treat `--interview` as an explicit trigger**
-
-Per the reference's Phase 0 trigger classification, `/quick --interview` is an explicit invocation. Skip the Phase 0 opt-out question — the user already opted in by passing the flag. Go directly to ENUMERATE BRANCHES.
-
-**Step 3: Compile output to inline context**
-
-The reference's Phase 3 emits a structured block (Resolved Decisions / Carried Forward / Scope Boundary / Mode Used). Keep this block inline as the discussion artifact and use it to inform Phase 3 PLAN. Do not write a separate `task_plan.md` for `/quick` tier.
-
-**GATE**: Interview output emitted. Resolved decisions inform the inline plan. Proceed to Phase 2 or Phase 3.
-
-### Phase 2: RESEARCH (only with --research flag)
-
-This phase activates when the user passes `--research` or the task touches code that needs investigation. Use `--research` when touching unfamiliar code because confidence about code behavior is not the same as correctness — `--trivial` exists for when you truly know.
-
-**Step 1: Identify scope**
-
-Determine which files and patterns need reading to understand the change.
-
-**Step 2: Read and analyze**
-
-Read relevant source files, tests, and configuration. Build a mental model of:
-- Current behavior
-- Where the change fits
-- What might break
-
-**Step 3: Summarize findings**
-
-Present a brief (3-5 line) summary of what you learned and how it affects the plan.
-
-**GATE**: Sufficient understanding to plan the change. Proceed to Phase 3.
-
-### Phase 3: PLAN
-
-**Step 1: Generate task ID**
-
-Assign the task ID now, not later, because untracked tasks become invisible and "later" never comes.
-
-Format: `YYMMDD-xxx` where xxx is Base36 sequential (0-9, a-z).
+Use `YYMMDD-xxx`, with a Base36 sequence: `001` through `009`, `00a` through `00z`, then `010`.
 
 ```bash
-# Check STATE.md for today's tasks to determine next sequence
 date_prefix=$(date +%y%m%d)
 ```
 
-If STATE.md exists in the repo root, find the highest sequence number for today's date prefix and increment. If no tasks today, start at `001`. Use Base36 for the sequence: 001, 002, ... 009, 00a, 00b, ... 00z, 010, ...
+Increment today's highest sequence in root `STATE.md`, starting at `001` if absent. If corrupted, recover the sequence from git log entries matching `Quick task YYMMDD-`. Increment again on branch-name collision.
 
-If STATE.md is corrupted, scan git log for `Quick task YYMMDD-` patterns to find the true next ID. If a branch name collision occurs, increment the sequence number and try again.
+Display the inline plan from `references/templates.md`: intended edits, files, rationale, and estimated edit count. Create the branch under the setup rules. With `--full`, verify that the plan meets acceptance criteria before editing. Recommend `--full` for security, payments, or data migration.
 
-**Step 2: Create inline plan**
+### 3. Execute and watch scope
 
-Always display the inline plan, even for obvious tasks, because the plan catches misunderstandings before they become wrong edits and confirms alignment in 10 seconds that saves minutes. Use the inline plan banner instead of writing a `task_plan.md` file; that keeps the workflow in the Simple+ tier and preserves the minimum viable ceremony.
+Make the planned edits and track their count. Above 15 estimated edits, suggest `/do`. Warn at 10 actual edits and reassess at 15. These standard-mode thresholds are advisory; continue within established authorization when the work remains contained. Ask only when a scope decision is unresolved. Trivial mode's 3-edit limit remains strict.
 
-Use the inline plan banner format from `references/templates.md`.
+For base verification, run an appropriate syntax/build check, such as `python3 -m py_compile <files>`, `go build ./...`, or `tsc --noEmit`, plus required repository checks.
 
-If estimated edits exceed 15, prompt the user to consider `/do` -- edit count is a scope signal regardless of difficulty.
+With `--full`, run tests for affected packages/modules, configured lint on changed files, and `git diff` review for unintended changes, missing error handling, and broken imports. Run the full suite when required by the repository or requested by the user. Fix relevant failures before claiming completion; report unrelated blockers accurately.
 
-If the task involves security, payments, or data migration, recommend `--full` because a one-line auth change can be catastrophic and risk is about impact, not size.
+### 4. Commit and log
 
-**Step 3: Create feature branch** (unless --no-branch)
+Unless `--no-commit`, stage specific intended files with `git add <specific-files>`, use the conventional commit format from `references/templates.md`, and include `Quick task <task-id>` in the body. Verify with `git log -1 --oneline`.
 
-Create a feature branch because small changes on main break the same as big ones:
-
-```bash
-git checkout -b quick/<task-id>-<brief-kebab-description>
-```
-
-If already on a non-main feature branch and `--no-branch` is set, stay on the current branch.
-
-**GATE**: Task ID assigned, plan displayed, branch created. Proceed to Phase 4.
-
-### Phase 4: EXECUTE
-
-**Step 1: Make edits**
-
-Execute the changes described in the plan. Track edit count throughout.
-
-**Step 2: Scope monitoring**
-
-- At 10 edits: display a warning -- "10 edits reached. Quick tasks typically stay under 15."
-- At 15 edits: suggest upgrade -- "15 edits reached. This may benefit from /do with full planning. Continue? [Y/n]"
-- No hard cap -- the user decides. Quick's scope is advisory, not enforced like Fast's 3-edit gate.
-
-**Step 3: Verify changes** (base mode)
-
-Run a language-appropriate syntax check on edited files (e.g., `python3 -m py_compile`, `go build ./...`, `tsc --noEmit`). If `--full` flag is set, run the full quality gate instead (see Phase 5).
-
-**GATE**: All planned edits complete. Sanity check passes.
-
-### Phase 5: VERIFY (only with --full flag)
-
-**Step 1: Run tests** for affected packages/modules only -- do not run the full suite unless explicitly requested.
-
-**Step 2: Lint check** using the repo's configured linter on changed files.
-
-**Step 3: Review changes** with `git diff`. Check for unintended changes, missing error handling, and broken imports.
-
-**GATE**: Tests pass, lint clean, diff reviewed. Proceed to Phase 6.
-
-### Phase 6: COMMIT (skip with --no-commit)
-
-Stage specific files with `git add <specific-files>` -- not `git add .`, to avoid accidental inclusions. Commit using the format from `references/templates.md`. Include the task ID in the commit body for traceability.
-
-**GATE**: Commit succeeded. Verify with `git log -1 --oneline`.
-
-### Phase 7: LOG
-
-**Step 1: Update STATE.md**
-
-Log the task to STATE.md because this is how tasks stay visible and cross-referenceable. Use the STATE.md schema from `references/templates.md` to create the file if it does not exist, and append one row per task. If escalated from `--trivial`, use tier `trivial->quick`.
-
-**Step 2: Display summary**
-
-Use the completion banner format from `references/templates.md`.
-
-## Reference Material
-
-> See `references/examples.md` for worked examples per flag mode, task ID format, and error handling.
+Create or append to root `STATE.md` using the reference schema. Use tier `trivial->quick` after escalation; otherwise `quick`. Record skipped commits explicitly. Emit the completion summary with changes, checks, commit or skipped status, branch, flags, and log location. Continue any already-authorized delivery steps.

--- a/skills/process/quick/references/examples.md
+++ b/skills/process/quick/references/examples.md
@@ -45,8 +45,8 @@ Full ID: `YYMMDD-xxx` (e.g., `260322-001`, `260322-00a`)
 **Solution**: Increment the sequence number. If STATE.md is corrupted, scan git log for `Quick task YYMMDD-` patterns to find the true next ID.
 
 ### Error: Scope Exceeds Quick Tier
-**Cause**: Task requires 15+ edits, multiple components, or parallel work
-**Solution**: Display upgrade suggestion. If user confirms, continue in quick mode. If user wants full ceremony, invoke `/do` with the original request.
+**Cause**: Task grows beyond the contained, single-threaded tier.
+**Solution**: Use `/do` for multiple components, architectural changes, or parallel work. More than 15 edits alone is advisory: suggest an upgrade and continue within existing authorization if the task remains contained.
 
 ### Error: Test Failure in --full Mode
 **Cause**: Quality gate found issues with the changes

--- a/skills/process/quick/references/templates.md
+++ b/skills/process/quick/references/templates.md
@@ -56,8 +56,8 @@ Banner and STATE.md templates used across phases.
 
 Upgrade prompt when estimated edits exceed 15:
 ```
-This task estimates 15+ edits. Consider using /do for full planning
-and agent routing. Proceed with /quick anyway? [Y/n]
+This task estimates more than 15 edits. Consider /do if the work
+needs multiple components, architecture changes, or parallel execution.
 ```
 
 ---
@@ -120,3 +120,5 @@ If escalated from `--trivial`, use tier `trivial->quick`.
 
 ===================================================================
 ```
+
+For `--no-commit`, replace commit hashes with `skipped (--no-commit)` in summaries and STATE.md. Continue already-authorized delivery steps instead of presenting them as new permission requests.


### PR DESCRIPTION
## Summary
Reduce `/quick` instructions from 1,881 to 976 words while retaining its small-task contracts.

## Changes
- Keep routing frontmatter unchanged and preserve every flag, task IDs, tracking schema, interview limits, commands, and scope thresholds.
- Resolve contradictory trivial-mode branch instructions and honor `--no-commit` in both execution modes.
- Replace repeated phase ceremony with one contained procedure; respect existing authorization at advisory scope thresholds.

## Notes
Direct review checked the retained contracts; model A/B experiments are intentionally omitted under the user's updated validation policy. Existing routing, dispatch, workflow, and reorganization tests passed locally. Routing selection and `/do` are unchanged.
