### PR TITLE
Compact local agent discovery context

### DIFF
--- a/docs/injected-context-contracts.md
+++ b/docs/injected-context-contracts.md
@@ -33,10 +33,10 @@ Source: `hooks/pretool-dispatch-spec-gate.py` (PreToolUse, matcher `Agent`).
 Meaning: A `[do-route]` dispatch at medium or complex complexity lacks one or more of `**Request (verbatim):**`, `**Acceptance criteria:**`, or `## Repo state`. The router hand-assembled the prompt instead of pasting `scripts/build-dispatch.py` output.
 Action: Re-run `python3 scripts/build-dispatch.py --json '<routing decision>'` and re-dispatch with its output verbatim. Warn-only by default; `DISPATCH_SPEC_GATE_MODE=deny` returns the same text as a `permissionDecision: deny` reason (promotion date 2026-09-05); `DISPATCH_SPEC_GATE_BYPASS=1` disables the gate.
 
-### `[cross-repo] Found N agent(s)`
+### `[cross-repo] N local agents`
 
 Source: `hooks/cross-repo-agents.py`.
-Meaning: Local (project-scoped) agents are available in addition to the global fleet.
+Meaning: Local agents are available alongside the global fleet. The header gives their directory; each row gives the name, filename, description, and triggers. Keep local entries even when their names match global agents.
 Action: Treat the local agents as available for routing decisions in this session.
 
 ### `[strategic-compact] {N} tool calls reached`

--- a/hooks/cross-repo-agents.py
+++ b/hooks/cross-repo-agents.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 """
 SessionStart Hook: Cross-Repo Agent Discovery
 
@@ -113,19 +113,18 @@ def main():
         if not agents:
             empty_output(EVENT_NAME).print_and_exit()
 
-        # Aggregate output lines
-        lines = []
-        lines.append(f"[cross-repo] Found {len(agents)} local agent(s) in .claude/agents/")
-        lines.append("[cross-repo] Available local agents:")
+        # Keep every local identity; names can override globally installed agents.
+        agents_dir = Path(cwd) / ".claude" / "agents"
+        lines = [
+            f"[cross-repo] {len(agents)} local agents. Files below are relative to {agents_dir}/",
+            "name [file] | description | triggers",
+        ]
         for agent in agents:
             triggers = ", ".join(agent["triggers"][:3])
-            lines.append(f"  - {agent['name']}: {agent['description']}")
-            lines.append(f"    Triggers: {triggers}")
-            lines.append(f"    File: {agent['file']}")
+            filename = Path(agent["file"]).name
+            lines.append(f"{agent['name']} [{filename}] | {agent['description']} | {triggers}")
 
-        lines.append("")
-        lines.append("[cross-repo] To use local agents, read the agent file and follow its instructions.")
-        lines.append("[cross-repo] The /do router can invoke these via: Task tool with prompt referencing agent file")
+        lines.append("[cross-repo] /do can dispatch these agents; read the selected file for instructions.")
 
         context_output(EVENT_NAME, "\n".join(lines)).print_and_exit()
 

--- a/hooks/tests/test_cross_repo_agents.py
+++ b/hooks/tests/test_cross_repo_agents.py
@@ -197,3 +197,24 @@ class TestDebugLogging:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_catalog_preserves_local_paths_and_duplicate_names(tmp_path, capsys, monkeypatch):
+    """A shared directory must still identify differently named override files."""
+    import json
+
+    agents_dir = tmp_path / ".claude" / "agents"
+    agents_dir.mkdir(parents=True)
+    for filename in ("custom.md", "override.md"):
+        (agents_dir / filename).write_text(
+            "---\nname: same-name\ndescription: Local domain knowledge\nrouting:\n  triggers:\n    - local task\n---\n"
+        )
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit) as result:
+        cross_repo_agents.main()
+    assert result.value.code == 0
+    payload = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert payload.count(str(agents_dir)) == 1
+    for filename in ("custom.md", "override.md"):
+        assert f"same-name [{filename}] | Local domain knowledge | local task" in payload
+    assert "read the selected file" in payload


### PR DESCRIPTION
## Summary
Shorten the local-agent catalog injected at session start without removing agent knowledge or local overrides.

## Changes
- Print the shared directory once and retain each agent's actual filename, name, description, and triggers.
- Keep all local entries, including agents that share a name.
- Update the context contract and test duplicate names with distinct files.

## Notes
The current 44-agent catalog shrinks from 11,241 to 8,332 UTF-8 bytes (25.9%). This is a payload measurement, not a model-token or quality claim. The hook ran in 38.5 ms and exited successfully. All 13 focused tests and repository Ruff checks pass. Routing selection, metadata parsing, registrations, and global/local precedence are unchanged.
