### PR TITLE
Fix retired Codex hook symlink cleanup

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -909,9 +909,17 @@ def _link_py_files(src_dir: Path, dst_dir: Path) -> tuple[int, int, int]:
     Mirrors install.sh's per-file convention (``ln -s src dst/name``; skip when
     the target exists or is a link). Returns ``(linked, current, kept)``:
     ``current`` counts links that already resolve to the repo file, ``kept``
-    counts foreign entries left in place. Never deletes, never recurses.
+    counts foreign entries left in place. Removes only missing same-name
+    source links created by this mirror. Never recurses or cleans linked dirs.
     """
     linked = current = kept = 0
+    # Match the literal target used below, not just any path inside the repo.
+    # Leave copies, renamed links, external links, and linked directories alone.
+    if dst_dir.resolve() == dst_dir.absolute():
+        for target in dst_dir.glob("*.py"):
+            source = src_dir / target.name
+            if target.is_symlink() and target.readlink() == source and not source.exists() and not source.is_symlink():
+                target.unlink()
     for item in sorted(src_dir.glob("*.py")):
         if not item.is_file():
             continue
@@ -943,6 +951,8 @@ def _sync_codex_hook_links(repo_hooks: Path, codex_hooks: Path) -> tuple[int, in
         return None
     if _is_ephemeral_path(repo_hooks):
         print(f"[sync] BLOCKED: refusing to link Codex hooks to {repo_hooks} (ephemeral path)", file=sys.stderr)
+        return None
+    if codex_hooks.is_symlink():
         return None
     linked, current, kept = _link_py_files(repo_hooks, codex_hooks)
     repo_lib = repo_hooks / "lib"

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -1511,6 +1511,53 @@ class TestSyncCodexHookLinks:
         assert sync_mod._sync_codex_hook_links(repo_hooks, codex) == (1, 4, 0)
         assert (codex / "lib" / "new_lib.py").is_symlink()
 
+    def test_retired_links_removed_without_touching_user_entries(self, tmp_path: Path) -> None:
+        repo_hooks = self._repo_hooks(tmp_path)
+        codex = tmp_path / "codex" / "hooks"
+        codex.mkdir(parents=True)
+        sync_mod._sync_codex_hook_links(repo_hooks, codex)
+        (repo_hooks / "a-hook.py").unlink()
+        (repo_hooks / "lib" / "hook_utils.py").unlink()
+        copy = codex / "copied.py"
+        copy.write_text("user copy")
+        links = {
+            "custom.py": tmp_path / "missing.py",
+            "renamed.py": repo_hooks / "old-name.py",
+            "other-checkout.py": tmp_path / "other-repo" / "hooks" / "other-checkout.py",
+        }
+        for name, source in links.items():
+            (codex / name).symlink_to(source)
+        # A broken source link is not a retired source file.
+        (repo_hooks / "broken.py").symlink_to(tmp_path / "missing-source.py")
+        (codex / "broken.py").symlink_to(repo_hooks / "broken.py")
+        for _ in range(2):
+            assert sync_mod._sync_codex_hook_links(repo_hooks, codex) == (0, 2, 0)
+            assert not (codex / "a-hook.py").is_symlink()
+            assert not (codex / "lib" / "hook_utils.py").is_symlink()
+            assert copy.read_text() == "user copy"
+            assert (codex / "broken.py").is_symlink()
+            for name, source in links.items():
+                assert (codex / name).readlink() == source
+
+    @pytest.mark.parametrize("linked_directory", ["hooks", "lib"])
+    def test_cleanup_does_not_follow_directory_links(self, tmp_path: Path, linked_directory: str) -> None:
+        repo_hooks = self._repo_hooks(tmp_path)
+        codex = tmp_path / "codex" / "hooks"
+        codex.parent.mkdir(parents=True)
+        external = tmp_path / "external"
+        external.mkdir()
+        if linked_directory == "hooks":
+            codex.symlink_to(external, target_is_directory=True)
+            source = repo_hooks / "retired.py"
+        else:
+            codex.mkdir()
+            (codex / "lib").symlink_to(external, target_is_directory=True)
+            source = repo_hooks / "lib" / "retired.py"
+        retired = external / "retired.py"
+        retired.symlink_to(source)
+        sync_mod._sync_codex_hook_links(repo_hooks, codex)
+        assert retired.readlink() == source
+
     def test_summary_line_reports_codex_hooks(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         self._repo_hooks(tmp_path)
         repo_root = self._repo_root(tmp_path)


### PR DESCRIPTION
## Summary

Remove retired toolkit hook symlinks during normal Codex sync so deleted hooks do not leave dangling installed paths.

## Changes

- Remove missing same-name source links in the existing hook mirror.
- Preserve copies, custom and external links, broken source links, and linked directories.
- Cover retirement, preservation, and repeat sync in regression tests.

## Notes

Cleanup requires the exact link target written by this checkout. Links from other checkouts remain untouched.
