### PR TITLE
refactor(process): simplify planning and subagent execution

### DIFF
--- a/skills/process/pair-programming/SKILL.md
+++ b/skills/process/pair-programming/SKILL.md
@@ -27,97 +27,75 @@ routing:
 
 # Pair Programming Skill
 
-Collaborative coding through the **Announce-Show-Wait-Apply-Verify** micro-step protocol. The user controls pace, sees every planned change as a diff, and confirms before any file is modified. Works with any domain agent as executor.
-
-This skill runs in the main session (not `context: fork`) because every step requires an interactive user gate — forking would execute autonomously and break the confirmation protocol.
+Use **Announce-Show-Wait-Apply-Verify** when the user wants to review each change before it is applied. Any domain agent can execute. Stay in the interactive main session; a fork cannot conduct these user gates.
 
 ## Instructions
 
 ### Session Setup
 
-1. **User describes what they want to build.** Read relevant code to understand the starting point.
-2. **Create a high-level plan.** Break the task into numbered steps, each representing one logical change. Show the numbered step list to the user before starting any micro-steps.
-3. **Confirm the plan.** Wait for user acknowledgment before starting Step 1. The user may reorder, remove, or add steps.
+1. Read the request and relevant code.
+2. Show a numbered plan with one logical change per step.
+3. Wait for acknowledgment; incorporate requested additions, removals, or reordering.
 
-Maintain step count, current speed setting, and remaining plan throughout the session so you can display "Step N of ~M" with each announcement. The user needs this orientation to stay engaged with the collaborative flow.
+Track current step, remaining steps, and speed. Announce each change as “Step N of ~M.”
 
 ### Micro-Step Protocol (Per Change)
 
-For each step in the plan, execute this 5-step protocol:
-
-**1. Announce** — Describe the next change in 1-2 sentences: what will change and why. Keep announcements brief (1-2 sentences) before showing code immediately because the user came to code together, not to read an essay. Long explanations break flow and reduce collaborative momentum.
-
-**2. Show** — Display the planned code as a diff or code block. The current step size limit (default 15 lines, max 50 lines) exists because users cannot make informed decisions about changes they have not seen. Every change gets shown—even trivial ones, which are fast to approve—so you and the user stay synchronized. Never exceed the limit: split large changes into sub-steps instead.
-
-**3. Wait** — Stop and let the user respond with a control command. Do not proceed until you receive an explicit command—assuming the user will say "ok" and applying preemptively turns this into autonomous mode with a running commentary, violating the micro-step protocol.
+1. **Announce** the change and reason in 1–2 sentences.
+2. **Show** the proposed diff or code block, including trivial changes. Default: 15 lines; hard cap: 50. Split larger changes into named sub-steps such as 3a, 3b, and 3c.
+3. **Wait** for an explicit control command.
+4. **Apply** only after `ok`, `yes`, or `y`.
+5. **Verify** with relevant checks and report the result in one sentence. Use `verification-before-completion` for check selection and evidence; keep project-required checks.
 
 | Command | Action |
 |---------|--------|
-| `ok` / `yes` / `y` | Apply current step, proceed to next |
-| `no` / `n` | Skip this step, propose alternative approach |
-| `faster` | Double step size (max 50 lines) |
-| `slower` | Halve step size (min 5 lines) |
-| `skip` | Skip current step entirely, move to next |
-| `plan` | Show remaining steps overview |
-| `done` | End pair session, run final verification |
+| `ok` / `yes` / `y` | Apply current step, then propose the next |
+| `no` / `n` | Skip this step and propose an alternative |
+| `faster` | Double step size, up to 50 lines; show any revised proposal and wait |
+| `slower` | Halve step size, down to 5 lines; show any revised proposal and wait |
+| `skip` | Skip current step and move to the next |
+| `plan` | Show remaining steps |
+| `done` | End pairing and run final verification |
 
-**4. Apply** — Execute the change only after receiving `ok`/`yes`/`y`. Never apply changes without explicit confirmation—doing so turns collaborative pair programming into autonomous mode with a running commentary.
-
-**5. Verify** — Run relevant checks (lint, type check, test) and report results in one sentence. Catching errors immediately keeps the codebase green and prevents error accumulation across steps, ensuring every change is validated before moving forward.
-
-If a step exceeds the current size limit, split it into sub-steps (Step 3a, 3b, 3c). Announce the split: "This change is ~40 lines. I will split it into 3 sub-steps." This splitting exists because the user must be able to approve or reject individual logical changes—bundling multiple logical changes into one step to avoid splitting defeats the purpose of the micro-step protocol.
+Speed and navigation commands do not approve a code change. Split changes by logical unit as well as size; announce the split before showing its first part.
 
 ### Speed Adjustment
 
-Sessions start at 15 lines per step, balancing progress with reviewability. Apply speed changes immediately when the user requests them and acknowledge the new setting because ignoring pace signals breaks trust and the user's sense of control. The user must feel they are the one steering the session.
+Apply and acknowledge speed changes immediately: “Speed adjusted to ~N lines per step.”
 
-| Setting | Lines Per Step | Trigger |
-|---------|---------------|---------|
-| Slowest | 5 | Multiple `slower` commands |
+| Setting | Lines per step | Trigger |
+|---------|----------------|---------|
+| Slowest | 5 | Repeated `slower` |
 | Slow | 7 | `slower` from default |
 | Default | 15 | Session start |
 | Fast | 30 | `faster` from default |
-| Fastest | 50 | Multiple `faster` commands (hard cap) |
-
-When the user says `faster` or `slower`, acknowledge the change: "Speed adjusted to ~N lines per step."
+| Fastest | 50 | Repeated `faster` |
 
 ### Session End
 
-When the user says `done` or all steps are complete: run final verification (lint, type check, full test suite), show a summary (steps completed, steps skipped, files modified), and report verification results. This end-of-session gate ensures the codebase is left in a valid state.
+When the user says `done` or all steps finish, run required final checks and relevant checks not already valid for the final state. Include a full suite when the project requires it or the changes warrant it. Report completed and skipped steps, changed files, check results, and unfinished work. Ending pairing does not complete skipped work.
 
 ### Examples
 
-**Standard Session** — User says: "Pair program a function that parses CSV lines in Go"
-1. Read existing code, create 5-step plan (struct, parser func, error handling, tests, integration)
-2. Show plan, wait for confirmation
-3. Step 1: Announce "Define a CSVRecord struct" — show 8-line struct — wait — user says `ok` — apply — verify
-4. Step 2: Announce "Add ParseLine function" — show 12-line function — wait — user says `ok` — apply — verify
-5. Continue through remaining steps
+For a Go CSV parser, a plan might cover the record struct, parser, error handling, tests, and integration. Show the plan and wait. Propose an 8-line `CSVRecord` struct, wait for `ok`, apply, and verify. Repeat for the parser.
 
-**Speed Adjustment** — User says `faster` after Step 2
-1. Acknowledge: "Speed adjusted to ~30 lines per step."
-2. Next step shows up to 30 lines instead of 15
-3. If user says `slower` later, drop to ~15
-
-**Session End** — User says `done` after Step 4 of 6
-1. Run `go vet`, `go test ./...`
-2. Report: "4 of 6 steps completed, 0 skipped. Modified: parser.go, parser_test.go. Tests: all passing."
+After `faster` at the default speed, show up to 30 lines per step; `slower` then returns to 15. If the user ends after step 4 of 6, run relevant Go checks such as `go vet` and `go test ./...`, then report the two remaining steps with the results.
 
 ## Error Handling
 
 ### User Says "Just Do It" / Wants Autonomous Mode
-Cause: User wants speed, not collaboration.
-Solution: Acknowledge the preference and offer to switch. Say: "Would you like to switch to autonomous mode? I can implement the remaining steps without confirmation." If they accept, drop the micro-step protocol and implement normally.
+
+An explicit request to finish autonomously changes the mode. Acknowledge it and continue the remaining authorized work without micro-step approvals. Ask only if the requested mode is unclear.
 
 ### Verification Fails After a Step
-Cause: Applied change introduces a lint error, type error, or test failure.
-Solution: Announce the fix as the next micro-step. Show the fix diff, wait for confirmation, apply, re-verify. Do not silently fix verification failures regardless of cause—silent fixes violate the protocol.
+
+Propose the fix as the next micro-step: announce, show, wait, apply, and recheck. Keep the interactive approval contract until the user changes mode.
 
 ### Step Too Large to Fit Size Limit
-Cause: A logical change requires more lines than the current limit.
-Solution: Split into sub-steps (Step 3a, 3b, 3c). Each sub-step stays within the limit. Announce the split: "This change is ~40 lines. I will split it into 3 sub-steps."
+
+Split into logical sub-steps within the current limit. Announce the split and seek approval for each sub-step.
 
 ## References
 
-- [Micro-step protocol control commands](#micro-step-protocol-per-change) — user command table
-- [Speed adjustment table](#speed-adjustment) — lines-per-step settings
+- [Micro-step controls](#micro-step-protocol-per-change)
+- [Speed settings](#speed-adjustment)

--- a/skills/process/planning/SKILL.md
+++ b/skills/process/planning/SKILL.md
@@ -97,47 +97,30 @@ routing:
 
 # Planning Skill
 
-Umbrella skill for the planning lifecycle. Routes to the correct reference based on intent. `/do` remains the front door; the references below are internal methods, not new user commands.
-
-## Routing
-
-Detect the user's intent and load the appropriate reference file:
-
-| Intent | Trigger phrases | Reference |
-|--------|----------------|-----------|
-| **Spec** | "write spec", "user stories", "define requirements", "scope this", "acceptance criteria", "define scope", "spec out" | `${CLAUDE_SKILL_DIR}/references/spec.md` |
-| **Pre-plan** | "discuss ambiguities", "resolve gray areas", "clarify before planning", "assumptions mode", "before we plan", "pre-planning discussion" | `${CLAUDE_SKILL_DIR}/references/pre-plan.md` |
-| **Interview** | dependency tree with independent questions batched into frontier rounds, dependent questions asked sequentially, and a recommendation per question. Triggers: "interview me", "grill me", "depth-first review", "depth-first interview", "not sure", "i'm not sure", "where do i start", "want clarity on", "need clarity on", "what am i missing", "poke holes in", "challenge my assumptions", "think this through with me", "lots of moving parts", "many decisions" | `${CLAUDE_SKILL_DIR}/references/depth-first-interview.md` |
-| **Ambiguity triage** | `/do` detects unresolved choices; decide whether to assume, ask, elicit, or test | `${CLAUDE_SKILL_DIR}/references/ambiguity-triage.md` |
-| **Human source** | knowledge or authority exists with a stakeholder, expert, client, or team | `${CLAUDE_SKILL_DIR}/references/human-source-elicitation.md` |
-| **Empirical question** | a prototype, spike, benchmark, or mock can settle an uncertainty | `${CLAUDE_SKILL_DIR}/references/empirical-prototype.md` |
-| **Context boundary** | decide whether to continue, hand off, use a fresh worker, or compact | `${CLAUDE_SKILL_DIR}/references/context-boundary.md` |
-| **Plan-files** | "create plan", "task plan", "working memory", "persistent plan", "file-backed planning" | `${CLAUDE_SKILL_DIR}/references/plan-files.md` (+ `${CLAUDE_SKILL_DIR}/references/executor-ready-plan-template.md` when the plan will be executed by subagents (SDD)) |
-| **Check** | "check plan", "validate plan", "plan checker", "review plan", "is this plan ready", "pre-execution check" | `${CLAUDE_SKILL_DIR}/references/check.md` |
-| **Manage** | "list plans", "show plan", "complete plan", "plan status", "manage plans" | `${CLAUDE_SKILL_DIR}/references/manage.md` |
-| **Pause** | "pause", "save progress", "handoff", "stopping for now", "end session", "session handoff", "wrap up session" | `${CLAUDE_SKILL_DIR}/references/pause.md` |
-| **Resume** | "resume", "continue", "pick up where I left off", "what was I doing", "continue work", "where did I leave off", "what's next" | `${CLAUDE_SKILL_DIR}/references/resume.md` |
+Select the planning method below. `/do` owns capability routing; these references are internal methods. Planning owns specs, saved plans, and plan pause/resume. `subagent-driven-development` owns execution; `session-handoff` owns inline transfers, including live processes. Use `verification-before-completion` for outcome checks.
 
 ## Reference Loading Table
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| "write spec", "user stories", "define requirements", "scope this", "acceptance criteria", "define scope", "spec out" | `spec.md` | **Spec** |
-| "discuss ambiguities", "resolve gray areas", "clarify before planning", "assumptions mode", "before we plan", "pre-planning discussion" | `pre-plan.md` | **Pre-plan** |
-| "interview me", "grill me", "depth-first review", "depth-first interview", "not sure", "i'm not sure", "where do i start", "want clarity on", "need clarity on", "what am i missing", "poke holes in", "challenge my assumptions", "think this through with me", "lots of moving parts", "many decisions" | `depth-first-interview.md` | **Interview** |
-| implicit ambiguity or unclear implementation choices | `ambiguity-triage.md` | Decide whether questions earn their interruption cost |
-| another person holds needed facts, preferences, constraints, or approval | `human-source-elicitation.md` | Create a targeted, sendable question artifact |
-| observation can settle a disputed or unknown choice | `empirical-prototype.md` | Turn uncertainty into bounded evidence |
-| a phase, worker, or session transition is near | `context-boundary.md` | Preserve only the state the receiver needs |
-| "create plan", "task plan", "working memory", "persistent plan", "file-backed planning" | `plan-files.md` (+ `executor-ready-plan-template.md` when plan targets SDD execution) | **Plan-files** |
-| "check plan", "validate plan", "plan checker", "review plan", "is this plan ready", "pre-execution check" | `check.md` | **Check** |
-| "list plans", "show plan", "complete plan", "plan status", "manage plans" | `manage.md` | **Manage** |
-| "pause", "save progress", "handoff", "stopping for now", "end session", "session handoff", "wrap up session" | `pause.md` | **Pause** |
-| "resume", "continue", "pick up where I left off", "what was I doing", "continue work", "where did I leave off", "what's next" | `resume.md` | **Resume** |
+| "write spec", "user stories", "define requirements", "scope this", "acceptance criteria", "define scope", "spec out" | `${CLAUDE_SKILL_DIR}/references/spec.md` | **Spec** |
+| "discuss ambiguities", "resolve gray areas", "clarify before planning", "assumptions mode", "before we plan", "pre-planning discussion" | `${CLAUDE_SKILL_DIR}/references/pre-plan.md` | **Pre-plan** |
+| "interview me", "grill me", "depth-first review", "depth-first interview", "not sure", "i'm not sure", "where do i start", "want clarity on", "need clarity on", "what am i missing", "poke holes in", "challenge my assumptions", "think this through with me", "lots of moving parts", "many decisions" | `${CLAUDE_SKILL_DIR}/references/depth-first-interview.md` | **Interview** |
+| implicit ambiguity or unclear implementation choices | `${CLAUDE_SKILL_DIR}/references/ambiguity-triage.md` | Decide whether questions earn their interruption cost |
+| another person holds needed facts, preferences, constraints, or approval | `${CLAUDE_SKILL_DIR}/references/human-source-elicitation.md` | Create a targeted, sendable question artifact |
+| observation can settle a disputed or unknown choice | `${CLAUDE_SKILL_DIR}/references/empirical-prototype.md` | Turn uncertainty into bounded evidence |
+| a phase, worker, or session transition is near | `${CLAUDE_SKILL_DIR}/references/context-boundary.md` | Preserve only the state the receiver needs |
+| "create plan", "task plan", "working memory", "persistent plan", "file-backed planning" | `${CLAUDE_SKILL_DIR}/references/plan-files.md` (+ `${CLAUDE_SKILL_DIR}/references/executor-ready-plan-template.md` when plan targets SDD execution) | **Plan-files** |
+| "check plan", "validate plan", "plan checker", "review plan", "is this plan ready", "pre-execution check" | `${CLAUDE_SKILL_DIR}/references/check.md` | **Check** |
+| "list plans", "show plan", "complete plan", "plan status", "manage plans" | `${CLAUDE_SKILL_DIR}/references/manage.md` | **Manage** |
+| "pause", "save progress", "handoff", "stopping for now", "end session", "session handoff", "wrap up session" | `${CLAUDE_SKILL_DIR}/references/pause.md` | **Pause** |
+| "resume", "continue", "pick up where I left off", "what was I doing", "continue work", "where did I leave off", "what's next" | `${CLAUDE_SKILL_DIR}/references/resume.md` | **Resume** |
+
+For interviews, use independent questions batched into frontier rounds, dependent questions asked sequentially, and a recommendation per question.
 
 ## Instructions
 
 1. Identify the planning intent and inspect available evidence.
-2. For implicit ambiguity, load `ambiguity-triage.md` before choosing an interview.
+2. For implicit ambiguity, load `${CLAUDE_SKILL_DIR}/references/ambiguity-triage.md` before choosing an interview.
 3. Load the matching reference. Compose references when the task crosses sources or context boundaries.
 4. Follow the selected reference and return to execution as soon as its gate clears.

--- a/skills/process/subagent-driven-development/SKILL.md
+++ b/skills/process/subagent-driven-development/SKILL.md
@@ -25,209 +25,103 @@ routing:
 
 # Subagent-Driven Development Skill
 
+Execute a plan with fresh implementers. Planning owns the plan format; this skill owns task dispatch and integration. Check requirements before code quality. Use the review lane in `skills/process/pr-workflow/SKILL.md` to choose direct or independent review; do not add another roster to a completed review.
+
 ## Instructions
 
 ### Phase 1: SETUP
 
-**Goal**: Extract all tasks and establish project context before any implementation begins.
-
 **Step 1: Read plan and extract tasks**
 
-Read the plan file ONCE. Extract every task with full text:
-
-```markdown
-## Tasks Extracted from Plan
-
-**Task 1: [Title]**
-Full text: [Complete task description from plan]
-Files: [List of files to create/modify]
-Verification: [How to verify this task]
-
-**Task 2: [Title]**
-...
-```
-
-**Why**: Providing complete task text inline prevents subagents from burning tokens reading files and pollutes their context if they need to refer back to the plan. This isolation is critical for clean review cycles.
+Read the plan once. For each task, retain its full text, files, dependencies, and verification commands. Pass these inline rather than sending workers back to the plan.
 
 **Step 2: Create TodoWrite**
 
-Create TodoWrite with ALL tasks:
-```
-1. [pending] Task 1: [Title]
-2. [pending] Task 2: [Title]
-3. [pending] Task 3: [Title]
-```
-
-**Why**: TodoWrite gives the operator visibility and prevents task slip.
+Track all tasks as pending, in progress, or complete with TodoWrite or the harness's task tracker. Reuse the existing plan; do not create a second status artifact.
 
 **Step 3: Gather scene-setting context**
 
-Before dispatching any implementer, capture:
-- Current branch status (`git status`)
-- Capture BASE_SHA: `git rev-parse HEAD` -- required for final integration review
-- Relevant existing code patterns (naming conventions, error handling style)
-- Project conventions from CLAUDE.md
-- Dependencies and setup requirements
-
-This context gets passed to EVERY subagent to prevent repeated discovery and question loops.
-
-**Why**: Early context capture answers 80% of subagent questions before they ask, unblocks implementation immediately, and must be collected once (not rediscovered per task). BASE_SHA must be captured BEFORE the first implementer runs because subsequent edits will move HEAD forward.
+Capture `git status`, project conventions from CLAUDE.md, relevant code patterns, dependencies, and setup requirements. Capture `BASE_SHA` with `git rev-parse HEAD` before the first implementer: it anchors the final integration diff. Include the context each worker needs in its dispatch.
 
 **Step 4: Determine parallel vs sequential dispatch (scope-overlap check)**
-
-Each extracted task already carries its `Files:` list. Feed those file scopes into the deterministic overlap checker before defaulting to sequential. Tasks whose scopes do not overlap can run in parallel; only overlapping tasks must serialize.
 
 ```bash
 python3 scripts/check-scope-overlap.py \
   --tasks '[{"id":"task-1","scope":["path/a.py"]},{"id":"task-2","scope":["path/b.py"]}]' \
-  --human   # use --check for exit 0 (no conflicts) / exit 1 (conflicts) in scripted gates
+  --human   # --check: exit 0 for no conflicts, 1 for conflicts
 ```
 
-Each task object takes `id` (string) and `scope` (list of file/dir paths); add `"readonly": true` for tasks that only read a path. Directory entries match any file beneath them. The output reports conflicting pairs plus parallel groups and a dispatch recommendation. Use those groups to decide Phase 2 dispatch: parallelize within a group, serialize across overlapping tasks.
+Each task has an `id` and `scope` path list. Directories include descendants; `"readonly": true` marks read-only tasks. Use the reported parallel groups, then account for dependencies: serialize overlapping writes and tasks that consume earlier results. Independent groups may run in parallel.
 
-**Gate**: All tasks extracted with full text. BASE_SHA captured. Scene-setting context gathered. Scope-overlap check run; parallel groups identified. Proceed only when gate passes.
+**Gate**: Full tasks, BASE_SHA, context, dependencies, and checked file scopes are ready.
 
 ### Phase 2: EXECUTE (Per-Task Loop)
 
-**Goal**: Implement each task with a fresh subagent, then verify through two-stage review.
-
 **Step 1: Mark task in_progress**
 
-Update TodoWrite status for the current task.
+Update the task tracker.
 
 **Step 2: Dispatch implementer subagent**
 
-Use the Task tool with the prompt template from `./implementer-prompt.md`. Include:
-- Full task text (Replace with "see plan" -- subagents must have complete context)
-- Scene-setting context
-- Clear deliverables
-- Permission to ask questions
+Use `./implementer-prompt.md` with full task text, relevant context, deliverables, and checks. Resolve material questions from available evidence; ask the user only when their decision is needed.
 
-Allocate one implementation worktree for the task and reuse it for every correction. Dispatch ADR and code-quality reviewers as read-only agents against the committed candidate; those reviews use `git diff` or `git show` and allocate no worktree. Before implementation checkout creation, run the capacity guard from `worktree-agent`; at the hard threshold, reclaim accepted clean checkouts before dispatch.
+Allocate one implementation worktree per task and reuse it for corrections. Before creating it, run the capacity guard from `worktree-agent`; at the hard threshold, reclaim accepted clean checkouts. Reviewers read the committed candidate with `git diff` or `git show` and need no worktree.
 
-**Verification and STOP contract**: When the plan follows the executor-ready format (see `skills/process/planning/references/executor-ready-plan-template.md`), append the "Executor-Ready Plans" section of `./implementer-prompt.md` to the dispatch prompt — the contract binds only if the implementer receives it. The implementer runs the ancestry drift check before starting, executes each step's verify command before proceeding, and triggers a STOP on any of the template's five STOP conditions (drift, double verification failure, out-of-scope touch, ambiguous or missing instruction, test regression).
+For executor-ready plans, append the template's **Executor-Ready Plans** contract. Keep the plan-creation SHA distinct from execution `BASE_SHA`. The implementer checks ancestry and context drift, runs each step's verify command, and stops for drift, two verification failures, scope violations, ambiguous or missing instructions, or test regression. The complete contract lives in `skills/process/planning/references/executor-ready-plan-template.md`; do not weaken it during dispatch.
 
-**Implementation constraints** (enforced inline):
-- Implementer must understand task fully before coding begins. If they ask questions: answer clearly and completely, provide additional context, re-dispatch with answers. Give them time to fully understand the task.
-- Dispatch follows the Phase 1 scope-overlap decision: parallelize tasks within a non-overlapping group; serialize tasks whose file scopes overlap, because overlapping file edits cause conflicts that are expensive to resolve. When the overlap check reports any conflict, run those tasks sequentially.
-- Implementer MUST follow these steps in order:
-  1. Understand the task fully
-  2. Ask questions if unclear (BEFORE implementing)
-  3. Implement following TDD where appropriate
-  4. Run tests
-  5. Self-review code
-  6. Commit changes
-
-**Why scope-aware dispatch**: When task scopes overlap, parallel edits to the same files break file-locking semantics and require complex merge handling — those tasks serialize so each output feeds the next. When scopes are disjoint (verified by the scope-overlap check), parallel dispatch is safe and faster. The check makes the choice deterministic instead of defaulting to sequential for every plan.
+Implementers understand the task, implement with TDD where appropriate, run relevant and required checks, self-review, and commit. Use `verification-before-completion` for verification rules. A still-valid passing check does not need repeating merely because the task reaches another phase.
 
 **Step 3: Dispatch ADR compliance reviewer subagent**
 
-Use the prompt template from `./adr-reviewer-prompt.md`. The ADR compliance reviewer checks:
-- Does implementation match the ADR EXACTLY?
-- Is anything MISSING from requirements?
-- Is anything EXTRA that was not requested?
+Check the implementation against requirements and any applicable ADR: missing work, unwanted additions, and mismatches. For an independent review, use `./adr-reviewer-prompt.md`. For a direct review lane, the coordinator performs this check. Reuse review of the same candidate and scope.
 
-**Two-stage review constraint** (enforced inline): run ADR compliance review first, then code quality review. ADR compliance gates code quality because code that doesn't match requirements is wrong, regardless of how well-written. Reviewing code quality on functionally wrong code wastes the quality reviewer's effort.
-
-If ADR compliance reviewer finds issues: dispatch new implementer subagent with fix instructions. ADR compliance reviewer reviews again. Repeat until ADR compliance passes.
-
-**Max retries: 3** -- After 3 failed ADR compliance reviews, STOP and escalate:
-> "ADR compliance failing after 3 attempts. Issues: [list]. Need human decision."
-
-**Why escalation after 3 retries**: 3 retries = ~15-20 min of subagent time. If unresolved by then, the problem is structural (ADR is ambiguous, requirements conflict, or subagent fundamentally misunderstood something). Continuing loops wastes tokens. Human needs to decide: clarify ADR, adjust requirements, or accept the implementation as-is.
+Fix requirement failures before code-quality review. Reuse the task worktree and provide precise corrections. After three failed reviews at this stage, stop the loop, report the findings and attempted fixes, and request the decision needed to resolve the conflict.
 
 **Step 4: Dispatch code quality reviewer subagent**
 
-Use the prompt template from `./code-quality-reviewer-prompt.md`. The code quality reviewer checks:
-- Code is well-structured
-- Tests are meaningful
-- Error handling is appropriate
-- No obvious bugs
-
-**Quality review sequencing** (enforced inline): Only dispatch quality reviewer AFTER ADR compliance passes. Code quality review focuses on how well requirements are met, not whether wrong things were built.
-
-If quality reviewer finds issues: implementer fixes Critical and Important issues (Minor issues are optional). Quality reviewer reviews again.
-
-**Max retries: 3** -- After 3 failed quality reviews, STOP and escalate:
-> "Quality review failing after 3 attempts. Issues: [list]. Need human decision."
-
-**Why different retry limits for both stages**: Both stages can get stuck. Both deserve a fair number of attempts (3 each = up to 60 min total per task). Both hitting the limit means something is wrong with the process or the task definition itself.
+After requirements pass, check structure, meaningful tests, error handling, and bugs. For an independent review, use `./code-quality-reviewer-prompt.md`; otherwise review directly. Fix Critical and Important findings; Minor findings are optional. Recheck affected findings and behavior after fixes. After three failed reviews at this stage, stop and report the unresolved decision as in Step 3.
 
 **Step 5: Mark task complete**
 
-Only when BOTH reviews pass:
-```
+Record both results:
+
+```text
 Task [N]: [Title] -- COMPLETE
   ADR compliance: PASS
   Code quality: PASS
 ```
 
-Return to Step 1 for the next task.
+When no ADR applies, label the first result `Requirements: PASS` instead. Do not report an independent review if the check was direct. Continue with the next ready task.
 
-After integration accepts the task, confirm the worktree is clean and inactive, then remove it with `git worktree remove -- <path>`. Preserve the branch until the normal merged-branch cleanup proves it is disposable.
+After integration accepts the task, verify its worktree is clean and inactive, then run `git worktree remove -- <path>`. Preserve the branch until normal merged-branch cleanup proves it disposable.
 
-**Gate**: Both ADR compliance and code quality reviews pass. Task marked complete in TodoWrite. Proceed only when gate passes.
+**Gate**: Requirements and code quality pass; task status records completion.
 
 ### Phase 3: FINALIZE
 
-**Goal**: Verify the full implementation works together and complete the workflow.
-
 **Step 1: Final integration review**
 
-Dispatch a reviewer subagent for the entire changeset (diff from BASE_SHA to HEAD):
-- All tests pass together
-- No integration issues between tasks
-- No conflicting patterns or redundant code
-
-**Why final integration review after all tasks**: Per-task reviews ensure each task is correct in isolation. Final integration review catches cross-task problems: Task 1 and Task 3 both define the same utility, tests pass individually but conflict when run together, or Task 2 introduced a breaking change that Task 4 didn't account for. This catch-all review is why BASE_SHA was captured upfront.
+Review the combined `BASE_SHA..HEAD` diff for cross-task conflicts, duplicate utilities, incompatible patterns, and broken integration. Use independent review when the selected lane requires it or unresolved risk warrants it. Reuse completed review that covers this combined candidate. Run required integration checks and tests affected by combining the tasks.
 
 **Step 2: Complete development workflow**
 
-Use the appropriate completion path:
-- `/pr-workflow` to create PR
-- Manual merge
-- Keep branch for further work
+Follow the authorized completion path: `pr-workflow` for a PR, authorized merge, or keeping the branch. Do not ask again for an action already authorized.
 
-**Gate**: Final review passes. All tests pass. Integration verified. Proceed only when gate passes.
-
----
+**Gate**: Combined changes work together, required checks pass, and the requested delivery is complete.
 
 ## Error Handling
 
-### Error: "Subagent Asks Questions Mid-Implementation"
-Cause: Insufficient context in the dispatch prompt
-Solution:
-1. Answer all questions clearly and completely
-2. Add the missing context to the scene-setting for future tasks
-3. Re-dispatch implementer with answers included
-
-**Prevention**: The answer-questions-first constraint prevents this by design. If a subagent still asks questions after full context, they're asking for clarification on the ADR itself, which is valuable signal that requirements are ambiguous.
-
-### Error: "Review Loop Exceeds 3 Retries"
-Cause: ADR ambiguity, fundamental misunderstanding, or unreasonable review criteria
-Solution:
-1. STOP the loop immediately
-2. Summarize all issues and attempted fixes for the user
-3. Ask user to clarify ADR or adjust requirements
-4. Resume only after user provides direction
-
-**Why hard limit**: Review loops that fail to converge are expensive and signal a deeper problem. Continuing them burns tokens without progress. Human judgment is needed to decide whether to clarify, change, or accept.
-
-### Error: "Subagent File Conflicts"
-Cause: Multiple subagents modifying overlapping files — the scope-overlap check missed an overlap because a task's declared `scope` list was incomplete.
-Solution:
-1. Resolve conflicts manually
-2. Re-run the affected review stage
-3. Re-run `check-scope-overlap.py` with the corrected (complete) scope lists, then serialize the now-overlapping tasks
-
-**Why this happens**: Parallel dispatch is only safe for disjoint scopes. A conflict means the declared scopes understated the real file footprint. Complete the scope lists and let the overlap check re-group the tasks.
-
----
+| Problem | Action |
+|---|---|
+| Worker lacks context | Supply the missing evidence or decision; include it in later dispatches where relevant. Resume the worker, or redispatch with complete context. |
+| Review fails three times | Stop that loop, report findings and attempted fixes, and resolve the requirements or review criteria before retrying. |
+| Workers conflict | Correct the declared scopes, rerun `check-scope-overlap.py`, resolve conflicts, serialize overlapping tasks, and rerun affected checks and review. |
+| Executor-ready STOP | Preserve completed work, report the trigger and needed decision, and follow the executor contract rather than improvising. |
+| Worker or session transfer | Use planning's `references/context-boundary.md`; use `session-handoff` for inline state and live processes, and planning pause/resume for plan artifacts. |
 
 ## References
 
-### Prompt Templates
-- `implementer-prompt.md`: Dispatch template for implementation subagents
-- `skills/process/planning/references/executor-ready-plan-template.md`: Self-contained plan format with drift checks, per-step verification, and STOP conditions
-- `adr-reviewer-prompt.md`: Dispatch template for ADR compliance review
-- `code-quality-reviewer-prompt.md`: Dispatch template for code quality review
+- `implementer-prompt.md`: implementation dispatch and executor-ready contract.
+- `skills/process/planning/references/executor-ready-plan-template.md`: plan schema, drift checks, verification, and STOP conditions.
+- `adr-reviewer-prompt.md`: requirements review.
+- `code-quality-reviewer-prompt.md`: code-quality review.

--- a/skills/process/subagent-driven-development/implementer-prompt.md
+++ b/skills/process/subagent-driven-development/implementer-prompt.md
@@ -32,9 +32,9 @@ Tests command: {TEST_COMMAND}
 
 ## Instructions
 
-1. **Understand First** - Read the task completely. If ANYTHING is unclear, ask questions BEFORE implementing. It's better to ask than to guess wrong.
+1. **Understand First** - Read the task completely. Resolve routine choices from the request and repository. Ask before implementing when a missing decision materially affects the task. Executor-ready STOP conditions still apply.
 
-2. **Follow TDD** - Write failing test first, then implement, then verify tests pass.
+2. **Verify behavior** - Use TDD where appropriate. Run relevant and project-required checks using `verification-before-completion`; preserve explicit per-step verification contracts.
 
 3. **Stay Focused** - Only implement what the task specifies. No "while I'm here" improvements.
 
@@ -52,7 +52,7 @@ If you have questions about:
 - What conventions to follow
 - Anything else
 
-ASK THEM NOW. I will answer before you proceed.
+Use the supplied context first. Ask for missing decisions that affect correctness or scope; continue independent work while waiting.
 
 ## Output
 
@@ -62,7 +62,7 @@ When done, report:
 - Self-review findings (if any issues you fixed)
 - Commit message used
 
-Begin by confirming you understand the task, or asking questions.
+Begin the task when its requirements are clear; ask only for a needed decision.
 ```
 
 ## Placeholder Definitions
@@ -121,39 +121,8 @@ The migration should be reversible.
 - Run `python manage.py check` - should exit 0
 - Run `python manage.py migrate --dry-run` - should show this migration
 
-## Instructions
+Follow the template instructions above. Report the implementation, checks, self-review findings, and commit.
 
-1. **Understand First** - Read the task completely. If ANYTHING is unclear, ask questions BEFORE implementing. It's better to ask than to guess wrong.
-
-2. **Follow TDD** - Write failing test first, then implement, then verify tests pass.
-
-3. **Stay Focused** - Only implement what the task specifies. No "while I'm here" improvements.
-
-4. **Test Your Work** - Run tests before committing. All tests should pass.
-
-5. **Self-Review** - Before committing, review your own code for obvious issues.
-
-6. **Commit** - Commit your changes with a clear message.
-
-## Questions?
-
-If you have questions about:
-- The requirements
-- How to approach something
-- What conventions to follow
-- Anything else
-
-ASK THEM NOW. I will answer before you proceed.
-
-## Output
-
-When done, report:
-- What you implemented
-- Tests status (all pass?)
-- Self-review findings (if any issues you fixed)
-- Commit message used
-
-Begin by confirming you understand the task, or asking questions.
 ```
 
 ## Executor-Ready Plans


### PR DESCRIPTION
## Summary
Simplify planning, subagent execution, and interactive pairing while preserving their entrypoints and routing metadata. Remove the duplicate planning reference table and repeated worker instructions.

## Changes
- Give planning, execution, handoff, and verification clear owners.
- Keep requirement and code-quality checks, using the existing review lane instead of forcing two new reviewers for every task.
- Preserve executor-ready plan schemas, drift checks, STOP conditions, worktree capacity checks, and scope-aware dispatch.
- Keep pairing's per-change controls; honor an explicit request to finish autonomously without another confirmation.

## Notes
Direct before/after review, 68 planning and scope tests, content audit, and Ruff pass. All three skill frontmatter blocks are byte-for-byte unchanged. No model A/B runs; no router selection changes.
