### PR TITLE
Simplify quality loop and scale review to risk

### DIFF
--- a/skills/meta/do/references/lazy-completion-detector.md
+++ b/skills/meta/do/references/lazy-completion-detector.md
@@ -11,7 +11,7 @@ A check the orchestrator runs against an agent's "done" claim before accepting i
 This file fills ONE gap: laziness — an agent stops at partial progress and declares done. The other two agentic failure modes are already covered elsewhere; this file does NOT re-cover them:
 
 - **Goal drift** → `skills/meta/do/references/quality-loop.md` PHASE 5 (INTENT VERIFY): adversarial check that the diff matches the original request.
-- **Self-preferential bias** → quality-loop PHASE 7 (FIX): a fresh agent, not the original author, so anchoring bias toward its own work is broken.
+- **Self-preferential bias** → quality-loop PHASE 7 (FIX): use independent context when a specific blind spot warrants it; fresh-agent fixing is not mandatory.
 
 Do not duplicate those controls here.
 

--- a/skills/meta/do/references/quality-loop.md
+++ b/skills/meta/do/references/quality-loop.md
@@ -8,7 +8,7 @@ Work in four stages: implement, check, review, deliver. The phase numbers below
 retain the 0–13 identifiers used by `/do` and `hooks/pipeline-phase-gate.py`;
 they are checkpoints, not fourteen mandatory agent calls or tracking tasks.
 
-## Implement (0–2)
+## Implement: ADR, PLAN, IMPLEMENT (0–2)
 
 - **0 — ADR:** For creation requests, write `adr/{kebab-case-name}.md` with
   Context, Decision, Consequences, and Implementation Checklist. Register it:
@@ -31,7 +31,7 @@ handoff for review or resumed work, not a second plan. Phase 2 requires
 `task_plan.md`; phases 3, 4, 7, and 9 require `quality-loop-state.md` under the
 existing phase gate.
 
-## Check (3, 5–6)
+## Check: TEST, INTENT VERIFY, LIVE VALIDATE (3, 5–6)
 
 - **3 — Tests:** Run the project's required checks and checks relevant to the
   changed behavior. Use repository commands/configuration first. When applicable:
@@ -59,7 +59,7 @@ existing phase gate.
   check blocks completion. Do not downgrade a reproduced correctness failure to
   a suggestion merely because a browser found it.
 
-## Review and fix (4, 7–8, optional 10)
+## Review and fix: REVIEW, FIX, RETEST, optional CODEX REVIEW (4, 7–8, 10)
 
 Review the diff for correctness, scope, security, and domain constraints. Scale
 independent review to the change: authentication, sensitive data, migrations,
@@ -82,7 +82,7 @@ If stuck, investigate the cause or report the concrete blocker; there is no
 arbitrary three-round approval loop. Unresolved correctness/security failures or
 required failed checks block merge. A draft may document unfinished work honestly.
 
-## Deliver (9, 11–13)
+## Deliver: PR, ADR RECONCILE, REPORT, CLEANUP (9, 11–13)
 
 - **9 — PR:** Use `pr-workflow` to push and create the PR. Describe the resulting
   behavior, relevant validation, and unresolved limitations. Follow existing

--- a/skills/meta/do/references/quality-loop.md
+++ b/skills/meta/do/references/quality-loop.md
@@ -1,282 +1,105 @@
-# Quality Loop Pipeline
-
-The canonical pipeline for all Medium+ code modifications. The quality-loop is the **outer orchestration** — it wraps the agent+skill that `/do` Phase 2 selected. The agent provides domain expertise. The quality-loop adds every verification, review, and lifecycle gate around it.
-
-```
-quality-loop (14 phases)
- 0  ADR             — architectural decision record (creation requests)
- 1  PLAN            — task_plan.md with approach + acceptance criteria
- 2  IMPLEMENT       — agent+skill builds the change (worktree isolated)
- 3  TEST            — deterministic: lint, tests, build, vet
- 4  REVIEW          — 3 parallel reviewers (security, domain, architecture)
- 5  INTENT VERIFY   — adversarial: does the diff match the original request?
- 6  LIVE VALIDATE   — Playwright: does it render correctly? (web projects only)
- 7  FIX             — fresh agent fixes CRITICALs (separate commits)
- 8  RETEST          — re-run tests after fixes (loop to 7, max 3)
- 9  PR              — push branch, create PR with findings in body
-10  CODEX REVIEW    — cross-model second opinion via Codex CLI (GPT-5.4)
-11  ADR RECONCILE   — compare ADR decision vs what was actually built
-12  REPORT          — state the pipeline outcome and the ADR reconciliation
-13  CLEANUP         — move ADR to completed, clear artifacts, clean worktree
-```
-
-## When This Applies
-
-- All code modification requests at Medium+ complexity (implementation, bug fix, feature addition, refactoring)
-- Does NOT apply to: Trivial (direct), Simple (quick/fast), review-only tasks, research, debugging-only, content creation
-- Force-route skills (go-patterns, feature-lifecycle, etc.) are used INSIDE PHASE 2, not excluded from the loop
-
-## Task Tracking
-
-At pipeline start, create a task for each phase using TaskCreate. This makes progress visible to the user and provides a checklist the orchestrator follows.
-
-```
-TaskCreate: "PHASE 0: ADR"           — "Write architectural decision record"
-TaskCreate: "PHASE 1: PLAN"          — "Write task_plan.md with approach + acceptance criteria"
-TaskCreate: "PHASE 2: IMPLEMENT"     — "Agent+skill builds the change"
-TaskCreate: "PHASE 3: TEST"          — "Run deterministic test suite"
-TaskCreate: "PHASE 4: REVIEW"        — "3 parallel reviewers (security, domain, architecture)"
-TaskCreate: "PHASE 5: INTENT VERIFY" — "Adversarial: does diff match request?"
-TaskCreate: "PHASE 6: LIVE VALIDATE" — "Playwright validation (web projects only)"
-TaskCreate: "PHASE 7: FIX"           — "Fix CRITICAL findings"
-TaskCreate: "PHASE 8: RETEST"        — "Re-run tests after fixes"
-TaskCreate: "PHASE 9: PR"            — "Push branch, create PR"
-TaskCreate: "PHASE 10: CODEX REVIEW" — "Cross-model second opinion"
-TaskCreate: "PHASE 11: ADR RECONCILE"— "Compare decision vs implementation"
-TaskCreate: "PHASE 12: REPORT"       — "State the pipeline outcome"
-TaskCreate: "PHASE 13: CLEANUP"      — "Move ADR to completed, clear artifacts"
-```
-
-As each phase begins, mark it `in_progress`. When it completes, mark it `completed`. If a phase is skipped (e.g., PHASE 0 for non-creation requests, PHASE 6 for non-web projects), mark it `completed` with a note "skipped — not applicable."
-
-This tracking is mandatory — it's how the user knows where the pipeline is and what's left.
-
-## Pipeline Phases
-
-### PHASE 0 — ADR
-
-Write an architectural decision record before touching code. Only for creation requests ("create", "new", "scaffold", "build").
-
-- Write ADR at `adr/{kebab-case-name}.md` with: Context, Decision, Consequences, Implementation Checklist
-- Register via `python3 ~/.claude/scripts/adr-query.py register adr/{name}.md`
-- The implementation checklist becomes the verification target for PHASE 10
-
-For non-creation requests (bug fixes, refactoring, feature additions to existing components): if an active ADR session exists (`.adr-session.json`), load it for context. No new ADR needed.
-
-**Gate:** For creation requests: ADR exists and is registered. For non-creation: no gate. Proceed to PHASE 1.
-
-### PHASE 1 — PLAN
-
-Write the execution plan before implementation.
-
-- Create `task_plan.md` with: approach, files to modify, acceptance criteria, risks
-- The plan feeds into PHASE 2 (what to implement), PHASE 5 (what to verify), and PHASE 10 (what was promised)
-
-**Gate:** `task_plan.md` exists with acceptance criteria. Proceed to PHASE 2.
-
-### PHASE 2 — IMPLEMENT
-
-Dispatch the agent+skill that `/do` Phase 2 selected with one implementation worktree. The quality-loop does not choose the agent — it uses whatever the router already picked (e.g., `golang-general-engineer` + `go-patterns` for Go work, `python-general-engineer` + `python-quality-gate` for Python work).
-
-- Run `worktree_capacity.py --strict` from `references/worktree-rules.md` before checkout creation.
-- Create feature branch in worktree
-- Reuse this checkout for correction rounds. Dispatch read-only reviewers from the repository root using the committed candidate; review allocates no checkout.
-- Agent uses its own skill and reference files for domain-specific implementation
-- Agent commits on the feature branch
-- Inject worktree rules into agent prompt (see `references/worktree-rules.md`)
-- Include "commit your changes on the branch" in agent prompt
-
-**State artifact:** Before proceeding, write `quality-loop-state.md` in the worktree root:
-```
-agent: <domain-agent-name>
-skill: <skill-name>
-request: <original user request verbatim>
-branch: <feature-branch-name>
-```
-This artifact is read by PHASE 5 (intent verification), PHASE 7 (fix agent selection), and PHASE 10 (ADR reconciliation).
-
-**Gate:** Agent commits exist on feature branch AND `quality-loop-state.md` written; proceed to PHASE 3. If agent failed to commit, halt and report.
-
-### PHASE 3 — TEST
-
-**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
-
-Run deterministic test suite. Language auto-detected from changed files.
-
-Detection and commands:
-- Go files changed: `go test ./...` (from repo root), `go vet ./...`
-- TypeScript files changed: `tsc --noEmit`, then `npx vitest run` if vitest config exists
-- Python files changed: `ruff check . --config pyproject.toml`, `ruff format --check . --config pyproject.toml`, `python -m pytest` if pytest config exists
-- If Playwright config exists: `npx playwright test`
-- If Makefile has `check` target: `make check`
-- **Toolkit agent/skill files changed** (`agents/*.md` or `skills/*/SKILL.md`): run structure validation:
-  - `python3 scripts/validate-references.py --agent {name}` for each changed agent
-  - `python3 -m pytest scripts/tests/test_reference_loading.py -k {name}` for reference loading tests
-  - These catch broken reference declarations before merge — a soft CLAUDE.md instruction converted into a deterministic gate
-
-Run ALL applicable test suites — a change may touch multiple languages.
-
-Capture: exit codes, failure output, test counts.
-
-**Gate:** Record results. If tests fail, mark failures as CRITICAL findings for PHASE 7. Proceed to PHASE 4.
-
-### PHASE 4 — REVIEW
-
-Dispatch 3 parallel review agents against the diff (feature branch vs main):
-
-1. **Security reviewer** (reviewer-system) — injection vectors, auth issues, secret exposure, input validation
-2. **Business logic reviewer** (reviewer-domain) — correctness, edge cases, domain rules, error handling
-3. **Architecture reviewer** (reviewer-perspectives) — design patterns, coupling, API contracts, performance
-
-Give each reviewer the diff plus the `request_verbatim` and `acceptance` fields of the Task Spec, read from the PHASE 2 state artifact. Reviewers judge the diff against what the user asked for, not against the diff alone.
-
-Each reviewer produces findings as:
-- CRITICAL: Must fix before merge
-- IMPROVEMENT: Should fix, not blocking
-- POSITIVE: Good patterns to reinforce
-
-**Gate:** All 3 reviewers complete. Proceed to PHASE 5.
-
-### PHASE 5 — INTENT VERIFY
-
-**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
-
-Adversarial verification: does the diff accomplish what the user actually asked for?
-
-Dispatch one read-only verifier agent that reads the original user request from `quality-loop-state.md` (written in PHASE 2) and compares it against the actual diff. The verifier answers:
-
-1. Does the diff accomplish what the user requested?
-2. Are there aspects of the request that the implementation missed?
-3. Are there changes in the diff that go beyond what was requested?
-
-Any gap between request and implementation is a CRITICAL finding — because passing tests don't prove the code does what the user actually asked for. This implements the verifier pattern from PHILOSOPHY.md: "planner (read-only), executor (full access), verifier (read-only, adversarial intent)."
-
-**Gate:** Intent verification complete. Proceed to PHASE 6.
-
-### PHASE 6 — LIVE VALIDATE
-
-**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
-
-Behavioral verification for web projects. **Skip if not a web project.**
-
-When the project has a dev server (detected by: `package.json` with `dev` or `start` script, Hugo config, or `docker-compose.yml` with web service), spin up the dev server and use Playwright to visit changed routes/pages.
-
-- Only run when Playwright is installed AND a dev server config exists
-- Timeout: 60 seconds for server startup, 30 seconds per page
-- If dev server fails to start, skip with a warning (not a CRITICAL)
-- Uses the `e2e-testing` or `wordpress-live-validation` skill methodology
-- Playwright test failures are IMPROVEMENT-level unless they reproduce a PHASE 3 failure, in which case CRITICAL
-
-**Gate:** Collect all findings from PHASES 3-6. If any CRITICAL findings, proceed to PHASE 7. If no CRITICALs, skip to PHASE 9.
-
-### PHASE 7 — FIX
-
-For each CRITICAL finding, dispatch a fresh domain agent to fix it.
-
-- Each fix is a separate commit with a message referencing the finding
-- Read `quality-loop-state.md` to determine which domain agent PHASE 2 used — do not rely on session memory
-- Fresh agent context — not the same agent that made the mistake — because the original agent has anchoring bias toward its own implementation
-- Give the fix agent the full Task Spec (`request_verbatim`, `acceptance`, `files`, `decisions`, `prior_results`) plus the specific CRITICAL finding text. The finding alone is not enough context.
-
-**Gate:** All CRITICAL findings addressed with commits. Proceed to PHASE 8.
-
-### PHASE 8 — RETEST
-
-Run the same test suite as PHASE 3.
-
-- If all tests pass AND no new issues: proceed to PHASE 9
-- If tests fail: loop back to PHASE 7
-
-**Loop counter:** Maximum 3 FIX→RETEST iterations. After 3 loops:
-- **HALT** — block PR creation until unresolved CRITICALs are addressed
-- Display remaining CRITICAL findings to the user
-- Ask: "Quality loop exhausted 3 fix iterations with unresolved CRITICALs. Create PR anyway? (findings will be listed in PR body)"
-- Only proceed to PHASE 9 if user confirms
-- State the loop exhaustion in the PR body alongside the remaining CRITICALs
-
-A pipeline that promises quality enforcement must not silently ship CRITICALs. The user must consciously choose to proceed.
-
-**Gate:** All tests green after fixes. Proceed to PHASE 9. If tests fail, loop to PHASE 7 (max 3 iterations per the loop counter above).
-
-### PHASE 9 — PR
-
-Push branch and create PR via pr-workflow skill.
-
-PR body includes:
-- Summary of the change
-- Review findings (all CRITICAL, IMPROVEMENT, POSITIVE from PHASES 4-6)
-- Test results (pass/fail counts from PHASES 3 and 8)
-- Intent verification result (PHASE 5)
-- Fix iterations (how many FIX→RETEST loops were needed)
-
-Only fires when PHASE 8 passes clean (or user confirmed after max loops).
-
-**Gate:** PR created and CI triggered. Wait for merge before proceeding to PHASE 10.
-
-### PHASE 10 — CODEX REVIEW
-
-Cross-model second opinion on the PR. Uses the `pr-workflow` skill's codex-review intent to get a review from OpenAI Codex CLI (GPT-5.4 xhigh), providing a perspective independent of the Claude reviewers in PHASE 4.
-
-- Pass the PR number, the ADR (if exists), and the full review context from PHASES 4-6
-- Codex receives: the diff, the original request, the Claude review findings, and the ADR decision
-- Codex produces: CRITICAL/IMPROVEMENTS/POSITIVE findings from a fresh model perspective
-- Any new CRITICAL findings from Codex loop back to PHASE 7 (FIX) → PHASE 8 (RETEST) before merge
-
-The value of cross-model review: Claude reviewers share inference patterns. A different model family catches blind spots that same-family reviewers miss. This is the same principle as having both static analysis and LLM review — orthogonal verification surfaces.
-
-**Gate:** Codex review complete. If new CRITICALs found, loop to PHASE 7. If clean, proceed to merge, then PHASE 11.
-
-### PHASE 11 — ADR RECONCILE
-
-After PR is merged, compare what was planned against what was built.
-
-**When ADR exists** (creation requests):
-1. Read the original ADR from `adr/{name}.md`
-2. Read the merged diff (`git diff main~1..main`)
-3. Compare the ADR's Decision and Implementation Checklist against the actual implementation
-4. For each checklist item: mark as completed, partially completed, or deviated
-5. Note any deviations from the original decision (scope changes, alternative approaches taken, unexpected discoveries)
-6. Add a `## Implementation Notes` section documenting what actually happened vs what was planned
-
-**When no ADR exists** (non-creation requests):
-- Compare `task_plan.md` acceptance criteria against the merged diff
-- Note any deviations from the plan
-
-**Gate:** Reconciliation documented. Proceed to PHASE 12.
-
-### PHASE 12 — REPORT
-
-State what this pipeline run produced.
-
-- Report the pipeline outcome: phases executed, loop iterations, CRITICAL count, total agent dispatches
-- Report the reconciliation outcome (how closely implementation matched plan/ADR)
-- Route any finding worth keeping into the file that owns it through a reviewed edit — a skill, an agent, or `docs/what-didnt-work.md` when the finding is a refuted experiment
-
-**Gate:** Outcome reported. Proceed to PHASE 13.
-
-### PHASE 13 — CLEANUP
-
-Close the loop. Remove temporary artifacts, finalize ADR lifecycle.
-
-**ADR lifecycle** (when ADR exists):
-- Change ADR status from `PROPOSED` to `Accepted`
-- Move ADR to `adr/completed/{name}.md`
-- Clear `.adr-session.json`
-
-**Artifact cleanup:**
-- Remove `quality-loop-state.md` from worktree
-- Remove `task_plan.md` (work is complete)
-- Confirm the task is inactive and the checkout is clean, then run `git worktree remove -- <accepted-worktree-path>`; the branch remains recoverable
-- Run `bash scripts/worktree-cleanup.sh --force` after the checkout removal
-
-**Gate:** ADR in completed (if applicable). Artifacts cleaned. Pipeline complete.
-
-## Phase reporting
-
-Each phase reports its outcome in one line: `quality-loop PHASE_N: [outcome summary]`.
-
-## Worktree Isolation
-
-- Phases 2–8 run in the same worktree
-- Phase 9 (PR) runs pr-workflow from the main checkout using the feature branch
-- Phases 10–12 run from the main checkout after merge
+# Quality Loop
+
+For Medium+ code changes, use the agent and skill already selected by `/do`.
+Do not change routing or replace domain instructions. Trivial, Simple, review-only,
+research, debugging-only, and content tasks keep their existing workflows.
+
+Work in four stages: implement, check, review, deliver. The phase numbers below
+retain the 0–13 identifiers used by `/do` and `hooks/pipeline-phase-gate.py`;
+they are checkpoints, not fourteen mandatory agent calls or tracking tasks.
+
+## Implement (0–2)
+
+- **0 — ADR:** For creation requests, write `adr/{kebab-case-name}.md` with
+  Context, Decision, Consequences, and Implementation Checklist. Register it:
+  `python3 ~/.claude/scripts/adr-query.py register adr/{name}.md`.
+  For other changes, read an active `.adr-session.json` and its ADR when present;
+  do not create an unrelated ADR.
+- **1 — Plan:** Keep `task_plan.md` brief: original request, acceptance criteria,
+  approach, affected files, and material risks. Use it to resume longer work and
+  check the result against the request. Do not create a separate task for every
+  checkpoint.
+- **2 — Implement:** Use one feature branch and worktree. Before creating it, run
+  `worktree_capacity.py --strict` as described in `references/worktree-rules.md`.
+  Reuse the checkout for fixes; preserve unrelated work. Give the selected agent
+  the task, domain references, worktree rules, and instruction to commit its changes.
+
+Before checks, commit the candidate and write `quality-loop-state.md` in the
+worktree root. Keep the original request intact and record acceptance criteria,
+selected agent/skill, branch, decisions, and relevant prior results. This is the
+handoff for review or resumed work, not a second plan. Phase 2 requires
+`task_plan.md`; phases 3, 4, 7, and 9 require `quality-loop-state.md` under the
+existing phase gate.
+
+## Check (3, 5–6)
+
+- **3 — Tests:** Run the project's required checks and checks relevant to the
+  changed behavior. Use repository commands/configuration first. When applicable:
+
+  | Scope | Commands |
+  |---|---|
+  | Go | `go test ./...`, `go vet ./...` from the module root |
+  | TypeScript | Installed `tsc --noEmit`; installed Vitest runner when configured |
+  | Python | `ruff check . --config pyproject.toml`, `ruff format --check . --config pyproject.toml`; `python -m pytest` when configured |
+  | Project checks | `make check` when required by the project; configured build and integration checks |
+  | Agent references | `python3 scripts/validate-references.py --agent {name}` for each changed agent; `python3 -m pytest scripts/tests/test_reference_loading.py -k {name}` for its loading tests |
+
+  Check skill references and routing contracts when those files change. Cover all
+  affected languages. Do not install dependencies implicitly or treat a missing
+  required tool as a passing check. Record actual exit codes and relevant failures;
+  keep full logs available without pasting them into every update.
+- **5 — Intent:** Compare the diff and observed behavior with the original request
+  and acceptance criteria. Identify omissions and unintended changes. This check
+  is required; a separate verifier is optional unless the project requires one.
+- **6 — Live behavior:** For changed web behavior, use installed Playwright and the
+  configured dev server when needed to verify rendering or interactions. Follow
+  `e2e-testing` or `wordpress-live-validation`. Allow 60 seconds for startup and
+  30 seconds per page. Run required browser suites even when unit tests pass.
+  If unavailable, report the unverified behavior; a required failed or unavailable
+  check blocks completion. Do not downgrade a reproduced correctness failure to
+  a suggestion merely because a browser found it.
+
+## Review and fix (4, 7–8, optional 10)
+
+Review the diff for correctness, scope, security, and domain constraints. Scale
+independent review to the change: authentication, sensitive data, migrations,
+concurrency, public contracts, or uncertain architecture merit focused expertise.
+Routine changes can use direct review. No default quota of three reviewers or
+cross-model review applies.
+
+When delegating, give read-only reviewers the committed candidate, original
+request, acceptance criteria, and relevant decisions/results. Use the repository
+root; reviewers do not need additional checkouts. Select `reviewer-system`,
+`reviewer-domain`, or `reviewer-perspectives` for the actual risk. Phase 10 remains
+available through `pr-workflow`'s codex-review intent when requested or useful;
+perform it before merge if its findings could block delivery.
+
+Fix blocking findings in the implementation worktree. Keep related corrections
+in clear commits. Reuse the implementing agent unless independent context would
+help resolve a specific problem. Re-run affected checks after fixes, plus any
+required full suite. Do not repeat unchanged passing checks without a reason.
+If stuck, investigate the cause or report the concrete blocker; there is no
+arbitrary three-round approval loop. Unresolved correctness/security failures or
+required failed checks block merge. A draft may document unfinished work honestly.
+
+## Deliver (9, 11–13)
+
+- **9 — PR:** Use `pr-workflow` to push and create the PR. Describe the resulting
+  behavior, relevant validation, and unresolved limitations. Follow existing
+  authorization; do not request approval again for an authorized action. Merge
+  only the reviewed revision after all required GitHub checks pass. Report pending
+  work if merge is outside the authorized scope.
+- **11 — Reconcile:** Compare the actual PR/merge diff with the ADR checklist or
+  plan acceptance criteria. Use the PR's base and head or recorded merge commit,
+  not an assumed `main~1`. Document deviations in the ADR's Implementation Notes
+  and mark checklist items completed, partial, or deviated.
+- **12 — Report:** State what changed, what checks ran, and any material limits.
+  Record reusable lessons in their owning skill/agent through a reviewed edit;
+  refuted experiments belong in `docs/what-didnt-work.md`.
+- **13 — Cleanup:** After completion, mark the applicable ADR Accepted, move it
+  to `adr/completed/{name}.md`, and clear its `.adr-session.json`. Remove this
+  task's temporary plan/state artifacts only when no longer needed for resumption.
+  Confirm the task is inactive and the checkout clean before
+  `git worktree remove -- <accepted-worktree-path>`, then run
+  `bash scripts/worktree-cleanup.sh --force`. Preserve recoverable branches and
+  other tasks' worktrees and artifacts.

--- a/skills/workflow/references/workflow-patterns.md
+++ b/skills/workflow/references/workflow-patterns.md
@@ -27,10 +27,10 @@ Each maps to existing HAVE machinery. Load the linked file for mechanics.
 |---|---|---|
 | Classify-and-act | Route by type up front; or classify-at-end (judge output, re-route) | `/do` Phase 1 CLASSIFY + Phase 4 evaluation; `skills/meta/do/references/lazy-completion-detector.md` for classify-at-end |
 | Fan-out-and-synthesize | Independent agents in parallel, barrier, one synthesizer | `fan-out-workflow.js`; dispatch multiple Agent tools in one message (prose floor) |
-| Adversarial verification | Executor builds, fresh skeptic refutes the result | quality-loop PHASE 5 (intent-verify) + PHASE 7 (fresh-agent fix) |
+| Adversarial verification | Executor builds, fresh skeptic refutes the result | quality-loop PHASE 5 (intent-verify) + PHASE 7 (focused fixes) |
 | Generate-and-filter | Over-generate candidates, a gate keeps survivors | voice-writer HOOK-GATE / VARIETY-GATE; `right-size-review.py` tiering |
 | Tournament | N agents attempt the SAME task; pairwise judges pick a winner per round | `tournament-workflow.md` |
-| Loop-until-done | Repeat until a hard completion test passes | quality-loop PHASE 8 RETEST (max 3) + verification-before-completion as the completion bar; `/loop` for interval re-run |
+| Loop-until-done | Repeat until a hard completion test passes | quality-loop PHASE 8 RETEST (after relevant fixes) + verification-before-completion as the completion bar; `/loop` for interval re-run |
 
 ## The 3 Failure Modes Workflows Fight
 
@@ -39,7 +39,7 @@ These are agentic-execution failures (a single agent declaring victory wrong). T
 | Failure mode | Symptom | Control + when to escalate |
 |---|---|---|
 | Agentic laziness | Stops at partial progress ("fixed 20 of 50"), declares done | `skills/meta/do/references/lazy-completion-detector.md` — scope-vs-objective check at evaluation; escalate to re-dispatch the remainder |
-| Self-preferential bias | Agent reviews its own work, rates it good | quality-loop PHASE 7 fresh-agent (already covered); escalate when the builder is also the judge |
+| Self-preferential bias | Agent reviews its own work, rates it good | quality-loop focused independent review when risk or a blind spot warrants it |
 | Goal drift | Output answers a nearby question, not the asked one | quality-loop PHASE 5 intent-verify (already covered); escalate when the diff diverges from request |
 
 ## Repeatable Workflows: completion bar + /loop


### PR DESCRIPTION
Medium+ changes currently require fourteen tracked phases, three reviewers, a separate intent verifier, fresh agents for fixes, and a cross-model review regardless of risk. This change organizes execution into implement, check, review, and deliver, with independent review selected for concrete risks.

Preserves the existing router byte-for-byte, selected domain agent/skill, phase identifiers and artifact gates, branch/worktree safety, required project checks, request/acceptance verification, applicable ADR lifecycle, and authorized delivery. Updates two coupled descriptions of mandatory fresh-agent fixing and the retired three-round limit.

Quality-loop reference: 2,363 → 930 words. Validation: 25 existing pipeline-phase-gate tests and pipeline-index validation passed; full Ruff lint and format checks passed. No model A/B claims; this uses the user's requested direct review and existing checks.
