### PR TITLE
refactor(pr-workflow): condense shared instructions and reuse review

### DIFF
--- a/skills/process/pr-workflow/SKILL.md
+++ b/skills/process/pr-workflow/SKILL.md
@@ -116,7 +116,7 @@ routing:
 
 Umbrella skill for the entire pull request lifecycle. Routes to the correct reference based on the PR task requested.
 
-## Routing
+## Reference Loading Table
 
 Detect the user's intent and load the appropriate reference file:
 
@@ -138,30 +138,9 @@ Detect the user's intent and load the appropriate reference file:
 | **Changelog** | "update changelog", "release notes", "curate changelog" | `${CLAUDE_SKILL_DIR}/references/changelog-curation.md` |
 | **Decision brief** | "decision brief", "authorization tier", "ask the owner", "is it decision-ready" | `${CLAUDE_SKILL_DIR}/references/owner-decision-briefs.md` |
 | **Risk classify** | automatic pre-review step; also "classify PR risk", "pr risk", "risk check" | `${CLAUDE_SKILL_DIR}/references/pr-risk-policy.md` |
+| **INDEX conflict** | "INDEX.json conflict", "INDEX conflict on rebase", "two PRs regenerated INDEX", "regenerate INDEX after rebase" | `${CLAUDE_SKILL_DIR}/references/index-conflict-resolution.md` |
 
 **Default action**: When invoked with no arguments or ambiguous intent, load `sync.md` (the most common PR use case).
-
-## Reference Loading Table
-
-| Signal | Load These Files | Why |
-|---|---|---|
-| "push", "create PR", "sync", "ship this" | `sync.md` | **Sync** (default) |
-| "submit PR", "full PR", "end-to-end PR", "open PR" | `pipeline.md` | **Pipeline** |
-| "fix PR comments", "address review", "pr-fix", "resolve feedback" | `fix.md` | **Fix** |
-| "pr status", "branch status", "is my PR ready", "check CI" | `status.md` | **Status** |
-| "clean up branches", "delete merged branch", "prune" | `cleanup.md` | **Cleanup** |
-| "process PR feedback", "address reviews", "what did reviewers say" | `feedback.md` | **Feedback** |
-| "mine PRs", "extract review comments", "tribal knowledge", "reviewer patterns" | `miner.md` | **Miner** |
-| "generate branch name", "validate branch name", "name branch", "branch convention", "git branch name" | `branch-name.md` | **Branch name** |
-| "check CI", "CI status", "actions status", "did CI pass", "build status", "CI passed" | `ci-check.md` | **CI check** |
-| "commit changes", "stage and commit", "commit my changes", "commit my files", "commit these" | `commit.md` | **Commit** |
-| "codex review", "second opinion", "code review codex", "gpt review", "cross-model review" | `codex-review.md` | **Codex review** |
-| "land PR", "land the PR", "merge contributor PR", "rebase and merge PR" | `land-pr.md` | **Land** |
-| any `gh` call writing or reading a PR/issue body | `gh-body-safety.md` | **Body safety** |
-| "update changelog", "release notes", "curate changelog" | `changelog-curation.md` | **Changelog** |
-| "decision brief", "authorization tier", "ask the owner", "is it decision-ready" | `owner-decision-briefs.md` | **Decision brief** |
-| "INDEX.json conflict", "INDEX conflict on rebase", "two PRs regenerated INDEX", "regenerate INDEX after rebase" | `index-conflict-resolution.md` | **INDEX conflict** |
-| "classify PR risk", "pr risk", "risk check", or automatic pre-review step | `pr-risk-policy.md` | **Risk classify** |
 
 ## Review Lanes by Risk
 
@@ -175,58 +154,26 @@ Route to the appropriate review lane based on the `risk` field:
 
 | Risk | Lane | Action |
 |---|---|---|
-| `low` | Quick single review | `parallel-code-review` (3 agents) — lightweight, fast |
+| `low` | Direct or single review | Review the diff directly; use one independent reviewer when useful |
 | `medium` | Full right-size-review roster | Run `right-size-review.py` for tier-appropriate wave composition |
 | `high` | Full roster + operator sign-off | Right-size-review roster + add `**Operator sign-off required**` note to PR body Notes section |
 
 When `recommend_split` is true, surface the recommendation to the user before dispatching review: "This PR has N lines changed (above the 800-line ceiling). Consider splitting into smaller PRs for faster, higher-quality review." Proceed with review if the user chooses to continue.
 
-## Mandatory PR Body Structure
+## PR body
 
-`gh pr create --body "..."` is how every agent in this toolkit opens PRs, and it **bypasses `.github/pull_request_template.md` entirely** — GitHub only applies that file to the web UI and to a bare `gh pr create` with no `--body`. So the structure must be reproduced in the `--body` string by hand.
+Use **Summary → Changes → Notes**, following `.github/pull_request_template.md`. Passing `--body` or `--body-file` supplies the body instead of loading that template.
 
-Every agent-authored PR body uses the same three sections as `.github/pull_request_template.md`, in this order: **Summary → Changes → Notes**. This keeps PR bodies consistent across models (Opus, Sonnet, and every other harness produce the same shape).
+- **Summary:** State what changes and why in 1–3 plain sentences; name the relevant issue or ADR.
+- **Changes:** One fact per line: what changed and where. Summarize large lists by shape and count; let the diff enumerate them.
+- **Notes:** Include non-obvious decisions, deliberate omissions, follow-ups, gotchas, superseded PRs, and material plan deviations. Also include manual verification, gaps in CI coverage, migration/rollout ordering, and security-sensitive changes. Omit the section only when none apply.
 
-Tests run as GitHub Actions, so the Checks tab is the test record. Let CI carry the proof: keep command output (ruff exit, pytest counts, gate traces, dogfood runs) out of the body. Pasting `$ pytest → N passed` duplicates the Checks tab and bloats the PR — leave it to CI.
+Keep command dumps out of the body; GitHub Checks records CI results. Retain verification facts that CI does not establish, such as “Apply the column migration before deploying” or “Not covered by CI — Terraform plan checked manually.”
 
-### Write for Density
+Use existing planning artifacts for intent and completed work; otherwise use the diff and commits. Describe the final change, not the conversation or abandoned approaches unless they explain a tradeoff.
 
-Aim for high meaning per word: each line states one fact about the change, declaratively, so a reviewer understands it fast. Density is the target, not minimal length — a large change keeps the three sections and carries the detail it needs; it earns that length by packing each line with signal. Four rules carry the vibe:
+Write the body to a temporary file with a quoted heredoc, then pass `--body-file`, following `${CLAUDE_SKILL_DIR}/references/gh-body-safety.md`. Read the body back before submitting it.
 
-1. **One fact per line.** Each Changes line reads verb + what + where; Summary states the goal and why. Plain words, high meaning.
-2. **Summary states the goal.** 1-3 plain sentences or a few crisp bullets. Keep metrics to the single number that matters.
-3. **One line per change.** When a change has many sub-items, state the shape and count ("add 21 PR-creation trigger phrases") and let the diff enumerate them. Keep rationale to the clause that earns its place.
-4. **Notes carries non-obvious signal — required when a trigger applies.** Omit it for routine PRs and drop the section when nothing qualifies. Note it, one terse declarative line per point, when a reviewer cannot infer the signal from the diff: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, a "supersedes #N". Note it too when a RISK/VERIFICATION trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). State each caveat as one fact and let CI carry command output. Skip what is always true (a PR can be reverted; CI runs the tests).
+## Execution
 
-**Worked example — the shape to emulate (#608-good vs #710-bad):**
-
-| Section | Dense (emulate, like #608) | Bloated (rewrite toward dense, the #710 shape) |
-|---------|-----------------|--------------------------------|
-| Summary | "Registers 3 hooks in settings.json; integrates `pre-route.py` into /do Phase 2 as a deterministic pre-filter." | One 5-sentence block stuffed with jargon and four metrics. |
-| Changes | "`SKILL.md` — add 21 PR-creation trigger phrases." | One bullet inlining all 21 phrases verbatim; another a 3-sentence rationale paragraph. |
-| Notes | "Not covered by CI — the Terraform plan is applied manually." or "Apply the column migration before deploying." (a required risk/verification caveat) — or omitted entirely when nothing qualifies | "Roll back by reverting the branch commits. Tests run in CI — see Checks." (always-true filler) plus a pasted `pytest -v` dump and a Scope & Risk wall. |
-
-The dense column reads in seconds because each cell carries facts; the bloated column buries the same facts in volume (and re-states what the Checks tab already shows). Aim every body at the dense column.
-
-Copy this canonical skeleton into `--body`:
-
-```markdown
-## Summary
-<!-- State the goal plainly: 1-3 sentences or a few crisp bullets, one fact per line. Name the ADR/issue if any. Keep metrics to the single number that matters. -->
-
-## Changes
-<!-- One line per change: verb + what + where. State shape and count for many sub-items; let the diff enumerate them. -->
-- `path/or/area` — what changed
-
-## Notes
-<!-- Omit for routine PRs (drop the section when nothing qualifies). Note it, one terse declarative line per point, when a reviewer cannot infer the signal from the diff: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, a "supersedes #N". Note it too when a RISK/VERIFICATION trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Let CI carry command output. Skip what is always true (a PR can be reverted; CI runs the tests). -->
-```
-
-The sync (`sync.md` Step 5) and pipeline (`pipeline.md` Phase 5) references carry this same skeleton at their `gh pr create` call sites. When either path writes a `--body`, it uses this structure and the density rules above.
-
-## Instructions
-
-1. Identify the user's PR task from their message
-2. Load the matching reference file from the table above
-3. Follow the instructions in that reference file exactly
-4. When the task creates a PR, build the `--body` from the canonical three-section skeleton above (Summary / Changes / Notes), because `--body` bypasses the GitHub template file. Write the body via temp file + quoted heredoc + `--body-file` per `${CLAUDE_SKILL_DIR}/references/gh-body-safety.md`. Tests run in CI — the Checks tab is the test record, so keep command output out of the body
+Load the matching reference and execute within the user's existing authorization. Ask only for an uncovered action or an explicit applicable repository requirement; do not ask again for actions already authorized. Preserve repository branch protection and review requirements.

--- a/skills/process/pr-workflow/references/ci-check.md
+++ b/skills/process/pr-workflow/references/ci-check.md
@@ -1,142 +1,53 @@
-# GitHub Actions CI Check
+# GitHub Actions CI check
 
-Check GitHub Actions workflow status after a git push, identify failures, and suggest local reproduction commands. This reference observes and reports -- it modifies workflow files or auto-fixes code only with explicit permission.
+Check the pushed branch and commit, investigate failed jobs, and report the result. A status-only request does not authorize edits. When the user has already requested fixes and delivery, apply relevant fixes and rerun checks without another permission round. Workflow YAML changes need to fit that authorized scope.
 
-## Pre-Push Checks for Python Changes
+## Before pushing Python changes
 
-Before pushing any branch that touches Python files, run both commands locally. The toolkit's `Tests` workflow (enforced by branch protection) runs both; running only `ruff check` misses formatting violations and leaks the failure to CI.
+Read repository instructions. Both checks must pass locally before pushing:
 
 ```bash
 ruff check . --config pyproject.toml
 ruff format --check . --config pyproject.toml
 ```
 
-Both must exit 0 before `git push`. Fix failures locally; do not rely on CI to surface them.
-
-## Instructions
-
-### Step 1: Identify Repository and Branch
-
-Read and follow any repository CLAUDE.md before proceeding -- it may contain CI-specific instructions or branch naming conventions.
-
-Determine which repository and branch to check:
+## Identify the run
 
 ```bash
-# Get repository from git remote
 git remote get-url origin
-
-# Get the branch that was pushed
-git branch --show-current
-```
-
-Always use the branch that was actually pushed, always the branch that was actually pushed. Checking without `--branch` can show runs from other branches and give misleading status for the user's actual push.
-
-**Gate**: Repository and branch both identified. Confirm both values before proceeding.
-
-### Step 2: Wait and Check Workflow Status
-
-GitHub needs 5-10 seconds after a push to register the workflow run. Checking immediately returns stale results from previous runs, not the current push.
-
-```bash
-# Wait for GitHub to register the workflow run
-sleep 10
-
-# Check workflow runs for the pushed branch
 BRANCH=$(git branch --show-current)
-gh run list --branch "$BRANCH" --limit 5
+HEAD_SHA=$(git rev-parse HEAD)
+gh run list --branch "$BRANCH" --commit "$HEAD_SHA" --limit 20
 ```
 
-Always use the `gh` CLI rather than raw GitHub API calls -- `gh` handles authentication, pagination, and formatting automatically. Writing custom scripts with `curl` or `requests` adds unnecessary complexity when `gh` already does the job.
+Check the branch actually pushed and its current commit. GitHub can take 5–10 seconds to register a run; retry if absent, up to 30 seconds initially. Do not treat an earlier green run or “no checks reported” as success. If there are more runs than the limit, retrieve them too.
 
-Show the complete `gh` output verbatim. Show complete output rather than summarizing as "build passed" or "tests failed" -- that hides which jobs ran, their timing, and any warnings. Claiming "build passed" without showing output is unverifiable. The user needs to see the actual data.
+Use `gh` for authentication, pagination, and status queries. For a PR, inspect its full checks list with `gh pr checks <pr-number>`. Wait for every applicable check to finish; pending, missing, and failed are not passed. `gh run watch <run-id> --exit-status` can monitor a run. If the head changes, inspect checks for the new head before claiming completion or merging.
 
-**Gate**: Workflow status retrieved and complete output displayed to user. Wait for the gate to pass before proceeding.
-
-### Step 3: Investigate Failures
-
-Only execute this step if Step 2 shows a failed or failing run. Compare against previous runs before classifying failures as pre-existing without comparing against previous runs -- that is speculation, not evidence.
+## Investigate failures
 
 ```bash
-# Get details of the failed run
 gh run view <run-id>
-
-# For deeper investigation (only if user explicitly requests it,
-# since full logs can be very verbose)
 gh run view <run-id> --log-failed
 ```
 
-For each failing job, identify:
-1. Which job failed (build, test, lint, deploy)
-2. The specific error message
-3. A local reproduction command
+Identify the failing job, exact error, and local reproduction command. Compare previous runs before calling a failure pre-existing. Read logs as needed without asking permission to inspect them; summarize relevant evidence instead of dumping full output.
 
-```markdown
-## Failure Report
-Job: [job name]
-Error: [specific error from logs]
-Local reproduction: [command to reproduce locally]
-Suggested fix: [exact commands to fix, if applicable]
-```
+If fixing is authorized, fix the cause, run relevant local checks, push, and verify the new head. Otherwise report a proposed fix. For local test debugging, use this action: Call the Skill tool with `workflow`. Run the `systematic-debugging` pipeline. For local linting, use this action: Call the Skill tool with `code-linting`.
 
-For common failures like linting or formatting, provide exact fix commands but present them for user approval. Wait for explicit user permission before auto-fixing and re-pushing -- making code changes and git commits without review may introduce unintended changes. Only use `gh run watch` for interactive monitoring if the user specifically asks for it.
+Report the checked commit, passed/pending/failed status, and PR or run link. Include failures and reproduction commands when needed. Retain logs for inspection; full command output is unnecessary unless requested. Remove temporary files created solely for this check.
 
-**Gate**: All failures identified with reproduction commands. Wait for the gate to pass before proceeding.
+## Advisory AI review
 
-### Step 4: Report and Suggest
+`.github/workflows/pr-ai-review.yml` runs on PR `opened`, `synchronize`, and `reopened` events without an `@claude` mention. It reports correctness bugs and safety-policy violations in one comment.
 
-If all checks passed:
-- Show the complete `gh run list` output (not a summary)
-- Confirm which workflows ran and their status
+It is warn-only: it never requests changes, fails the build, or acts as a required check. Making it blocking requires a dedicated ADR and operator sign-off. The quick-pass workflow does not read `skills/process/pr-workflow/references/pr-risk-policy.md`; that remains a possible deeper-review integration.
 
-If checks failed:
-- Show the failure report from Step 3
-- Suggest local reproduction commands
-- Suggest fix commands but wait for confirmation before executing without permission
-- Ask the user if they want you to apply fixes
+## Recovery
 
-Report facts without self-congratulation. Show command output rather than describing it. Be concise but informative.
-
-Clean up any temporary scripts or cache files created during the check before finishing.
-
-This reference only checks CI status. For local test-failure debugging, use this action: Call the Skill tool with `workflow`. Run the `systematic-debugging` pipeline. For local linting, use this action: Call the Skill tool with `code-linting`. Keep workflow YAML files and CI configuration out of scope for this reference.
-
-**Gate**: Complete status report delivered to user.
-
----
-
-## Automatic PR AI Review (Advisory)
-
-`.github/workflows/pr-ai-review.yml` runs a quick AI review on every PR push (`opened`, `synchronize`, `reopened`) — no `@claude` mention needed. Scope: correctness bugs and safety-policy violations in the PR diff only, posted as one PR comment.
-
-Warn-only by design (docs/PHILOSOPHY.md, Warn-Only Gates Beat Blocking Gates): it never requests changes, never fails the build, and is not a required status check. Graduating any part of it to a blocking gate needs a dedicated ADR and operator sign-off.
-
-Future extension point: if `skills/process/pr-workflow/references/pr-risk-policy.md` exists, a follow-up job could key a deeper, tier-based review off it. The quick-pass workflow does not read or depend on that file today.
-
----
-
-## Error Handling
-
-### Error: "gh CLI not found"
-**Cause**: GitHub CLI not installed on the system
-**Solution**:
-1. Check if `gh` is available: `which gh`
-2. If missing, suggest installation: `brew install gh` or `sudo apt install gh`
-3. As last resort, use `curl` with GitHub API (but prefer installing gh)
-
-### Error: "gh auth required"
-**Cause**: GitHub CLI not authenticated
-**Solution**:
-1. Run `gh auth status` to check current auth
-2. If not authenticated, suggest `gh auth login`
-3. Check if GITHUB_TOKEN environment variable is set as alternative
-
-### Conflicting PR: "no checks reported"
-A same-repo PR in `mergeable=CONFLICTING` state fires no workflow run on push, so `gh pr checks` shows "no checks reported" — a missing run, not a failure. Merge `origin/main` into the branch first; CI triggers on that push. (Evidence: PRs #789/#791/#797, 2026-06-11.)
-
-### Error: "No workflow runs found"
-**Cause**: Workflow not triggered, branch has no workflows, or checked too early
-**Solution**:
-1. Wait longer (up to 30 seconds) and retry
-2. Verify `.github/workflows/` directory exists in the repository
-3. Check if workflow is configured to trigger on the pushed branch
-4. Verify push event matches workflow trigger conditions
+| Problem | Action |
+|---|---|
+| `gh` missing | Check `which gh`; suggest `brew install gh` or `sudo apt install gh`. GitHub API via `curl` is a last resort. |
+| Authentication missing | Run `gh auth status`; use configured `GITHUB_TOKEN` or request `gh auth login`. Never print credentials. |
+| Conflicting same-repo PR, no checks | `mergeable=CONFLICTING` can prevent workflow runs. Integrate `origin/main`, resolve conflicts, and push before checking again. Observed in PRs #789/#791/#797 on 2026-06-11. |
+| No runs after retry | Check `.github/workflows/`, branch/event filters, and the pushed commit. Absence is not success. |

--- a/skills/process/pr-workflow/references/pipeline.md
+++ b/skills/process/pr-workflow/references/pipeline.md
@@ -1,6 +1,6 @@
 # PR Pipeline
 
-A structured pipeline for creating high-quality pull requests with proper staging, meaningful commits, parallel review, and CI verification.
+Create pull requests with selective staging, meaningful commits, risk-selected review, and CI verification.
 
 ---
 
@@ -17,10 +17,10 @@ REPO_TYPE=$(python3 ~/.claude/scripts/classify-repo.py --type-only)
 
 | Repo Type | Review Policy | Merge Policy | Step Execution |
 |-----------|--------------|--------------|----------------|
-| `protected-org` | Phase 2 parallel review only (their reviewers handle comprehensive review) | **Create PR, report URL, stop** — merge is handled by org reviewers. | **Human-gated**: confirm commit message, push, and PR creation with user before each step |
-| `personal` | Phase 2 parallel review + Phase 4b review-fix loop (max 3 iterations of `/pr-review` -> fix) | Create PR after review passes | Auto-execute steps normally |
+| `protected-org` | Risk-selected review plus organization requirements | **Create PR, report URL, stop** — merge is handled by org reviewers. | Use existing authorization; honor explicit repository approval requirements |
+| `personal` | Risk-selected review; follow up only on changed or unresolved scope | Create PR after review passes | Auto-execute steps normally |
 
-Protected-org repos require user confirmation before EACH step (commit message approval, push approval, PR creation approval) because unauthorized actions in shared org repos can trigger CI storms, notify entire teams, or violate org policies. Never auto-execute any of these steps -- present the proposed action and wait for user approval.
+Use existing authorization for commit, push, and PR creation. Ask only for an uncovered action or an explicit applicable repository requirement.
 
 **Gate**: Repo type classified. Policy determined.
 
@@ -32,7 +32,7 @@ PR creation can fail mid-way because the working tree is dirty, the branch is ma
 
 Run 5 checks sequentially (verification status, clean working tree, correct branch, remote configured, `gh` authenticated). Abort on the first failure with a specific error message.
 
-See `references/preflight-checklist.md` for the full check table, bash script, and note on Check 1 (verification status).
+See **Preflight Checklist** below for the full check table, bash script, and note on Check 1 (verification status).
 
 **Gate**: All preflight checks pass. Environment is ready for PR creation. Proceed to Phase 1.
 
@@ -80,53 +80,17 @@ If the changeset spans 30+ files or multiple unrelated features, suggest the use
 
 **Gate**: Changes staged. No sensitive files included. Staged diff makes sense as a cohesive unit.
 
-### Phase 2: REVIEW (Comprehensive Multi-Agent Review)
+### Phase 2: REVIEW
 
-**Goal**: Catch ALL issues before they reach the commit. Run the review loop before creating the commit because post-merge fixes cost 2 PRs instead of 1.
+Classify risk and use the review lanes in `../SKILL.md`. Review the staged diff directly for routine changes. For substantial changes, choose specialists through `right-size-review.py`. Preserve required high-risk review and operator sign-off. `--skip-review` skips optional review, not repository requirements.
 
-**Skip condition**: Only if user explicitly passes `--skip-review`. One-line changes can still introduce security vulnerabilities or break business logic, so the default is always to review.
+Assess findings before fixing them. Fix confirmed issues, stage the fixes, and rerun affected checks. Blocking correctness and security issues prevent merge. Repeat review only for new changes or unresolved concerns; reuse clean review of unchanged work.
 
-**Run the comprehensive-review pipeline:**
+### Phase 2b: Optional cross-model review
 
-Call the Skill tool with `workflow`.
+Use the `codex-review` intent before merge when requested or when a second model can resolve a concrete uncertainty. Review the staged diff; do not repeat review already performed on that scope. `--skip-codex` skips this optional review.
 
-```
-Pipeline: comprehensive-review
-Scope: git diff --cached (staged changes)
-Mode: review + fix (default)
-```
-
-This dispatches:
-- **Wave 1**: 11 foundation agents in parallel (security, business logic, architecture, silent failures, test coverage, type design, code quality, comments, language specialist, docs validator, ADR compliance)
-- **Wave 2**: 10 deep-dive agents with Wave 1 context (performance, concurrency, API contracts, dependencies, error messages, dead code, naming, observability, config safety, migration safety)
-
-All findings are auto-fixed. The fix commit is applied to the staged changes before proceeding to Phase 3.
-
-**If comprehensive-review finds CRITICAL issues that cannot be auto-fixed**: STOP and report to user. Do not proceed to commit.
-
-**Gate**: Comprehensive review complete. All findings fixed or explained. No unresolved CRITICAL issues.
-
-### Phase 2b: CROSS-MODEL REVIEW (auto-injected)
-
-**Goal**: Get an independent second opinion from OpenAI Codex CLI to catch issues that same-model review might miss.
-
-**Note**: The `codex-auto-review` UserPromptSubmit hook now automatically injects a reminder to run this phase whenever any review skill is invoked (`/systematic-code-review`, `/parallel-code-review`, `/pr-review`, `/full-repo-review`, etc.). This makes cross-model review standard across all review workflows, not just pr-workflow.
-
-**Skip condition**: Skip if `codex` CLI is not installed (`which codex` fails), if user passes `--skip-codex`, or if the codex-review intent was already invoked as part of the current pipeline. This phase is additive -- it never blocks the pipeline, only adds signal.
-
-**Invoke the pr-workflow codex-review intent:**
-
-```
-Invoke: /pr-workflow codex-review
-Scope: git diff --cached (staged changes)
-```
-
-Codex runs in read-only sandbox mode with GPT-5.5 `high` reasoning by default (`xhigh` is opt-in for hard correctness analysis -- security/concurrency/migrations). It produces structured findings (CRITICAL / IMPROVEMENTS / POSITIVE / SUMMARY). Claude assesses each finding before incorporating -- Codex feedback is a second opinion, not authoritative.
-
-**If Codex finds CRITICAL issues that Claude agrees with**: Fix them and re-stage before proceeding.
-**If Codex is unavailable or errors**: Log the skip reason and proceed. This phase must never block the pipeline.
-
-**Gate**: Cross-model review complete (or skipped). Any agreed-upon findings fixed.
+Assess findings independently and fix agreed issues. If Codex is unavailable or errors, report the limitation; this optional phase does not block the pipeline. Invocation, model settings, and output details live in `codex-review.md`.
 
 ### Phase 3: COMMIT
 
@@ -159,9 +123,9 @@ EOF
 
 Follow CLAUDE.md rules for commit messages. Never add "Generated with Claude Code", "Co-Authored-By: Claude", or similar attribution lines because they add noise and violate most project commit conventions.
 
-**Protected-org repos**: Before executing the commit, present the proposed commit message to the user and wait for explicit approval. Show the full message and list of files that will be committed.
+**Protected-org repos**: Follow applicable organization requirements. Existing user authorization covers the requested commit, push, and PR creation; ask only when an action is not covered or an explicit repository rule requires separate approval.
 
-**Gate**: Commit created successfully. Message follows conventional format. (protected-org: user confirmed.)
+**Gate**: Commit created successfully. Message follows conventional format. (protected-org: authorization checked.)
 
 ### Phase 4: PUSH
 
@@ -194,21 +158,14 @@ CLAUDE_GATE_BYPASS=1 git push -u origin $(git branch --show-current)
 
 Confirm push succeeded by checking output. If push fails (e.g., rejected), report error and stop.
 
-**Protected-org repos**: Before executing the push, present the branch name, remote, and list of commits that will be pushed. Wait for user to confirm before executing `CLAUDE_GATE_BYPASS=1 git push`.
 
-**Gate**: Changes pushed to remote. Branch tracks upstream. (protected-org: user confirmed.)
+**Gate**: Changes pushed to remote. Branch tracks upstream. (protected-org: authorization checked.)
 
-### Phase 4b: REVIEW-FIX LOOP (personal repos only)
+### Phase 4b: REVIEW-FIX (personal repos)
 
-**Goal**: Iteratively review and fix issues until clean or max 3 iterations reached.
+Reuse Phase 2's review. If new findings or changes need follow-up, fix confirmed issues and rerun affected checks. Document unresolved nonblocking issues in Notes; blocking correctness and security issues prevent merge. Protected-org repos retain their own review gates.
 
-**Skip condition**: If `REPO_TYPE == "protected-org"`, skip this phase entirely. Protected-org repos have their own PR gates. This phase cannot be skipped for personal repos -- even with `--skip-review` (which only skips Phase 2), this loop always runs because it is the final quality gate before PR creation.
-
-**Loop**: Up to 3 iterations of `/pr-review` -> fix -> amend commit -> push. After iteration 3, exit and document remaining issues in the PR body.
-
-See `references/review-fix-loop.md` for the full loop logic, steps 1-5 with code blocks, result table, and iteration report format.
-
-**Gate**: Review-fix loop complete. Either clean (0 issues) or max 3 iterations reached with remaining issues documented.
+See **Review-Fix Loop** below for commit and push handling.
 
 ### Phase 4c: RETRO (toolkit repo only)
 
@@ -218,7 +175,7 @@ See `references/review-fix-loop.md` for the full loop logic, steps 1-5 with code
 
 Three steps: collect findings from Phases 2 and 4b, embed each in the responsible agent or skill file, and stage the updated files.
 
-See `references/retro-adr-phases.md` for full steps, bash commands, and the finding-target table.
+See **Retro and ADR Validation Phases** below for full steps, bash commands, and the finding-target table.
 
 **Gate**: All review findings embedded in the responsible agent/skill files. Updated files staged for commit.
 
@@ -230,7 +187,7 @@ See `references/retro-adr-phases.md` for full steps, bash commands, and the find
 
 Run `python3 ~/.claude/scripts/adr-status.py check`; fix any warnings and stage changes. Run `python3 ~/.claude/scripts/adr-status.py status` and include the summary in the PR body if the PR touches `adr/*.md` files.
 
-See `references/retro-adr-phases.md` for full ADR commands and fix workflow.
+See **Retro and ADR Validation Phases** below for full ADR commands and fix workflow.
 
 **Gate**: `python3 ~/.claude/scripts/adr-status.py check` exits 0. All ADRs have valid format.
 
@@ -248,39 +205,26 @@ Analyze the full diff against the base branch and all commit messages to draft:
 
 When planning artifacts exist (`task_plan.md`, review summaries, deviation logs), generate the PR body from them rather than writing freeform. Artifacts capture *intent*, which is more valuable to reviewers than a mechanical diff summary. Feed them into the three sections: the goal into Summary, the completed-task shapes into Changes, and context/rollback/deviations into Notes, so each line carries one fact. Tests run as GitHub Actions — the Checks tab is the test record, so leave verification output to CI rather than pasting it. Fall back to diff-based generation when no artifacts exist.
 
-See `references/pr-templates.md` for the full artifact table, PR body template, and fallback guidance.
+See **PR body inputs** below and `../SKILL.md` for the shared body rules.
 
 **Step 2: Create PR**
 
 This pipeline cannot create PRs without staged changes -- if nothing is staged, the earlier phases would have caught this.
 
-**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's three sections in the `--body` string, in order: **Summary → Changes → Notes**. This keeps PR bodies consistent across models.
-
-**Write for density.** Each Changes line states one fact, declaratively (verb + what + where), so a reviewer scans the body fast; Summary states the goal and why. Write one line per change in Changes (give shape and count for many sub-items, e.g. "add 21 trigger phrases", and let the diff enumerate them). Omit Notes for routine PRs and drop the section when nothing qualifies; note it, one terse line per point, when a reviewer cannot infer the signal from the diff (a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N") or when a risk/verification trigger holds — manual verification was performed, part of the change sits outside CI coverage, migration/rollout ordering matters, or a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests). Tests run as GitHub Actions and the Checks tab is the test record; reviewer verdicts likewise show on the PR, so leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
+Use the canonical **PR body** rules in `../SKILL.md`; preserve all material Notes caveats. Write and read back `$PR_BODY_FILE` using `gh-body-safety.md` before submitting.
 
 ```bash
-CLAUDE_GATE_BYPASS=1 gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
-## Summary
-[State the goal plainly: 1-3 sentences or a few crisp bullets, one fact per line. Name the ADR/issue if any.]
-
-## Changes
-- `path/or/area` — what changed [one line per change; give shape + count for many sub-items]
-
-## Notes
-[Omit for routine PRs (drop the section when nothing qualifies). Note it, one terse line per point, when a reviewer cannot infer the signal from the diff: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N". Note it too when a risk/verification trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests).]
-EOF
-)"
+CLAUDE_GATE_BYPASS=1 gh pr create --title "$PR_TITLE" --body-file "$PR_BODY_FILE"
 ```
 
 Add `--draft` flag if draft mode was requested via `--draft`.
 
-**Protected-org repos**: Before creating the PR, present the title, body, and target branch to the user. Wait for explicit approval before executing `gh pr create`.
 
 **Step 3: Capture PR URL**
 
 Record and report the PR URL to the user.
 
-**Gate**: PR created successfully. URL available. (protected-org: user confirmed.)
+**Gate**: PR created successfully. URL available. (protected-org: authorization checked.)
 
 **Protected-org repos**: After creating the PR, report the URL and **STOP the pipeline**. Do not wait for CI or attempt any merge operations. Output:
 ```
@@ -297,15 +241,7 @@ This pipeline will NOT auto-merge protected-org PRs.
 
 **Goal**: Wait for CI and report final status. Always check CI status before marking the pipeline complete because merging without CI confirmation risks shipping broken code.
 
-```bash
-# Get the latest workflow run for this branch
-gh run list --branch $(git branch --show-current) --limit 1
-
-# Wait for completion (timeout 10 minutes)
-gh run watch [run-id] --exit-status
-```
-
-If CI fails, report which checks failed and the PR URL. Keep the PR open and stop before cleanup. This pipeline reports CI failures but does not fix them -- diagnosing CI requires different context than PR creation.
+Use `ci-check.md` to inspect all applicable checks for the pushed head, not just the latest run. If checks fail, investigate and fix within existing authorization, rerun affected local checks, push, and verify the new head. Keep the PR open until all checks pass. A status-only request permits reporting, not edits.
 
 If CI passes and user requested merge:
 ```bash
@@ -359,7 +295,7 @@ When this pipeline runs inside a worktree agent (dispatched with `isolation: "wo
 
 ### Options Reference and Examples
 
-See `references/pr-templates.md` for the full options reference table and all 4 usage examples (Standard PR, Draft PR, Trivial Change, Protected-Org).
+See **Options Reference** below.
 
 ---
 
@@ -475,61 +411,14 @@ This is context-dependent. If the project has a test suite (`go test`, `npm test
 
 # Review-Fix Loop
 
-Full details for Phase 4b of the PR Pipeline (personal repos only).
+Review only changed or unresolved scope using the selected risk lane. Exit when clean. Do not impose a fixed number of reviewer rounds. Report any unresolved issue; blocking correctness and security issues prevent merge.
 
-## Loop Logic
-
-Up to 3 iterations of `/pr-review` -> fix -> amend commit -> push.
-
-```
-ITERATION = 0
-MAX_ITERATIONS = 3
-
-while ITERATION < MAX_ITERATIONS:
-    ITERATION += 1
-
-    Step 1: Run /pr-review
-    Step 2: If no issues found -> EXIT LOOP (proceed to Phase 5)
-    Step 3: Fix all reported issues
-    Step 4: Stage fixes, amend commit, force push to branch
-    Step 5: Report iteration results
-```
-
-## Step 1: Run `/pr-review`
-
-Invoke the `/pr-review` command, which launches specialized review agents (code-reviewer, silent-failure-hunter, comment-analyzer, etc.) and captures retro learnings.
-
-## Step 2: Evaluate Results
-
-| Result | Action |
-|--------|--------|
-| No issues found | **Exit loop**. Proceed to Phase 5 (CREATE PR). |
-| Issues found (iteration < 3) | Fix issues in Step 3, then re-review. |
-| Issues remaining after iteration 3 | **Exit loop**. Include remaining issues in PR body as known items. Proceed to Phase 5. |
-
-## Step 3: Fix Reported Issues
-
-Address each issue found by the review. This includes:
-- Code quality fixes (naming, style, error handling)
-- Documentation updates (stale references, missing README entries)
-- Test gaps (if flagged)
-
-## Step 4: Amend and Push
+Stage fixes selectively. Prefer a new commit if earlier commits have external review or collaborators. Amend only the tip created and pushed by this workflow before external review; use `--force-with-lease`, never `--force`, and stop if the lease fails.
 
 ```bash
 git add [fixed files]
 git commit --amend --no-edit
 CLAUDE_GATE_BYPASS=1 git push --force-with-lease
-```
-
-## Step 5: Iteration Report Format
-
-```
-REVIEW-FIX ITERATION [N/3]
-  Found: [X issues]
-  Fixed: [Y issues]
-  Remaining: [Z issues]
-  Status: [CLEAN | FIXING | MAX ITERATIONS REACHED]
 ```
 
 ---
@@ -615,126 +504,15 @@ Include the status summary in the PR body if the PR touches any `adr/*.md` files
 
 ---
 
-# PR Templates and Examples
+# PR body inputs
 
-Full details for Phase 5 (CREATE PR) of the PR Pipeline: artifact-driven body generation, templates, and all usage examples.
-
----
-
-## Artifact-Driven PR Body Generation
-
-When planning artifacts exist, generate the PR body from them rather than writing freeform. Artifacts capture *intent* (why the change was made), which is more valuable to reviewers than a mechanical diff summary. Summarize each artifact into dense lines — one fact per line — so a reviewer scans the body fast. Pull the goal, the completed-task shapes, and any context a reviewer needs beyond the diff; let the diff and the linked reports carry the rest. Tests are covered by CI — the Checks tab is the test record, so leave command output to CI rather than pasting it.
-
-Check for artifacts in this order and build the PR body from what's available:
-
-| Artifact | PR Section Generated | How to Extract |
-|----------|---------------------|----------------|
-| `task_plan.md` | **Summary** (from Goal section) and **Changes** (from completed tasks) | Read the Goal and Phases sections; state the goal plainly; write one line per completed item (shape + count for many sub-items) |
-| Deviation logs (ADR-076 repair actions) | **Notes** (deviations) | List repair actions taken and why the original plan changed, one terse line each — these are non-obvious by nature |
-| Context a reviewer cannot infer (non-obvious decision, deliberate omission, follow-up, gotcha, supersedes) or a risk/verification trigger (manual verification performed, CI-coverage gap, migration/rollout ordering, security-surface change) | **Notes** (required on trigger) | One terse line each. Omit Notes for routine PRs and drop the section when nothing qualifies; note it when an artifact surfaces non-obvious context or a risk/verification trigger holds (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests). Verification reports and review summaries stay in CI — the Checks tab carries the result |
-
-**Fallback**: If no artifacts exist, fall back to diff-based generation -- summarize changes from the diff and commit messages. This is the existing behavior and remains the default for ad-hoc PRs without planning artifacts.
-
-## PR Body Template (Artifact-Driven)
-
-Follows the canonical three-section structure from `.github/pull_request_template.md` (Summary / Changes / Notes), with each section populated from artifacts. Deviation logs and reviewer context fold into **Notes**.
-
-```markdown
-## Summary
-<!-- From task_plan.md Goal section, or from commit messages if no plan. State the goal plainly: 1-3 sentences, one fact per line. Name the ADR/issue if any. -->
-[Goal statement: what changed and why, plainly, in 1-3 sentences.]
-
-## Changes
-<!-- From task_plan.md completed phases/tasks. One line per change: verb + what + where. Give shape + count for many sub-items. -->
-- `path/or/area` — [completed task description]
-- `path/or/area` — [completed task description]
-
-## Notes
-<!-- Omit for routine PRs (drop the section when nothing qualifies). Note it, one terse line per point, when an artifact surfaces something a reviewer cannot infer from the diff: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N", a deviation log (ADR-076). Note it too when a risk/verification trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests). -->
-[Optional context a reviewer cannot infer from the diff.]
-```
-
----
-
-## Examples
-
-### Example 1: Standard PR Submission (personal repo)
-
-User says: "Submit a PR for these changes"
-
-Actions:
-1. Classify repo from remote URL (CLASSIFY REPO)
-2. `git status`, review changes, stage files (STAGE)
-3. Launch 3 parallel reviewers on staged diff (REVIEW)
-4. Create conventional commit from staged changes (COMMIT)
-5. Push branch to remote with tracking (PUSH)
-6. Run review-fix loop: `/pr-review` -> fix -> re-review, up to 3 iterations (REVIEW-FIX LOOP)
-7. Embed review findings in the responsible agents/skills (RETRO, toolkit repo only)
-8. Validate ADR format consistency (ADR VALIDATION, toolkit repo only)
-9. Create PR with summary and review findings (CREATE PR)
-10. Wait for CI, report status (VERIFY)
-
-Result: PR URL with CI status and review-fix iteration count
-
-### Example 2: Draft PR for Work in Progress (personal repo)
-
-User says: "Open a draft PR for what I have so far"
-
-Actions:
-1. Classify repo (CLASSIFY REPO)
-2. Stage current changes, skip incomplete files if noted (STAGE)
-3. Run parallel review (REVIEW)
-4. Commit with `wip:` or appropriate prefix (COMMIT)
-5. Push to feature branch (PUSH)
-6. Run review-fix loop (REVIEW-FIX LOOP)
-7. Embed review findings in the responsible agents/skills (RETRO, toolkit repo only)
-8. Validate ADR format consistency (ADR VALIDATION, toolkit repo only)
-9. Create PR with `--draft` flag (CREATE PR)
-10. Report PR URL, skip CI wait if `--no-wait` (VERIFY)
-
-Result: Draft PR URL
-
-### Example 3: Trivial Change with Skip Parallel Review (personal repo)
-
-User says: "Quick PR for this typo fix, skip review"
-
-Actions:
-1. Classify repo (CLASSIFY REPO)
-2. Stage the single file change (STAGE)
-3. Skip Phase 2 parallel review (--skip-review)
-4. Commit: `fix(docs): correct typo in README` (COMMIT)
-5. Push to branch (PUSH)
-6. Run review-fix loop -- Phase 4b still runs even with --skip-review (REVIEW-FIX LOOP)
-7. Embed review findings in the responsible agents/skills (RETRO, toolkit repo only)
-8. Validate ADR format consistency (ADR VALIDATION, toolkit repo only)
-9. Create PR with minimal body (CREATE PR)
-10. Wait for CI (VERIFY)
-
-Result: PR URL for typo fix
-
-### Example 4: Protected-Org Repo (human-gated workflow)
-
-User says: "Submit a PR for these changes" (in a protected-org repo)
-
-Actions:
-1. Classify repo -> protected-org detected (CLASSIFY REPO)
-2. Stage files (STAGE)
-3. Run parallel review (REVIEW)
-4. Present commit message -> user confirms -> create commit (COMMIT, human-gated)
-5. Present push details -> user confirms -> push to remote (PUSH, human-gated)
-6. Skip Phase 4b (protected-org repos use their own review gates)
-7. Present PR title/body -> user confirms -> create PR (CREATE PR, human-gated)
-8. **STOP**. No CI wait, no merge. Report PR URL.
-
-Result: PR URL. Next steps handled by org CI gates and human reviewers.
-
----
+Use the canonical body rules in `../SKILL.md`. Read `task_plan.md` for the goal and completed tasks; include material ADR-076 deviations and required risk/verification caveats in Notes. Without artifacts, use the diff and commit messages. Do not manufacture planning files just to create a PR.
 
 ## Options Reference
 
 | Option | Effect | Default |
 |--------|--------|---------|
-| `--skip-review` | Skip Phase 2 (parallel subagent review) for trivial changes. Phase 4b review-fix loop still runs. | OFF (review runs) |
+| `--skip-review` | Skip optional review; required repository checks remain. | OFF (review runs) |
 | `--draft` | Create draft PR instead of ready PR | OFF (ready PR) |
 | `--no-wait` | Skip Phase 6 CI verification | OFF (waits for CI) |
 | `--title "..."` | Override generated PR title | Auto-generated |

--- a/skills/process/pr-workflow/references/sync.md
+++ b/skills/process/pr-workflow/references/sync.md
@@ -22,9 +22,9 @@ Then determine repo type:
 REPO_TYPE=$(python3 ~/.claude/scripts/classify-repo.py --type-only)
 ```
 
-**Protected-org repos**: Every subsequent step (commit, push, PR creation) requires **explicit user confirmation**. Present the proposed action, show what will happen, and wait for approval before executing. Never auto-execute, because protected-org repos have CI gates and review policies that assume human oversight at each stage.
+**Protected-org repos**: Follow applicable organization requirements. Existing user authorization covers the requested commit, push, and PR creation; ask only when an action is not covered or an explicit repository rule requires separate approval.
 
-**Personal repos**: Run `/pr-review` comprehensive review before creating the PR. Auto-execute steps normally.
+**Personal repos**: Use the risk-selected review lanes in `../SKILL.md` before creating the PR. Reuse review already completed for current changes.
 
 ### Step 1: Detect Current State
 
@@ -92,7 +92,6 @@ git commit -m "type(scope): description"
 
 If no uncommitted changes exist, skip to Step 4.
 
-**Protected-org repos**: Before executing the commit, present the proposed commit message and list of files to the user. Wait for explicit approval before committing.
 
 ### Step 4: Push to Remote
 
@@ -105,7 +104,6 @@ CLAUDE_GATE_BYPASS=1 git push -u origin "$CURRENT_BRANCH"
 
 If the user requested a rebase before push, run `git pull --rebase origin $MAIN_BRANCH` first, but this is off by default.
 
-**Protected-org repos**: Before executing the push, present the branch name, remote, and commits that will be pushed. Wait for explicit approval before pushing.
 
 ### Step 4a: ADR Decision Coverage (conditional -- ADR-094)
 
@@ -119,52 +117,24 @@ python3 scripts/adr-decision-coverage.py --adr <active-adr-path> --diff-base mai
 
 If verdict is PARTIAL or FAIL, display uncovered decision points and ask whether to proceed or address gaps first. This runs once before the review loop, not on every iteration.
 
-### Step 4b: Review-Fix Loop (personal repos only)
+### Step 4b: Review and fix (personal repos)
 
-**Skip if**: `REPO_TYPE == "protected-org"` (protected-org repos use their own review gates).
+Use the risk-selected review lane in `../SKILL.md`. Reuse completed review; repeat only for new changes or unresolved findings. Fix confirmed issues and rerun affected checks. Document nonblocking unresolved issues in Notes; blocking correctness and security issues prevent merge.
 
-Iteratively review and fix issues before creating the PR. Up to 3 iterations of: `/pr-review` -> fix -> amend -> push.
-
-Never modify commits already on the remote except the tip commit just pushed by this workflow. The review-fix loop amends only the tip commit it just created, before any external review, and uses `--force-with-lease` (not `--force`) because lease-checking confirms no one else has pushed to the branch in the meantime.
-
-**Loop (max 3 iterations):**
-1. Run `/pr-review` comprehensive review
-2. If clean -> exit loop, proceed to Step 5
-3. Fix all reported issues
-4. `git add [fixes] && git commit --amend --no-edit && CLAUDE_GATE_BYPASS=1 git push --force-with-lease`
-5. Report iteration: `REVIEW-FIX [N/3]: X found, Y fixed, Z remaining`
-
-After 3 iterations, proceed to Step 5 with any remaining issues documented in the PR body.
+Never amend externally reviewed or shared commits. Only the tip created and pushed by this workflow may be amended before external review, using `--force-with-lease`. Stop if the lease fails; never use `--force`. Otherwise use a new fix commit. Protected-org repos retain their own review gates.
 
 ### Step 5: Create or Update PR
 
 Generate the PR title from the branch name or first commit when not provided by the user. Never create a PR with an empty description, because reviewers need context to understand the changes and a missing test plan signals incomplete work.
 
-**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's three sections in the `--body` string, in order: **Summary → Changes → Notes**. This keeps PR bodies consistent across models.
-
-**Write for density.** Each Changes line states one fact, declaratively (verb + what + where), so a reviewer scans the body fast; Summary states the goal and why. Write one line per change in Changes (give shape and count for many sub-items, like "add 21 trigger phrases", and let the diff enumerate them). Omit Notes for routine PRs and drop the section when nothing qualifies; note it, one terse line per point, when a reviewer cannot infer the signal from the diff (a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N") or when a risk/verification trigger holds — manual verification was performed, part of the change sits outside CI coverage, migration/rollout ordering matters, or a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests). Tests run as GitHub Actions, so the Checks tab is the test record; leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
+Use the canonical **PR body** rules in `../SKILL.md`; preserve all material Notes caveats. Write and read back `$PR_BODY_FILE` using `gh-body-safety.md` before submitting.
 
 ```bash
-# Check if PR already exists for this branch
-EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null)
-
+EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number')
 if [[ -z "$EXISTING_PR" ]]; then
-    # Create new PR — --body follows .github/pull_request_template.md's section structure
-    CLAUDE_GATE_BYPASS=1 gh pr create --title "$PR_TITLE" --body "$(cat <<'EOF'
-## Summary
-[State the goal plainly: 1-3 sentences or a few crisp bullets, one fact per line. Name the ADR/issue if any.]
-
-## Changes
-- `path/or/area` — what changed [one line per change; give shape + count for many sub-items, e.g. "add 21 trigger phrases"]
-
-## Notes
-[Omit for routine PRs (drop the section when nothing qualifies). Note it, one terse line per point, when a reviewer cannot infer the signal from the diff: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N". Note it too when a risk/verification trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests).]
-EOF
-)"
+    CLAUDE_GATE_BYPASS=1 gh pr create --title "$PR_TITLE" --body-file "$PR_BODY_FILE"
 else
-    # PR exists, just pushed updates
-    echo "PR #$EXISTING_PR updated with new commits"
-    gh pr view "$EXISTING_PR" --web
+    gh pr view "$EXISTING_PR" --json url --jq .url
 fi
 ```
 
@@ -172,7 +142,6 @@ If the user requested a draft PR, add `--draft` to `gh pr create`. If auto-assig
 
 Always show the PR URL after creation for easy access.
 
-**Protected-org repos**: Before executing PR creation, present the PR title, body, and target branch. Wait for explicit approval. Do not run the review-fix loop -- protected-org repos rely on their own CI gates and human reviewers.
 
 ### Step 6: Post-Merge ADR Status Update (conditional -- ADR-095)
 
@@ -198,109 +167,9 @@ Report: `ADR updated: {name} -> Accepted, moved to completed/`
 
 This is local-only (ADR files are gitignored). No branch or PR needed.
 
-### Decision Tree
+### Report
 
-```
-/pr-sync invoked
-       |
-       v
-  Read CLAUDE.md + Classify repo (Step 0)
-       |
-       v
-  Has changes?
-   /        \
- YES         NO
-  |           |
-  v           v
-On main?    PR exists?
- / \         / \
-YES  NO    YES  NO
- |    |     |    |
- v    v     v    v
-Create  Stage  Show  Create
-branch  commit link  PR
-  |      |
-  v      v
-Stage & commit
-  |
-  v
-protected-org? ──YES──> Confirm commit msg with user
-  |                    |
-  NO                   v
-  |              Confirm push with user
-  v                    |
-Push to remote  <──────┘
-  |
-  v
-protected-org? ──YES──> Confirm PR creation with user
-  |                    |
-  NO                   v
-  |              Create PR, STOP (no merge)
-  v
-┌─> Run /pr-review (iteration N/3)
-|     |
-|     v
-|   Issues found?
-|    / \
-|  YES  NO ──────> Create PR
-|   |
-|   v
-|  Fix issues
-|   |
-|   v
-|  Amend commit, push
-|   |
-|   v
-|  N < 3? ──YES──┐
-|   |             |
-|   NO            |
-|   |             |
-|   v             |
-|  Create PR      |
-|  (note remaining)|
-└─────────────────┘
-```
-
-### Output Format
-
-**Personal repos:**
-```
-PR SYNC COMPLETE
-
-Status: [on main -> created branch | on feature branch]
-Changes: [N files modified]
-Review: /pr-review [N iterations] — [X issues found, Y fixed]
-
-Actions:
-  - Created branch: feature/your-feature (if from main)
-  - Staged N files
-  - Committed: "your commit message"
-  - Pushed to origin/feature/your-feature
-  - Review-fix loop: [N/3 iterations]
-    - Iteration 1: [X found, Y fixed]
-    - Iteration 2: [X found, Y fixed] (if needed)
-    - Iteration 3: [X found, Y fixed] (if needed)
-  - Created PR #123: "PR Title"
-    https://github.com/owner/repo/pull/123
-```
-
-**Protected-org repos:**
-```
-PR SYNC COMPLETE (protected-org repo — human-gated)
-
-Status: [on feature branch]
-Changes: [N files modified]
-
-Actions (each confirmed by user):
-  - Committed: "your commit message" (user confirmed)
-  - Pushed to origin/feature/your-feature (user confirmed)
-  - Created PR #123: "PR Title" (user confirmed)
-    https://github.com/your-org/your-repo/pull/123
-
-Next steps: Review and merge handled by org CI gates and human reviewers.
-```
-
----
+Return the PR URL, what changed, review result, and any unresolved issue. For protected-org repos, leave merge to the organization's reviewers unless separately authorized under its rules.
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

Reduce repeated PR instructions and reuse completed review so routine changes do not trigger fixed reviewer rounds.

## Changes

- Consolidate reference routing into one table and PR body rules into one shared contract.
- Remove repeated templates, examples, and permission requests already covered by user authorization.
- Select review by risk, make cross-model review optional, and verify CI against the pushed commit.

## Notes

Routing frontmatter, intent mappings, protected-branch rules, and high-risk review requirements remain intact. Existing routing and skill-contract tests validate compatibility; model A/B testing is omitted under the user's revised validation policy.
