### PR TITLE
Simplify review policy and reuse valid evidence

### DIFF
--- a/skills/process/pr-workflow/SKILL.md
+++ b/skills/process/pr-workflow/SKILL.md
@@ -142,23 +142,9 @@ Detect the user's intent and load the appropriate reference file:
 
 **Default action**: When invoked with no arguments or ambiguous intent, load `sync.md` (the most common PR use case).
 
-## Review Lanes by Risk
+## Review scope
 
-Before dispatching reviewers for any PR, run risk classification:
-
-```bash
-python3 scripts/pr-risk-classify.py --base "$MAIN_BRANCH" --head HEAD
-```
-
-Route to the appropriate review lane based on the `risk` field:
-
-| Risk | Lane | Action |
-|---|---|---|
-| `low` | Direct or single review | Review the diff directly; use one independent reviewer when useful |
-| `medium` | Full right-size-review roster | Run `right-size-review.py` for tier-appropriate wave composition |
-| `high` | Full roster + operator sign-off | Right-size-review roster + add `**Operator sign-off required**` note to PR body Notes section |
-
-When `recommend_split` is true, surface the recommendation to the user before dispatching review: "This PR has N lines changed (above the 800-line ceiling). Consider splitting into smaller PRs for faster, higher-quality review." Proceed with review if the user chooses to continue.
+Before dispatching reviewers, load `references/pr-risk-policy.md`. It owns risk classification, roster selection, and review reuse. Preserve explicit user and `/do` rosters and repository requirements; do not start a second review at each PR phase.
 
 ## PR body
 

--- a/skills/process/pr-workflow/references/pr-risk-policy.md
+++ b/skills/process/pr-workflow/references/pr-risk-policy.md
@@ -32,7 +32,7 @@ Changes confined to documentation or registry metadata:
 
 ### MEDIUM baseline
 
-Everything else. Adjusted upward by size: changes exceeding the size ceiling become HIGH.
+Everything else. Large changes recommend a split; MEDIUM paths remain MEDIUM unless a HIGH path is present.
 
 ## Size Classification
 
@@ -58,17 +58,38 @@ Above 800 changed lines (Tier 3+ territory from right-size-review), emit `recomm
 6. Any MEDIUM-risk path AND size medium/large => risk = MEDIUM (size large adds recommend_split).
 7. Path-based HIGH always wins; size can escalate but path dominance takes priority.
 
-Simplified: HIGH path wins. Otherwise, start at the highest path risk and let size escalate (LOW->MEDIUM->HIGH).
+HIGH paths win. Size escalates documentation-only changes from LOW to MEDIUM or HIGH; other MEDIUM paths stay MEDIUM.
 
-## Review Lanes
+## Review lanes
+
+This reference owns PR review selection. Use the shared procedure in
+`../../../review/systematic-code-review/SKILL.md` to execute the review and
+verify findings. Other PR phases reuse its result instead of dispatching again.
 
 | Risk | Review lane | Action |
 |---|---|---|
-| LOW | Quick single review | `parallel-code-review` (3 agents) |
-| MEDIUM | Full right-size-review roster | Tier-appropriate waves from `right-size-review.py` |
-| HIGH | Full roster + operator sign-off | Right-size-review roster + require operator sign-off note in PR body |
+| LOW | Direct or single review | Review the diff directly; use one independent reviewer when useful |
+| MEDIUM | Full right-size-review roster | Use the tier-appropriate roster from `scripts/right-size-review.py` |
+| HIGH | Full roster plus operator sign-off | Use the roster and include an operator sign-off note in the PR body |
 
-When `recommend_split` is true, surface the recommendation before review dispatch. The reviewer proceeds with the current PR but notes the split guidance in findings.
+Preserve explicit user or `/do` rosters and protected repository requirements.
+A requested comprehensive or three-reviewer review keeps its selected coverage;
+a low-risk classification does not cancel it. When a selected roster already
+covers the needed domains, do not add a separate parallel-review trio.
+
+Existing authorization remains valid. For HIGH-risk work, record the applicable
+operator authorization in Notes; ask only if required sign-off is missing.
+Required checks and blocking findings still prevent merge.
+
+When `recommend_split` is true, mention the size and split recommendation. It is
+advisory: continue authorized work when the change is coherent. A large deletion
+can be easier to review as one unit than several incomplete removals.
+
+Record the reviewed base/head or working diff, covered domains, findings, and
+check results. Reuse evidence while its code, dependencies, configuration, and
+environment remain relevant. After fixes, recheck changed paths and affected
+domains. Repeat the whole roster only when its coverage was invalidated or an
+explicit requirement calls for it. CI must cover the head being merged.
 
 ## Script Interface
 

--- a/skills/review/integration-checker/SKILL.md
+++ b/skills/review/integration-checker/SKILL.md
@@ -24,195 +24,62 @@ routing:
   category: process
 ---
 
-# Integration Checker Skill
+# Integration checker
 
-**Existence does not equal integration.** A component existing is implementation-level verification; a component being connected is integration-level verification. Both are necessary. Neither is sufficient alone.
+Check that components are connected and receive real data. A function can pass unit tests yet never be called; an endpoint can exist without being registered.
 
-This skill catches the most common class of real-world bugs in AI-generated code: components that are individually correct but not connected to each other. A function can exist, contain real logic, pass correctness verification, and never be imported or called. An API endpoint can be defined but never wired into the router. An event handler can be registered but never receive events.
+This skill reads and reports. Return fixes to the active implementation task or `feature-lifecycle`; do not create another approval round when fixes are already authorized.
 
-This is a read-only analysis skill -- it reads and reports but does not fix wiring issues. Fixes route back to /feature-lifecycle (implement phase) or the user, because integration fixes often require design decisions about which component should call which.
+## Reference loading
 
----
+Load `references/wiring-checks.md` for language detection, export exclusions, wiring states, data-flow failures, contract patterns, and the requirements map.
 
-## Reference Loading Table
+## Phase 0: PRIME
 
-| Signal | Load These Files | Why |
+Read repository instructions. In a feature pipeline, use `.feature/state/implement/` to scope changed and added files. Otherwise use the requested path or diff; a requested full audit covers all source files. If the implementation artifact is missing, use the diff and state the gap.
+
+Detect every language in scope. Reuse existing integration evidence for unchanged connections; trace affected producers and consumers beyond the diff where needed.
+
+**Gate:** Scope and languages are known.
+
+## Phase 1: EXPORT/IMPORT MAP
+
+Inventory public symbols using language-aware searches:
+
+- Go: exported package functions, types, constants, variables, and methods.
+- Python: module definitions, `__all__`, and `__init__.py` re-exports.
+- TypeScript/JavaScript: named/default exports and barrel re-exports.
+
+Exclude dependencies, generated files, build output, fixtures, and repository metadata. Apply the reference's exceptions for public library APIs, plugin contracts, framework entrypoints, and other legitimate external consumers before calling a symbol orphaned.
+
+For each symbol, record file, name, kind, and line. Find imports and actual usage; an import alone does not establish wiring. Classify as ORPHANED, IMPORTED_NOT_USED, or WIRED using the reference. Report failures first; show successful connections only in verbose mode.
+
+**Gate:** Every in-scope symbol has a status or an explicit unresolved limitation.
+
+## Phase 2: DATA FLOW AND CONTRACT CHECK
+
+Trace WIRED connections for real inputs and compatible contracts. Check hardcoded empty data, placeholders, dead parameters, mock remnants, shape/type mismatches, and event/message names using the reference.
+
+Static inspection establishes structure and likely compatibility, not runtime correctness. Use existing runtime evidence where available; distinguish observed failures from uncertain dynamic-language matches. Low-confidence contract findings warn rather than fail.
+
+**Gate:** Data-flow and contract findings include locations, evidence, and confidence.
+
+## Phase 3: REPORT
+
+Report component counts, wiring failures, data-flow issues, contract mismatches, and concrete fixes. In pipeline mode, use `.feature/state/plan/` to map each requirement from entrypoint to implementation as WIRED, PARTIAL, or UNWIRED.
+
+Compute integration score as `100 * WIRED / (WIRED + IMPORTED_NOT_USED + ORPHANED)`; report N/A when the denominator is zero.
+
+| Verdict | Condition | Next action |
 |---|---|---|
-| classifying exports/imports and tracing data flow (Phases 0-2) | `wiring-checks.md` | Loads detailed guidance from `wiring-checks.md`. |
+| PASS | No wiring, flow, or contract issues | Continue validation |
+| WARN | Unused imports or low-confidence contract findings only | Resolve or explain warnings |
+| FAIL | Orphaned components, data-flow defects, or high-confidence contract mismatches | Return concrete fixes to implementation |
 
-## Instructions
+State incomplete coverage separately; missing source or unresolved scope cannot establish a PASS. Include circular imports as integration findings. For a large monorepo, narrow to affected connections unless the user requested a full audit; split a full audit into bounded scopes without silently omitting files.
 
-### Phase 0: PRIME
-
-**Goal**: Establish context, detect language, identify scope.
-
-**Step 1: Read repository CLAUDE.md** (if present) and follow any project-specific conventions before proceeding.
-
-**Step 2: Detect execution context**
-
-Determine if running within the feature pipeline or standalone:
-- **Pipeline**: Check for `.feature/state/implement/` artifact. If present, load it to understand what was built and scope the check to changed/added files. Scoping to changed files prevents wasting time analyzing unchanged code in large repositories.
-- **Standalone**: Scope to the current working directory or user-specified path. Analyze all source files.
-
-**Step 3: Detect project language(s)**
-
-Detect language(s) before applying any verification techniques -- different languages have fundamentally different import/export patterns.
-
-> See `references/wiring-checks.md` for language detection indicators, per-language export/import patterns, and common integration failures per language.
-
-Multiple languages may coexist. Run all applicable techniques for each.
-
-**Gate**: Language(s) detected. Scope established. Proceed to Phase 1.
-
----
-
-### Phase 1: EXPORT/IMPORT MAP
-
-**Goal**: For every export in scope, determine its wiring status. Every export gets exactly one of three states -- no ambiguous classifications.
-
-**Step 1: Discover exports**
-
-Scan source files for exported symbols. Be language-aware:
-
-- **Go**: Find all capitalized function, type, const, and var declarations at package level. Include method receivers on exported types.
-- **Python**: Find all module-level function/class/variable definitions. Check `__all__` if present (it restricts the public API). Check `__init__.py` for re-exports.
-- **TypeScript/JavaScript**: Find all `export` declarations, `export default`, and barrel file re-exports.
-
-Skip `node_modules/`, `vendor/`, `.git/`, `__pycache__/`, `dist/`, `build/`, test fixtures, and generated files. These contain intentionally unused exports (library code, vendored deps) that would flood the report with false positives.
-
-Record each export as: `{file, name, kind (function/type/const/var), line}`.
-
-**Step 2: Discover imports and usages**
-
-For each export found, search the codebase for:
-1. **Import**: The symbol is imported (appears in an import statement referencing the exporting module)
-2. **Usage**: The imported symbol is actually used (called, referenced, assigned, passed as argument) beyond the import statement itself
-
-Both checks are required. An import without usage is a distinct failure mode from an orphan -- it signals someone intended to use the component but didn't finish wiring it.
-
-**Step 3: Classify each export**
-
-> See `references/wiring-checks.md` for the full classification table, exclusion list, and files to skip during discovery.
-
-**Step 4: Build the export/import map**
-
-Report failures first -- users need to see ORPHANED before IMPORTED_NOT_USED before WIRED.
-
-```
-## Export/Import Map
-
-### ORPHANED (Failure)
-| File | Export | Kind | Imported By |
-|------|--------|------|-------------|
-| api/handlers.go | HandleUserDelete | func | (none) |
-| utils/format.py | format_currency | func | (none) |
-
-### IMPORTED_NOT_USED (Warning)
-| File | Export | Kind | Imported By | Used? |
-|------|--------|------|-------------|-------|
-| api/handlers.go | HandleUserUpdate | func | routes/api.go | No |
-
-### WIRED (Pass) — [N] components
-(Shown only in verbose mode)
-```
-
-**Gate**: All in-scope exports classified. Map produced. Proceed to Phase 2.
-
----
-
-### Phase 2: DATA FLOW AND CONTRACT CHECK
-
-**Goal**: For WIRED components, verify that real data flows through the connections and that output shapes match input expectations. A component wired to always receive empty data is functionally disconnected.
-
-This phase checks two things simultaneously because they both operate on the same set of WIRED connections identified in Phase 1.
-
-This is structural analysis, not semantic verification. Contract checking verifies shape and naming compatibility, not whether data is logically correct -- semantic correctness would require runtime information that static analysis cannot provide.
-
-#### Data Flow Tracing
-
-For each WIRED connection, check whether real data actually reaches the component.
-
-> See `references/wiring-checks.md` for the full catalog of data flow failure patterns (hardcoded empty data, placeholder data, dead parameters, mock remnants) and contract mismatch patterns (shape, type, event/message mismatches) with confidence level guidance.
-
-**Gate**: Data flow and contract findings recorded. Proceed to Phase 3.
-
----
-
-### Phase 3: REPORT
-
-**Goal**: Produce a structured integration report with actionable findings. Report facts and show the wiring map -- not prose about the wiring map.
-
-**Step 1: Requirements integration map (pipeline mode only)**
-
-If running within the feature pipeline and a task plan exists in `.feature/state/plan/`, trace each requirement from entry point to implementation using WIRED / PARTIAL / UNWIRED status.
-
-> See `references/wiring-checks.md` for the requirements integration map format and status definitions.
-
-**Step 2: Compile integration report**
-
-```markdown
-# Integration Check Report
-
-## Summary
-- Components checked: [N]
-- WIRED: [N]
-- IMPORTED_NOT_USED: [N]
-- ORPHANED: [N]
-- Data flow issues: [N]
-- Contract mismatches: [N]
-- Integration score: [WIRED / (WIRED + IMPORTED_NOT_USED + ORPHANED) * 100]%
-
-## Verdict: PASS / WARN / FAIL
-
-PASS: No ORPHANED components, no data flow issues, no contract mismatches
-WARN: No ORPHANED, but has IMPORTED_NOT_USED or low-confidence contract findings
-FAIL: Has ORPHANED components, data flow issues, or high-confidence contract mismatches
-
-## Export/Import Map
-[From Phase 1 — only issues, unless verbose mode]
-
-## Data Flow Issues
-[From Phase 2 — data flow findings]
-
-## Contract Mismatches
-[From Phase 2 — contract findings with confidence level]
-
-## Requirements Integration Map
-[From Step 1 — if in pipeline mode]
-
-## Recommended Actions
-1. [Specific action for each ORPHANED component]
-2. [Specific action for each IMPORTED_NOT_USED]
-3. [Specific action for each data flow issue]
-4. [Specific action for each contract mismatch]
-```
-
-Only fail the verdict on high-confidence contract mismatches. Low-confidence findings in dynamic languages are informational -- they belong in the WARN tier, not FAIL.
-
-**Step 3: Verdict and next steps**
-
-| Verdict | Next Step |
-|---------|-----------|
-| **PASS** | Proceed to /feature-lifecycle (validate phase) |
-| **WARN** | Review warnings. Proceed if warnings are intentional (unused imports for future use, etc.). Fix if unintentional. |
-| **FAIL** | Route back to /feature-lifecycle (implement phase) with specific wiring tasks so validation runs only after the wiring is in place. |
-
-**Gate**: Report produced with verdict and actionable recommendations.
-
----
-
-## Error Handling
-
-| Error | Cause | Solution |
-|-------|-------|----------|
-| No source files found | Wrong scope path or empty project | Verify working directory, check scope parameter |
-| Language not detected | No recognizable build files or source extensions | Specify language manually or check project structure |
-| Too many exports to analyze | Large monorepo or library with thousands of exports | Narrow scope to changed files (use `git diff --name-only` against base branch) |
-| False positive ORPHANED | Library code, plugin interfaces, or entry points | Check exclusion patterns. If legitimate public API, add to exclusions. |
-| Circular import detected | Python circular imports or Go import cycles | Report as separate finding -- circular imports are integration issues themselves |
-| No implementation artifact | Running in pipeline mode but implement phase didn't checkpoint | Fall back to standalone mode using git diff to identify changed files |
+**Gate:** Findings, limitations, and next actions are clear. After fixes, recheck affected connections rather than repeating unchanged analysis.
 
 ## References
 
-- [Feature State Conventions](../feature-lifecycle/references/shared.md)
-- [ADR-078: Integration Checker](../../adr/078-integration-checker.md)
+- [Feature state conventions](../../process/feature-lifecycle/references/shared.md)

--- a/skills/review/parallel-code-review/SKILL.md
+++ b/skills/review/parallel-code-review/SKILL.md
@@ -21,284 +21,105 @@ routing:
     - verification-before-completion
 ---
 
-# Parallel Code Review Skill
+# Parallel code review
 
-Orchestrate three specialized code reviewers (Security, Business Logic, Architecture) in true parallel using the Fan-Out/Fan-In pattern. Each reviewer runs independently with domain-specific focus, then findings are aggregated by severity into a unified BLOCK/FIX/APPROVE verdict.
+Divide a review among Security, Business Logic, and Architecture reviewers, then combine their findings. Use the shared procedure in `../systematic-code-review/SKILL.md` for evidence, finding verification, and review reuse.
 
-## Reference Loading Table
+## Reference loading
 
-| Signal | Load These Files | Why |
-|---|---|---|
-| selecting the Architecture reviewer brief | `architecture-smell-baseline.md` | Supplies the required architecture smell baseline. |
+| Task | Reference |
+|---|---|
+| Select PR review scope and roster | `../../process/pr-workflow/references/pr-risk-policy.md` |
+| Brief the Architecture reviewer | `references/architecture-smell-baseline.md` |
 
----
+## Phase 1: IDENTIFY SCOPE
 
-## Instructions
-
-### Phase 1: IDENTIFY SCOPE
-
-**Goal**: Determine changed files and select appropriate agents before dispatching.
-
-**Step 1: Read repository CLAUDE.md** to load project-specific conventions that reviewers must respect.
-
-**Step 2: List changed files**
+Read repository instructions and identify the requested diff or files:
 
 ```bash
-# For recent commits:
 git diff --name-only HEAD~1
-# For PRs:
 gh pr view --json files -q '.files[].path'
 ```
 
-**Step 3: Select architecture reviewer agent** based on the dominant language. This ensures the architecture reviewer applies idiomatic standards rather than generic advice, because different languages have fundamentally different design patterns and conventions.
+Use the actual requested base, not `HEAD~1`, for a multi-commit change. Record the reviewed revision and relevant existing checks.
 
-| File Types | Agent |
-|-----------|-------|
-| `.go` files | `golang-general-engineer` |
-| `.py` files | `python-general-engineer` |
-| `.ts`/`.tsx` files | `typescript-frontend-engineer` |
-| Mixed or other | `Explore` |
+Honor an explicit user or `/do` roster. For this skill's three-reviewer mode, keep all three roles. Do not start another trio when this skill is used inside an already selected roster. Automatic PR review selection belongs to the risk policy, including its high-risk requirements.
 
-**Optional enrichments** (only when user explicitly requests):
-- "include threat model" -- adds threat modeling to Security reviewer scope
-- "find breaking commit" -- adds git bisect regression tracking
-- "benchmark" -- adds performance profiling to Architecture reviewer scope
+Select the Architecture reviewer by language: Go → `golang-general-engineer`; Python → `python-general-engineer`; TypeScript → `typescript-frontend-engineer`; mixed or other → `Explore`. Add threat modeling, git bisect, or benchmarks when explicitly requested.
 
-**Gate**: Changed files listed, architecture reviewer agent selected. Proceed only when gate passes.
+**Gate:** Scope, roster, and review evidence are known.
 
-### Phase 2: DISPATCH PARALLEL REVIEWERS
+## Phase 2: DISPATCH PARALLEL REVIEWERS
 
-**Goal**: Launch all 3 reviewers in a single message for true concurrent execution.
+Dispatch the selected independent reviewers together. Reviewers read and report; they do not edit code. Supply the same task intent, diff base/head, constraints, and relevant check results, with a distinct focus:
 
-**Critical constraint**: All three Task calls MUST appear in ONE response. Sending them sequentially triples wall-clock time and defeats the purpose of parallel review. This is not optional—parallelism is the entire value proposition of this skill.
+| Role | Focus |
+|---|---|
+| Security | Authentication, authorization, input validation, secrets, relevant OWASP risks |
+| Business Logic | Requirements, edge cases, state transitions, validation, failure modes, documentation accuracy |
+| Architecture | Design, structure, performance, maintainability, scope, simplicity |
 
-Dispatch exactly these 3 agents. This is a read-only review—reviewers observe and report but never modify code.
+All reviewers can flag documentation errors and scope creep. Give the Architecture reviewer `references/architecture-smell-baseline.md` verbatim; it contains the 12 smells, language counter-examples, and severity cap.
 
-**Reviewer 1 -- Security**
-- Focus: OWASP Top 10, authentication, authorization, input validation, secrets exposure
-- Output: Severity-classified findings with `file:line` references
+Require concrete findings with `[Reviewer]`, `file:line`, severity, and consequence. Reuse valid checks rather than having each worker run the same suite.
 
-**Reviewer 2 -- Business Logic**
-- Focus: Requirements coverage, edge cases, state transitions, data validation, failure modes
-- Output: Severity-classified findings with `file:line` references
+**Gate:** Every selected reviewer returned, or the report explicitly identifies incomplete coverage without claiming approval.
 
-**Reviewer 3 -- Architecture** (using agent selected in Phase 1)
-- Focus: Design patterns, naming, structure, performance, maintainability
-- Output: Severity-classified findings with `file:line` references
-- **Smell baseline (always-on):** in addition to the role focus, the Architecture reviewer carries a curated Fowler "Bad Smells" baseline so design issues surface even when nothing else flags the diff. The full brief — counter-examples per language, severity cap, and the 12 smells — lives in `references/architecture-smell-baseline.md`. Pass the brief verbatim to the Architecture reviewer; do not paraphrase.
+## Phase 3: AGGREGATE
 
-**Dimension lenses (all 3 reviewers apply, in addition to their role focus).** Roles cover *who* reviews; lenses cover *what classes of issue* every review must touch. Folding these into the existing briefs catches doc-accuracy and scope creep without paying for extra agents:
-
-| Lens | What it catches | Owner reviewer (primary) |
-|------|-----------------|--------------------------|
-| Doc-accuracy | Comments, docstrings, READMEs, or PR description that no longer match the code's actual behavior | Business Logic |
-| Scope / simplicity | Changes beyond the stated task, speculative abstraction, dead options, YAGNI violations | Architecture |
-
-Each reviewer reports lens findings inline with its role findings, tagged with the same `[Reviewer]` and `file:line` format so they flow through the schema gate unchanged.
-
-**Critical constraint**: Always run all 3 reviewers regardless of perceived change simplicity. Config changes can expose secrets, "trivial" fixes can break authorization, and each reviewer's specialization catches issues the others miss. Let a reviewer report "no findings" rather than skip it—because silence is information too.
-
-**Gate**: All 3 Task calls dispatched in a single message. Proceed only when ALL 3 return results—never issue a verdict from partial results, because the missing reviewer may hold the only CRITICAL finding. Partial results are worse than no review.
-
-### Phase 3: AGGREGATE
-
-**Goal**: Merge all findings into a unified severity-classified report.
-
-**Critical constraint**: Never dump raw reviewer outputs as three separate sections—the reader should not have to mentally merge findings across reviewers. Your job is to synthesize, not summarize.
-
-**Step 1: Classify each finding by severity**
+Combine duplicate findings, retaining evidence and resolving severity disagreements against the code. Use the shared procedure's finding verification step; group uncertain related findings for independent checking when warranted. Do not automatically spawn a verifier for each finding.
 
 | Severity | Meaning | Action |
-|----------|---------|--------|
-| CRITICAL | Security vulnerability, data loss risk | BLOCK merge |
-| HIGH | Significant bug, logic error | Fix before merge |
-| MEDIUM | Code quality issue, potential problem | Should fix |
-| LOW | Minor issue, style preference | Nice to have |
+|---|---|---|
+| CRITICAL | Security vulnerability or data loss | Block merge |
+| HIGH | Significant bug or logic error | Fix before merge |
+| MEDIUM | Material quality issue or potential problem | Should fix |
+| LOW | Minor issue or preference | Optional |
 
-**Step 2: Deduplicate overlapping findings**
+Report supported findings at their final severity. Record material refutations and severity changes; unresolved consequential disagreement remains visible.
 
-Multiple reviewers may flag the same issue. Merge duplicates, keeping the highest severity. Overlap between reviewers is a feature (independent confirmation), but the report should consolidate it so readers see a unified issue once, not three times.
+**Gate:** Findings are deduplicated and checked against evidence.
 
-**Step 3: Build reviewer summary matrix**
+## Phase 4: VERDICT
 
-Include this matrix in every report so stakeholders see the severity distribution at a glance:
+CRITICAL → **BLOCK**. HIGH without CRITICAL → **FIX**. Only MEDIUM/LOW or no findings → **APPROVE**, provided required coverage and checks are complete.
 
-```
-| Reviewer       | CRITICAL | HIGH | MEDIUM | LOW |
-|----------------|----------|------|--------|-----|
-| Security       | N        | N    | N      | N   |
-| Business Logic | N        | N    | N      | N   |
-| Architecture   | N        | N    | N      | N   |
-| **Total**      | **N**    | **N**| **N**  | **N**|
-```
-
-**Gate**: All findings classified, deduplicated, and summarized. Proceed only when gate passes.
-
-### Phase 3.5: ADVERSARIAL VERIFY (GATED)
-
-**Goal**: Refute each surviving finding independently before it reaches the report, so speculative or already-handled findings are dropped instead of shipped. This is the behavior that cut a native review from 10 findings to 3 (~70% noise removed) and directly targets the false-positive class that produced a 25% false-positive rate earlier.
-
-**Run this phase ONLY when the gate condition below is true. Otherwise skip straight to Phase 4 — small, clean reviews pay nothing.**
-
-**Gate condition (run the verify pass when EITHER is true):**
-
-```
-findings_count >= 4   OR   any finding is severity CRITICAL or HIGH
-```
-
-Otherwise (≤3 findings, all MEDIUM/LOW): skip this phase. State in the report: `Adversarial verify: SKIPPED (N findings, max severity MEDIUM — below gate).`
-
-**Step 1: Dispatch one verification check per finding.** Each finding gets an independent check (a Task call) prompted to REFUTE the finding, not confirm it. Dispatch the checks for a single review in one message so they run concurrently, matching the parallel pattern of Phase 2. The verifier's default stance is **not-real**; the finding survives only if the verifier cannot refute it.
-
-Verifier prompt contract (per finding):
-- Input: the finding text, its `file:line`, its claimed severity, and read access to the cited code.
-- Task: attempt to refute. Mark the finding **REFUTED** if any of these hold:
-  - **Speculative** — the failure path is hypothetical; no concrete input or call sequence reaches it.
-  - **Already-handled** — a guard, validation, type constraint, or upstream caller already prevents it (cite the line that handles it).
-  - **Not actionable** — no specific code change would resolve it, or it restates a style preference already covered by lint/format.
-- Output: `CONFIRMED` or `REFUTED`, a one-line justification with a `file:line` citation, and (for confirmed findings) a verified severity per Step 2.
-
-**Step 2: Verify-and-downgrade severity.** Reviewers over-grade. The verifier may re-grade a confirmed finding's severity, recording original→final with a written justification. Severity changes only on evidence (e.g., "downgraded CRITICAL→MEDIUM: the unsanitized value is server-issued UUID, not user input — `auth/token.go:88`"). Record every re-grade; never silently alter a severity.
-
-**Step 3: Keep only CONFIRMED findings.** REFUTED findings are removed from the aggregate and listed separately as refuted (with the refutation reason) so the reader sees what was filtered and why — transparency, not a silent drop.
-
-**Honest framing**: per-finding verify catches false positives at the structure-and-plausibility level — it refutes findings whose failure path is hypothetical or already-guarded. It is not a correctness oracle: it cannot prove a confirmed finding is a real exploitable bug, only that a refutation attempt failed. Treat CONFIRMED as "survived refutation," not "proven."
-
-**Cost guardrail**: the verify pass scales linearly with finding count (one check per finding) and is bounded two ways — (1) the gate above skips it entirely for small/clean reviews, and (2) it runs at most once per finding (no verify-the-verifier recursion). For larger diffs, cap the number of verify checks to the right-sizing tier for the review (the tier rules and `scripts/right-size-review.py` live outside this skill; reference the tier the review was sized to). When the cap is hit, verify the highest-severity findings first and note the uncapped remainder in the report.
-
-**Gate**: Verify pass was either skipped (gate condition false, stated in report) or completed (every finding marked CONFIRMED/REFUTED, severity re-grades recorded). Proceed only when gate passes.
-
-### Phase 4: VERDICT
-
-**Goal**: Produce final report with clear recommendation.
-
-**Critical constraint**: Every review must end with an explicit verdict. Ambiguity is a decision to merge untested code. Choose: BLOCK, FIX, or APPROVE.
-
-The verdict is computed from **confirmed findings only** (after Phase 3.5). When the verify pass was skipped, all aggregated findings count as confirmed. Use each finding's **final** severity (post-downgrade), not its original.
-
-**Step 1: Determine verdict**
-
-| Condition | Verdict |
-|-----------|---------|
-| Any CRITICAL findings | **BLOCK** |
-| HIGH findings, no CRITICAL | **FIX** (fix before merge) |
-| Only MEDIUM/LOW findings | **APPROVE** (with suggestions) |
-
-**Step 2: Output structured report**
+Use this structure for each reviewer's output and the combined report:
 
 ```markdown
 ## Parallel Review Complete
 
 ### Severity Matrix
-
 | Severity | Count | Summary |
 |----------|-------|---------|
-| Critical | N | One-line aggregated summary |
-| High     | N | One-line aggregated summary |
-| Medium   | N | One-line aggregated summary |
-| Low      | N | One-line aggregated summary |
-
-Counts above are CONFIRMED findings (post-verify). Details by reviewer below.
-
-### Adversarial Verify
-- Status: RAN (gate: N findings / max severity X) | SKIPPED (gate condition false)
-- Confirmed: N | Refuted: N
-- Severity re-grades: [original→final with justification, or "none"]
-
-### Refuted Findings (filtered, not in verdict)
-1. [Reviewer] Original finding - file:line — Refuted: [speculative | already-handled | not-actionable] ([citing file:line])
+| Critical | 0 | None |
+| High | 0 | None |
+| Medium | 0 | None |
+| Low | 0 | None |
 
 ### Combined Findings
-
-#### CRITICAL (Block Merge)
-1. [Reviewer] Issue description - file:line
-
-#### HIGH (Fix Before Merge)
-1. [Reviewer] Issue description - file:line
-
-#### MEDIUM (Should Fix)
-1. [Reviewer] Issue description - file:line
-
-#### LOW (Nice to Have)
-1. [Reviewer] Issue description - file:line
-
-### Summary by Reviewer
-[Matrix from Phase 3]
+[Findings grouped by severity; each has [Reviewer] and path/file.ext:42.]
 
 ### Recommendation
-**VERDICT** - [1-2 sentence rationale]
+**APPROVE** - Scope, evidence, and limitations.
 ```
 
-**Step 3: Validate the structured output (schema gate)**
+Update counts from the final findings. Include reviewer coverage and material unresolved questions. Keep a single combined report instead of pasting three raw reports.
 
-Each reviewer returns markdown. Before accepting a reviewer's output into the aggregate, run it through the deterministic schema validator so a malformed review is caught mechanically rather than trusted on sight:
+Validate each reviewer output before aggregation; use separate paths:
 
 ```bash
-# Pipe each reviewer's markdown directly (preferred — no shared temp file, so
-# 3 parallel reviewers never overwrite each other):
-echo "$reviewer_markdown" | python3 scripts/validate-review-output.py --type parallel -
-# Or, if writing to disk, use a per-reviewer path (NOT a shared /tmp file):
-python3 scripts/validate-review-output.py --type parallel /tmp/reviewer-<name>.md
+python3 scripts/validate-review-output.py --type parallel /tmp/reviewer-security.md
 ```
 
-Exit codes: `0` = structurally valid (verdict present, severity_matrix complete, every finding carries `[Reviewer]` and a `file:line` location); `1` = schema errors; `2` = unparseable; `3` = `jsonschema` not installed (`pip install jsonschema`).
+Exit `0` means valid structure; `1` means schema errors; `2` means unparseable; `3` means `jsonschema` is missing (`pip install jsonschema`). Repair the affected output once using the diagnostics and revalidate. If it still fails, report incomplete review rather than accepting malformed data.
 
-This gate verifies the review is **structurally well-formed** (verdict, severity buckets, and locations present) — it does NOT verify findings completeness (no minimum count; a parser-dropped malformed finding leaves no trace) NOR that the severity_matrix counts agree with the findings array (no matrix↔findings cross-check).
+The validator checks verdict, severity buckets, reviewer tags, and parsed locations. It does not prove completeness or match matrix counts to findings; check those yourself.
 
-**On validation failure:** retry that ONE reviewer exactly once, then stop.
-- **Exit 1 (schema errors):** re-invoke the reviewer passing the validator's specific numbered error lines (e.g. `MISSING: reviewer`, `MISSING: location`) so it knows precisely what to repair.
-- **Exit 2 (unparseable):** there are no per-error lines to feed back — the output couldn't be structured at all. Regenerate the reviewer's markdown from scratch in the required format.
+After fixes, review the changed paths and affected domains. Keep unaffected results when their code and assumptions remain valid. Repeat the full roster only when changes invalidate that coverage or an explicit review requirement demands it.
 
-Validate the retried result. If it still fails, STOP and report the malformed output — proceed only on review data that passes the schema, because a verdict synthesized from broken findings is worse than no verdict.
+**Gate:** Required reviewers returned valid reports; the combined verdict matches the evidence.
 
-**Step 4: If BLOCK verdict, initiate re-review protocol**
+## Recovery
 
-After user addresses CRITICAL issues, re-run ALL 3 reviewers (not just the one that found the issue) to verify:
-1. Original CRITICAL issues resolved
-2. No regressions introduced
-3. No new CRITICAL/HIGH issues from fixes
-
-Re-run all three because fixes often introduce new issues in adjacent code, and you need confirmation across all three domains that the solution is safe.
-
-**Gate**: Each reviewer's output passed `validate-review-output.py --type parallel` (exit 0), structured report delivered with verdict. Review is complete.
-
----
-
-## Error Handling
-
-### Error: "Reviewer Times Out"
-
-**Cause**: One or more Task agents exceed execution time.
-
-**Solution**:
-1. Report findings from completed reviewers immediately—a partial review is better than no review, because you'll know at least some classes of issues are present.
-2. Note which reviewer(s) timed out and on which files, so the user understands the blind spots.
-3. Offer to re-run failed reviewer separately or proceed with partial results (but disclose the incompleteness in the verdict).
-
-### Error: "All Reviewers Fail"
-
-**Cause**: Systemic issue (bad file paths, permission errors, context overflow).
-
-**Solution**:
-1. Verify changed file list is correct and files are readable—start with the basics.
-2. Reduce scope if file count is very large (split into batches), because each reviewer needs enough context tokens to reason properly.
-3. Fall back to systematic-code-review (sequential) as last resort, because at least one reviewer completing sequentially is better than zero reviewers failing.
-
-### Error: "Conflicting Findings Across Reviewers"
-
-**Cause**: Two reviewers disagree on severity or interpretation of same code.
-
-**Solution**:
-1. Keep the higher severity classification (classify UP), because you want to err on the side of caution—false positives are correctable, false negatives ship bugs.
-2. Include both perspectives in the finding description, so the code author understands the disagreement and can make an informed decision.
-3. Flag as "needs author input" if genuinely ambiguous, and include both interpretations verbatim so they can choose.
-
----
-
-## References
-
-- Severity classification: CRITICAL (blocks merge), HIGH (fix before), MEDIUM (should fix), LOW (nice to have)
-- Verdict decision tree: Any CRITICAL → BLOCK; HIGH without CRITICAL → FIX; MEDIUM/LOW only → APPROVE (computed from confirmed findings, final severity)
-- Adversarial verify gate: run per-finding refutation when `findings_count >= 4` OR any finding is CRITICAL/HIGH; else skip. One check per finding, capped to the right-sizing tier; refuted findings filtered, severity re-grades recorded
-- Re-review trigger: Always re-run all 3 reviewers after BLOCK fixes to catch regressions
-- Architecture smell baseline (passed verbatim to the Architecture reviewer): `references/architecture-smell-baseline.md`
+If a reviewer fails, report available findings and missing coverage, then retry that reviewer after fixing the cause. Check paths and permissions; split oversized input into bounded scopes. If parallel execution is unavailable, run the selected roles sequentially with the shared procedure. Never label partial coverage as a completed required review.

--- a/skills/review/systematic-code-review/SKILL.md
+++ b/skills/review/systematic-code-review/SKILL.md
@@ -23,348 +23,101 @@ routing:
     - parallel-code-review
 ---
 
-# Systematic Code Review Skill
+# Systematic code review
 
-Systematic 4-phase code review: UNDERSTAND changes, VERIFY claims against actual behavior, ASSESS security/performance/architecture risks, DOCUMENT findings with severity classification. Each phase has an explicit gate that must pass before proceeding because skipping phases causes missed context, incorrect conclusions, and incomplete risk assessment.
+Review the change, verify its claims, assess risk, and report actionable findings. This is the shared review procedure. Parallel review divides its scope among reviewers; it does not add another full review afterward.
 
-## Reference Loading Table
+## Reference loading
 
-| Signal | Load These Files | Why |
-|---|---|---|
-| reviewing Go code: type exports, concurrency, resource management, observability, test patterns | `go-review-patterns.md` | Loads detailed guidance from `go-review-patterns.md`. |
-| responding to review feedback on your own code | `receiving-feedback.md` | Loads detailed guidance from `receiving-feedback.md`. |
-| labeling findings: BLOCKING vs SHOULD FIX vs SUGGESTION | `severity-classification.md` | Loads detailed guidance from `severity-classification.md`. |
+| Task | Reference |
+|---|---|
+| Select PR review scope and roster | `../../process/pr-workflow/references/pr-risk-policy.md` |
+| Review Go exports, concurrency, resources, metrics, or tests | `references/go-review-patterns.md` |
+| Classify a finding | `references/severity-classification.md` |
+| Respond to feedback | `references/receiving-feedback.md` |
 
-## Instructions
+## Phase 1: UNDERSTAND
 
-### Phase 1: UNDERSTAND
+Read applicable repository instructions and the complete diff. Read enough surrounding code to understand each changed path and its consumers; load whole files when their structure matters. Check the requested outcome, compatibility requirements, and affected dependencies.
 
-**Goal**: Map all changes and their relationships before forming any opinions.
+When signatures, parameter meanings, or sentinel values change, find all callers and interface implementations. Search receiver syntax such as `.GetEvents(`; use type-aware references such as gopls when available. Trace each parameter to its source:
 
-**Step 1: Read CLAUDE.md**
-- Read and follow repository CLAUDE.md files first because project conventions override default review criteria and may define custom severity rules, approved patterns, or scope constraints.
+- Query parameters can contain any user-supplied string, including `"*"`.
+- Token fields may be server-issued IDs; verify that boundary rather than assuming it.
+- Constants and enums have a bounded value set.
 
-**Step 2: Read every changed file**
-- Use Read tool on EVERY changed file completely because reviewing summaries or reading partial files misses dependencies between changes and leads to incorrect conclusions.
-- Map what each file does and how changes affect it.
-- Check affected dependencies and identify ripple effects because changes in one file can break consumers that aren't in the diff.
+Check validation at each caller. A reachable user input that bypasses a security filter is blocking. Verify the caller set yourself; the PR description may omit callers.
 
-**Step 3: Identify dependencies**
-- Use Grep to find all callers/consumers of changed code.
-- Note any comments that make claims about behavior (these are claims to verify in Phase 2, not facts to trust).
+Record the reviewed base/head or working diff, scope, and material unknowns. Ask only when missing information prevents a sound review; continue independent checks.
 
-**Step 3a: Caller Tracing** (mandatory when diff modifies function signatures, parameter semantics, or introduces sentinel/special values)
+**Gate:** Every changed path is accounted for, with affected callers traced where needed.
 
-When the change modifies how a function/method is called or what parameters mean:
+## Phase 2: VERIFY
 
-1. **Find ALL callers** — Grep for the function name with receiver syntax (e.g., `.GetEvents(` not just `GetEvents`) across the entire repo. For Go repos, prefer gopls `go_symbol_references` via ToolSearch("gopls") — it's type-aware and catches interface implementations.
-2. **Trace the VALUE SPACE** — For each parameter source, classify what values can flow through:
-   - Query parameters (`r.FormValue`, `r.URL.Query`): user-controlled — ANY string including sentinel values like `"*"`
-   - Auth token fields: server-controlled (UUIDs, structured IDs)
-   - Constants/enums: fixed set
-   - Classify sentinel strings by their true source. If a value can originate from user input, treat it as reachable and verify the input path.
-3. **Verify each caller** — For each call site, check that parameters are validated before being passed. Pay special attention to sentinel values (e.g., `"*"` meaning "all/unfiltered") that bypass security filtering.
-4. **Report unvalidated paths** — Any caller that passes user input to a security-sensitive parameter without validation is a BLOCKING finding.
-5. **Verify callers independently** — Treat the PR description as a lead, then confirm the caller set directly in the codebase. The PR author may have forgotten about callers, or new callers may have been added in other branches.
+Reuse observed test and review results when they cover the current code, dependencies, configuration, and environment. Record their source and scope. A prior verdict alone is not evidence. After a fix, check the changed paths and affected consumers; repeat broader checks only when the fix invalidates their evidence or repository policy requires it.
 
-This step catches:
-- Unchecked paths where user input reaches a security-sensitive parameter
-- Callers the PR author forgot about or didn't mention
-- Interface implementations that don't enforce the same preconditions
+Run relevant tests for uncovered behavior and all required repository checks. Inspect actual output and retain logs; report commands, results, and limitations without pasting full logs. Missing tools, skipped checks, and inferred outcomes are not passes. Identify whether a test failure is caused by this change or is unrelated; required failing checks still prevent merge.
 
-**Step 4: Document scope**
+Check material claims in comments and the PR description against code, callers, tests, or observed behavior. Verify edge cases and coverage of changed paths. Source inspection can establish structure, but cannot substitute for a runtime result when that is the claim.
 
-```
-PHASE 1: UNDERSTAND
+**Gate:** Claims have supporting evidence; required checks passed or the review records the gap without approving it away.
 
-Changed Files:
-  - [file1.ext]: [+N/-M lines] [brief description of change]
-  - [file2.ext]: [+N/-M lines] [brief description of change]
+## Phase 3: ASSESS
 
-Change Type: [feature | bugfix | refactor | config | docs]
+Assess the risks the change can introduce:
 
-Scope Assessment:
-  - Primary: [what's directly changed]
-  - Secondary: [what's affected by the change]
-  - Dependencies: [external systems/files impacted]
+- Security: authentication, authorization, validation, injection, and secrets. Trace reachable paths; explain material exclusions without reciting unrelated vulnerability checklists.
+- Performance: N+1 queries, unbounded work, allocations, and resource use on affected hot paths. Benchmark when the request or uncertainty warrants it.
+- Architecture: repository conventions, compatibility, scope, and unnecessary abstractions.
+- Extraction: a new reusable helper may need guards that its former single caller supplied. Recheck its contract and callers; raise severity when the new reachability warrants it.
 
-Caller Tracing (if signature/parameter semantics changed):
-  - [function/method]: [N] callers found
-    - [caller1:line] — parameter validated: [yes/no]
-    - [caller2:line] — parameter validated: [yes/no]
-  - Unvalidated paths: [list or "none"]
+Use the severity reference. Blocking findings concern security, correctness, or reliability; SHOULD FIX covers material pattern, test, or debugging problems; SUGGESTIONS are optional. Resolve uncertainty with evidence. Document unresolved consequential uncertainty instead of presenting speculation as a confirmed defect.
 
-Questions for Author:
-  - [Any unclear aspects that need clarification]
-```
+**Gate:** Relevant risks and remaining uncertainty are explicit.
 
-**Gate**: All changed files read (not just some — reading 2 of 5 files and saying "I get the gist" fails this gate), scope fully mapped, callers traced (if applicable). Proceed only when gate passes.
+## Phase 3.5: VERIFY FINDINGS
 
-### Phase 2: VERIFY
+Before reporting a finding, check its input or call sequence, existing guards, and proposed fix. Drop unreachable, already-handled, or non-actionable claims. Cite evidence for material severity changes and disputed findings.
 
-**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+The reviewer normally does this check directly. Use an independent check when a consequential claim remains uncertain or the user requests one. Group related findings for that check; do not create a worker per finding or recursively review the verifier. A finding that survives refutation is supported, not proven correct.
 
-**Goal**: Validate all assertions in code, comments, and PR description against actual behavior.
+When combining reviews, deduplicate findings and resolve conflicting severity from evidence. Retain unresolved high-impact disagreements in the report. After fixes, revisit the findings and affected domains; reuse unaffected review evidence. Preserve explicitly requested rosters and repository review requirements.
 
-**Step 1: Run tests**
-- Execute existing tests for changed files because review cannot approve without test execution — visual inspection misses runtime issues that tests catch.
-- Capture complete test output. Show the output rather than describing it because facts outweigh narrative.
-- Verify test coverage: confirm tests exist for the changed code paths because untested code paths are a SHOULD FIX finding.
+**Gate:** Reported findings have concrete evidence, locations, and an actionable consequence.
 
-**Step 2: Verify claims**
-- Check every comment claim against code behavior because comments frequently become outdated and developers may not understand what "thread-safe" actually means — never accept a comment as truth without inspecting the code that backs it.
-- Verify edge cases mentioned are actually handled.
-- Trace through critical code paths manually.
+## Phase 4: DOCUMENT
 
-**Step 3: Document verification**
+Report issues introduced or exposed by the change, including fixes that must touch consumers outside the diff. Keep speculative features out of the review.
 
-```
-PHASE 2: VERIFY
-
-Claims Verification:
-  Claim: "[Quote from comment or PR description]"
-  Verification: [How verified - test run, code trace, etc.]
-  Result: VALID | INVALID | NEEDS-DISCUSSION
-
-Test Execution:
-  $ [test command]
-  Result: [PASS/FAIL with summary]
-
-Behavior Verification:
-  - Expected: [what change claims to do]
-  - Actual: [what code actually does]
-  - Match: YES | NO | PARTIAL
-```
-
-**Gate**: All assertions in code/comments verified against actual behavior. Tests executed with output captured. Proceed only when gate passes.
-
-### Phase 3: ASSESS
-
-**Goal**: Evaluate security, performance, and architectural risks specific to these changes.
-
-**Step 1: Security assessment**
-- Never skip this step because security implications must be explicitly evaluated for every review, even when changes appear benign.
-- Evaluate OWASP top 10 against changes.
-- Explain HOW each vulnerability was ruled out (not just checkboxes) because a checkbox approach misses context-specific vulnerabilities and gives false confidence.
-- If optionally enabled: perform extended deep security analysis beyond standard checks.
-
-**Step 2: Performance assessment**
-- Identify performance-critical paths and evaluate impact.
-- Check for N+1 queries, unbounded loops, unnecessary allocations.
-- If optionally enabled: benchmark affected code paths with profiling.
-
-**Step 3: Architectural assessment**
-- Compare patterns to existing codebase conventions.
-- Assess breaking change potential.
-- If optionally enabled: check for similar past issues via historical analysis.
-
-**Step 4: Extraction severity escalation**
-- If the diff extracts inline code into named helper functions, re-evaluate all defensive guards.
-- A missing check rated LOW as inline code (1 caller, "upstream validates") becomes MEDIUM as a reusable function (N potential callers).
-
-**Step 5: Document assessment**
-
-```
-PHASE 3: ASSESS
-
-Security Assessment:
-  SQL Injection: [N/A | CHECKED - how verified | ISSUE - details]
-  XSS: [N/A | CHECKED - how verified | ISSUE - details]
-  Input Validation: [N/A | CHECKED - how verified | ISSUE - details]
-  Auth: [N/A | CHECKED - how verified | ISSUE - details]
-  Secrets: [N/A | CHECKED - how verified | ISSUE - details]
-  Findings: [specific issues or "No security issues found"]
-
-Performance Assessment:
-  Findings: [specific issues or "No performance issues found"]
-
-Architectural Assessment:
-  Findings: [specific issues or "Architecturally sound"]
-
-Risk Level: LOW | MEDIUM | HIGH | CRITICAL
-```
-
-**Gate**: Security, performance, and architectural risks explicitly evaluated (not skipped or hand-waved). Proceed only when gate passes.
-
-### Phase 3.5: VERIFY FINDINGS (GATED)
-
-**Goal**: Refute each candidate finding before it reaches the DOCUMENT report, so speculative or already-handled findings are filtered out instead of written up. This mirrors the per-finding adversarial verify that cut a parallel review from 10 findings to 3 and targets the false-positive class that drives over-grading.
-
-**Run this phase ONLY when the gate condition is true. Otherwise skip to Phase 4 — small, clean reviews pay nothing.**
-
-**Gate condition (run the verify pass when EITHER is true):**
-
-```
-candidate_findings_count >= 4   OR   any finding is BLOCKING
-```
-
-Otherwise (≤3 findings, none BLOCKING): skip this phase and note in DOCUMENT: `Finding verify: SKIPPED (N findings, none blocking — below gate).`
-
-**Step 1: Refute each finding.** For every candidate finding from Phases 2–3, attempt to refute it against the actual code. The default stance is **not-real**; a finding survives only if refutation fails. Mark **REFUTED** when:
-- **Speculative** — the failure path is hypothetical; no concrete input or call sequence reaches it (Phase 1 caller tracing is the evidence here).
-- **Already-handled** — a guard, validation, type constraint, or upstream caller already prevents it; cite the line.
-- **Not actionable** — no specific code change resolves it, or it restates a lint/format-covered style preference.
-
-**Step 2: Verify-and-downgrade severity.** Reviewers over-grade; the verify step may re-grade a confirmed finding's tier (BLOCKING / SHOULD FIX / SUGGESTIONS) with a written justification, recording original→final. Change severity only on evidence (e.g., "BLOCKING→SHOULD FIX: the value is a server-issued UUID, not user input — `auth/token.go:88`"). Never silently alter a tier.
-
-**Step 3: Keep only confirmed findings** for DOCUMENT. List refuted findings separately with their refutation reason so the reader sees what was filtered and why.
-
-**Honest framing**: this verify is structure-and-plausibility level — it refutes findings whose path is hypothetical or already-guarded. It is not a correctness oracle: a CONFIRMED finding survived a refutation attempt, it is not thereby proven a real exploitable bug.
-
-**Cost guardrail**: the pass scales with finding count (one refutation per finding) and is bounded — the gate skips it for small/clean reviews, and each finding is verified at most once. For large reviews, cap verification to the right-sizing tier the review was sized to (tier rules and `scripts/right-size-review.py` live outside this skill); verify highest-severity findings first and note any uncapped remainder.
-
-**Gate**: Verify pass was skipped (gate false, noted in DOCUMENT) or completed (each candidate finding CONFIRMED/REFUTED, severity re-grades recorded). Proceed only when gate passes.
-
-### Phase 4: DOCUMENT
-
-**Goal**: Produce structured review output with clear verdict and rationale.
-
-Report facts without self-congratulation. Show command output rather than describing it. Be concise but informative because the review consumer needs actionable findings, not commentary.
-
-Only flag issues within the scope of the changed code because suggesting features outside PR scope is over-engineering — but DO flag all issues IN the changed code even if fixing them requires touching other files. No speculative improvements.
-
-When classifying severity, use the Severity Classification Rules below and classify UP when in doubt because it is better to require a fix and have the author push back than to let a real issue slip through as "optional."
-
-Document **confirmed findings only** (after Phase 3.5). When the verify pass was skipped, all candidate findings count as confirmed. Use each finding's **final** tier (post-downgrade).
-
-```
+```text
 PHASE 4: DOCUMENT
-
 Review Summary:
-  Files Reviewed: [N]
-  Lines Changed: [+X/-Y]
-  Test Status: [PASS/FAIL/SKIPPED]
-  Risk Level: [LOW/MEDIUM/HIGH/CRITICAL]
+  Files Reviewed: N
+  Lines Changed: +X/-Y
+  Test Status: PASS | FAIL | SKIPPED
+  Risk Level: LOW | MEDIUM | HIGH | CRITICAL
 
-Finding Verify: [RAN — confirmed N / refuted N; re-grades: original→final or "none"] | [SKIPPED — N findings, none blocking]
-
-Refuted (filtered, not in verdict):
-  1. [Original finding with file:line] — Refuted: [speculative | already-handled | not-actionable] ([citing file:line])
-
-Findings (use Severity Classification Rules - when in doubt, classify UP):
-
-BLOCKING (cannot merge - security/correctness/reliability):
-  1. [Issue with file:line reference and category from rules]
-
-SHOULD FIX (fix unless urgent - patterns/tests/debugging):
-  1. [Issue with file:line reference and category from rules]
-
-SUGGESTIONS (author's choice - purely stylistic):
-  1. [Suggestion with benefit - only if genuinely optional]
-
-POSITIVE NOTES:
-  1. [Good practice observed]
+BLOCKING:
+  1. Issue and consequence — path/file.ext:42
+SHOULD FIX:
+  1. Issue and consequence — path/file.ext:52
+SUGGESTIONS:
+  1. Optional improvement — path/file.ext:62
 
 Verdict: APPROVE | REQUEST-CHANGES | NEEDS-DISCUSSION
-
-Rationale: [1-2 sentences explaining verdict]
+Rationale: Evidence, review scope, and remaining limitations.
 ```
 
-**Validate the structured output (schema gate)**
+Omit empty findings rather than inventing them. Include reused checks and review scope, material refutations, severity changes, and unverified areas when they affect the decision. Blocking defects or required failing checks prevent approval. Use NEEDS-DISCUSSION for unresolved consequential questions.
 
-Before accepting this review as complete, run the DOCUMENT output through the deterministic schema validator so a malformed review is caught mechanically rather than trusted on sight:
+Validate the report:
 
 ```bash
-# Write the review markdown to a temp file, then validate.
 python3 scripts/validate-review-output.py --type systematic /tmp/review-output.md
-# Or pipe directly:
-echo "$review_markdown" | python3 scripts/validate-review-output.py --type systematic -
 ```
 
-Exit codes: `0` = structurally valid (verdict in {APPROVE, REQUEST-CHANGES, NEEDS-DISCUSSION}, `risk_level` present, every finding carries a `file:line` location); `1` = schema errors; `2` = unparseable; `3` = `jsonschema` not installed (`pip install jsonschema`).
+Exit `0` means structurally valid; `1` means schema errors; `2` means unparseable; `3` means `jsonschema` is missing (`pip install jsonschema`). Repair schema or parse errors once using the diagnostics, then validate again. If still invalid, report the failure without claiming review completion.
 
-This gate verifies the review is **structurally well-formed** (verdict, risk level, and finding locations present) — it does NOT verify findings completeness; a finding the parser couldn't structure is silently dropped rather than flagged.
+The validator checks verdict, risk level, and parsed finding locations. It cannot establish review completeness or catch every parser-dropped finding; compare the rendered report with the findings before accepting it.
 
-**On validation failure:** retry exactly once, then stop.
-- **Exit 1 (schema errors):** regenerate the DOCUMENT output using the validator's specific numbered error lines (e.g. `MISSING: risk_level`, `MISSING: location`) to repair the precise defect.
-- **Exit 2 (unparseable):** there are no per-error lines to feed back — the output couldn't be structured at all. Regenerate the DOCUMENT output from scratch in the required format.
-
-Validate the regenerated output. If it still fails, STOP and report the malformed output — deliver only a review that passes the schema, because a verdict built on findings without locations or a missing risk level is unactionable.
-
-After producing the review, remove any temporary analysis files, notes, or debug outputs created during review because only the final review document should persist.
-
-**Gate**: Output passed `validate-review-output.py --type systematic` (exit 0). Structured review output with clear verdict. Review is complete.
-
----
-
-## Reference Material
-
-### Trust Hierarchy
-
-When conflicting information exists, trust in this order:
-
-1. **Running code** (highest) - What tests show
-2. **HTTP/API requests** - Verified external behavior
-3. **Grep results** - What exists in codebase
-4. **Reading source** - Direct file inspection
-5. **Comments/docs** - Claims that need verification
-6. **PR description** (lowest) - May be outdated or incomplete
-
-### Severity Classification Rules
-
-Three tiers: BLOCKING (cannot merge — security, correctness, reliability), SHOULD FIX (fix unless urgent — patterns, tests, debugging), SUGGESTIONS (genuinely optional — style, naming, micro-optimizations). When in doubt, classify UP.
-
-See `references/severity-classification.md` for full classification tables, the decision tree, and common misclassification examples.
-
-### Go-Specific Review Patterns
-
-Watch for patterns that linters miss: type export design, concurrency patterns (batch+callback, loop variable capture, commit callbacks), resource management (defer placement, connection pool reuse), metrics pre-initialization, testing deduplication, and unnecessary function extraction.
-
-For projects using shared organization libraries: check for manual SQL row iteration instead of helpers, incorrect assertion depth, raw `sql.Open()` in tests, dead migration files, and database-specific naming violations.
-
-See `references/go-review-patterns.md` for full checklists and red flags.
-
-### Receiving Review Feedback
-
-When receiving feedback: read completely, restate requirement to confirm understanding, verify against codebase, evaluate technical soundness, respond with reasoning or just fix it. Never performative agreement. Apply YAGNI check before implementing "proper" features. Stop and clarify before implementing anything unclear — items may be related.
-
-See `references/receiving-feedback.md` for the full reception pattern, pushback examples, implementation order, and external vs internal reviewer handling.
-
----
-
-## Error Handling
-
-### Error: "Incomplete Information"
-Cause: Missing context about the change or its purpose
-Solution:
-1. Ask for clarification in Phase 1
-2. Do not proceed past UNDERSTAND with unanswered questions
-3. Document gaps in scope assessment
-
-### Error: "Test Failures"
-Cause: Tests fail during Phase 2 verification
-Solution:
-1. Document in Phase 2
-2. Automatic BLOCKING finding in Phase 4
-3. Cannot APPROVE with failing tests
-
-### Error: "Unclear Risk"
-Cause: Cannot determine severity of an issue
-Solution:
-1. Default to higher risk level (classify UP)
-2. Document uncertainty in assessment
-3. REQUEST-CHANGES if critical uncertainty exists
-
----
-
-## References
-
-### Examples
-
-#### Example 1: Pull Request Review
-User says: "Review this PR"
-Actions:
-1. Read CLAUDE.md, then read all changed files, map scope and dependencies (UNDERSTAND)
-2. Run tests, verify claims in comments and PR description (VERIFY)
-3. Evaluate security/performance/architecture risks (ASSESS)
-4. Produce structured findings with severity and verdict (DOCUMENT)
-Result: Structured review with clear verdict and rationale
-
-#### Example 2: Pre-Merge Verification
-User says: "Check this before we merge"
-Actions:
-1. Read CLAUDE.md, then read all changes, identify breaking change potential (UNDERSTAND)
-2. Run full test suite, verify backward compatibility claims (VERIFY)
-3. Assess risk level for production deployment (ASSESS)
-4. Document findings with APPROVE/REQUEST-CHANGES verdict (DOCUMENT)
-Result: Go/no-go decision with evidence
+**Gate:** The report passes the schema check and states the verdict and evidence accurately.


### PR DESCRIPTION
## Summary

Consolidate review execution in the systematic review skill and PR roster selection in the risk policy. Reuse checks and unaffected reviews after fixes instead of restarting full review rounds.

## Changes

- Reduce five instruction files from 8,287 to 4,200 words while keeping frontmatter unchanged.
- Preserve explicit user and `/do` rosters, high-risk review requirements, caller tracing, review output validation, and integration domain references.
- Replace automatic per-finding verifier workers with evidence checks and independent review when uncertainty warrants it.
- Correct the low-risk policy's contradictory three-reviewer instruction and its inaccurate medium-path size escalation description.

## Notes

Routing selection and runtime review scripts are unchanged. Existing review schema, risk classifier, and roster tests pass (107 tests); Ruff and skill-content checks pass. Direct review confirmed unchanged frontmatter and retained domain references. Model A/B runs are not part of this user-authorized simplification.
