### PR TITLE
Assign shared rule owners and reuse valid context and checks

### DIFF
--- a/agents/base-instructions.md
+++ b/agents/base-instructions.md
@@ -40,6 +40,24 @@ Read the dispatch's Task Specification before acting.
 - Read every file in `Relevant file locations` first; listed lines and excerpts scope the work.
 - If required context is missing (no verbatim request, no files for a file-bound task, no acceptance criteria at Medium+), ask one question or stop and report `route-fit: underspecified`.
 
+## Shared rule owners
+
+Use each procedure where it applies; do not load every owner at dispatch or repeat its work at each phase.
+
+| Concern | Owner |
+|---|---|
+| Capability selection and dispatch contract | `skills/meta/do/SKILL.md` and `scripts/build-dispatch.py` |
+| Scope, decisions, and plan lifecycle | `skills/process/planning/SKILL.md` |
+| Implementation | Selected domain agent and task skill |
+| Check evidence and completion claims | `skills/process/verification-before-completion/SKILL.md` |
+| Review scope and reuse | `skills/process/pr-workflow/references/pr-risk-policy.md` |
+| Commit, PR, CI, and merge | `skills/process/pr-workflow/SKILL.md` |
+| Context transfer | `skills/process/planning/references/context-boundary.md` and `skills/process/session-handoff/SKILL.md` |
+
+Keep domain exceptions with their domain. Follow higher-priority instructions and existing user authorization when defaults conflict; do not add another approval round.
+
+Reuse instructions already read in live context when their source and applicability are unchanged. Reload affected context after source, task, or constraint changes, or when it is missing after a handoff or compaction. Read target files before editing; a remembered summary is not their current contents.
+
 ## Temporary File Cleanup
 
 At completion, remove iteration files, helper scripts, test scaffolds, and development files unless explicitly requested or needed for future context.

--- a/skills/process/planning/references/context-boundary.md
+++ b/skills/process/planning/references/context-boundary.md
@@ -5,9 +5,11 @@ Choose context transitions inside `/do`; do not make the user manage sessions or
 | State | Action |
 |---|---|
 | The live conversation is primary evidence or decisions remain unresolved | Continue in the current context. |
-| The next task is fully described by durable artifacts | Start a fresh worker with a complete Task Spec, or start a fresh session from the plan artifacts. |
+| The next task is fully described by durable artifacts | A fresh worker or session can use those artifacts; transfer only when parallel work, separate expertise, or context limits warrant it. |
 | Plan or session lifecycle must survive a user-visible pause | Use `pause.md`; planning owns durable pause and resume artifacts. |
 | Inline worker or agent transfer within active execution | Use `session-handoff` and the Task Spec; do not create planning pause artifacts. |
 | Context pressure is high but the task remains coupled | Compact only the evidence needed for the next judgment. |
 
-Before a transition, verify that the receiver has the /do Task Spec fields (`skills/meta/do/SKILL.md`, Phase 3 Step G): `request_verbatim`, `intent`, `constraints` with `decisions:`, `prior_results:`, and `gaps:` lines, `files` as `path:line-range — excerpt`, `acceptance` as `command → expected`, and the next action. Never assume conversation memory crosses a worker or session boundary.
+Before a transition, use the Task Spec contract owned by `scripts/build-dispatch.py` and `/do`. Carry the request, intent, constraints and authority, relevant files, acceptance checks, and next action. Include decisions, prior results, and gaps when they affect the receiver's work. Keep required fields; do not invent a second schema here.
+
+Use `session-handoff` for working-tree, PR, and live-process state. Link durable evidence and quote the parts needed for the next decision. Never assume conversation memory crosses a worker or session boundary. In the same live context, reuse unchanged instructions instead of reloading them at every phase. For checks, apply the evidence-reuse rules in `verification-before-completion`; a transition alone does not invalidate a result.

--- a/skills/process/session-handoff/SKILL.md
+++ b/skills/process/session-handoff/SKILL.md
@@ -27,13 +27,13 @@ Two modes sharing one state contract. HANDOFF packages current work so the next 
 
 ## Mode: HANDOFF
 
-Produce a concise bullet package with these sections, in order. Every claim comes from a command you ran this session — re-run when stale, because a wrong handoff costs more than no handoff.
+Produce a concise bullet package with these sections, in order. Use observed state and linked evidence. Label inherited results with their source; refresh mutable state before relying on it. Preserve every section, using “not applicable” when needed, without running irrelevant commands.
 
 1. **Scope/status** — the task in one line, finished vs. remaining work, blockers.
-2. **Working tree** — `git status -sb` summary; note local commits not yet pushed and whether you are in a worktree (`pwd` contains `.claude/worktrees/`).
+2. **Working tree** — `git status -sb` summary; note local commits not yet pushed and the worktree path (`git worktree list`; do not infer it from a directory name).
 3. **Branch/PR** — current branch, PR number/URL, CI status (`gh pr checks <num>` when a PR exists).
 4. **Live processes** — long-running jobs the next agent must know about: summarize `ps auxww | grep -E '<your-process>'`, plus a copy-paste attach or log-tail command (`tail -f <logfile>`, `jobs -l`). Redact secrets in command lines.
-5. **Tests/checks** — which commands ran, results, what still needs to run.
+5. **Tests/checks** — commands, results, checked revision or file state, relevant configuration/environment, log paths, and remaining checks.
 6. **Next steps** — remaining actions in execution order, most urgent first.
 7. **Risks/gotchas** — flaky tests, feature flags, brittle areas, approvals still needed.
 
@@ -43,18 +43,19 @@ Produce a concise bullet package with these sections, in order. Every claim come
 
 Rehydrate in this order, then act.
 
-1. **Read the handoff** — the prior package, plus repo CLAUDE.md and any docs it names.
+1. **Read the handoff** — the prior package and applicable repository instructions. Load named documents needed for the next action; a linked archive does not require a full reread.
 2. **Repo state** — `git status -sb`; confirm branch, local commits, worktree path.
 3. **CI/PR** — `gh pr view <num> --comments` (derive the PR from the branch when unnumbered); note failing checks.
 4. **Processes** — check for live jobs named in the handoff; attach or tail logs using its commands.
-5. **Tests/checks** — note what last ran; decide what you will run first.
+5. **Tests/checks** — apply the evidence-reuse rules in `verification-before-completion`. Check that inherited results cover the current files and relevant environment; rerun only invalidated or missing checks, plus required release/CI checks.
 6. **Plan** — write the next 2–3 actions as bullets, then execute them.
 
 **Gate:** branch, PR state, and first action are confirmed before any edit. Report discrepancies between the handoff and observed state; observed state wins.
 
 ## Constraints
 
-- State only what you verified; mark inherited claims as "per handoff, unverified."
+- Separate directly observed results from inherited evidence. Name the source and any unverified conditions; never present another worker's run as your own.
+- Scale detail to the next action. Keep the request, authority, ownership, acceptance checks, unresolved decisions, and live-process recovery commands. Link full logs and prior investigation instead of copying them. The dispatch builder owns Task Spec fields; this skill owns transfer state.
 - In worktrees, follow worktree rules (`skills/meta/do/references/worktree-rules.md`): verify CWD, feature branch first.
 - Keep secrets out of the package: redact tokens and credential paths as `<redacted>`.
 

--- a/skills/process/verification-before-completion/SKILL.md
+++ b/skills/process/verification-before-completion/SKILL.md
@@ -48,6 +48,14 @@ Use project commands first. Defaults when no project command exists:
 | TypeScript | `npm test` | `npx tsc --noEmit` | `npm run lint` |
 | Rust | `cargo test` | `cargo build` | `cargo clippy` |
 
+## Reuse check evidence
+
+Reuse a passing result when it covers the current task and checked files, dependencies, configuration, and relevant environment. Keep its command, scope, revision or file state, result, and log path when available. A phase change or new worker alone does not require a rerun.
+
+After edits, rerun affected checks. Rerun when evidence is missing, the checked state cannot be established, shared dependencies or environment changed, or failures leave uncertainty. Refresh mutable external state such as CI and deployment status before acting on it. Required CI and release checks still apply to the commit or artifact being delivered; an earlier local pass does not replace them.
+
+For inherited results, cite their source and check their applicability. Do not claim you ran them. Review roster and review reuse belong to `skills/process/pr-workflow/references/pr-risk-policy.md`; this skill owns check evidence and completion claims.
+
 ## Recovery
 
 - **No tests:** perform suitable manual checks and state the coverage gap. Add a regression test when the task warrants one; do not imply manual inspection proves behavior.


### PR DESCRIPTION
## Summary

Give shared procedures one owner and reuse valid instructions and check results across phases and handoffs. Keep required CI checks and refresh evidence when relevant state changes.

## Changes

- Name the existing owners for routing, planning, implementation, verification, review, delivery, and context transfer.
- Reference the dispatch builder's Task Spec instead of maintaining a second schema.
- Keep handoff sections, authority, ownership, and live-process recovery while linking full investigation and logs.
- Define when check evidence remains valid and when to rerun it; distinguish inherited evidence from direct observation.

## Notes

Routing selection and reporting ceremony are unchanged. No cost tracking or model experiments were added. Existing user authorization covers implementation and merge after all GitHub checks pass. Direct diff review, 26 existing planning/routing contract tests, base reference validation, process content audit, and full Ruff checks passed locally.
