### PR TITLE
Refresh private skill discovery during sync

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 try:
@@ -552,6 +553,53 @@ def _merged_runtime_index(tracked: Path, local: Path) -> dict | None:
                 skills.setdefault(name, data)
     merged["skills"] = skills
     return merged
+
+
+def _refresh_local_skill_index(repo_root: Path) -> bool:
+    """Add discovered skills to the private overlay without changing public metadata."""
+    generator = Path(__file__).resolve().parent.parent / "scripts" / "generate-skill-index.py"
+    skills = repo_root / "skills"
+    with tempfile.TemporaryDirectory(prefix="vexjoy-skill-index-") as temporary:
+        output = Path(temporary) / "INDEX.local.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(generator),
+                "--repo-root",
+                str(repo_root),
+                "--include-private",
+                "--strict",
+                "--output",
+                str(output),
+            ],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "HOME": str(Path.home())},
+            timeout=30,
+        )
+        if result.returncode not in (0, 3):
+            raise RuntimeError(f"Skill discovery failed: {result.stderr.strip() or result.stdout.strip()}")
+        # Existing local entries retain their metadata. Discovery fills missing
+        # names; the public index still wins when runtime indexes are published.
+        merged = _merged_runtime_index(skills / "INDEX.local.json", output)
+        if merged is None:
+            return False
+        roots = (repo_root, Path.home() / ".claude", Path.home() / ".codex")
+        merged["skills"] = {
+            name: entry
+            for name, entry in merged["skills"].items()
+            if isinstance(entry, dict)
+            and isinstance(entry.get("file"), str)
+            and any((root / entry["file"]).is_file() for root in roots)
+        }
+        local = skills / "INDEX.local.json"
+        try:
+            if json.loads(local.read_text(encoding="utf-8")) == merged:
+                return False
+        except (OSError, json.JSONDecodeError):
+            pass
+        _atomic_json_write(local, merged)
+        return True
 
 
 def _sync_runtime_skill_index(src: Path, dst: Path) -> bool:
@@ -1504,6 +1552,15 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
                     errors.append(f"private-{deploy_name}: {e}")
         if private_count > 0:
             synced.append(f"private-skills({private_count})")
+
+    # Deployment can add private skills after the public index was generated.
+    # Refresh the local overlay before either harness publishes its inventory.
+    try:
+        if _refresh_local_skill_index(repo_root):
+            synced.append("skill-index(updated)")
+        _sync_runtime_skill_index(repo_root / "skills", user_claude / "skills")
+    except Exception as e:
+        errors.append(f"skill-index: {e}")
 
     # Sync skills and agents to ~/.codex/ for OpenAI Codex CLI.
     # Codex natively supports skills; agents are mirrored as reference

--- a/hooks/tests/test_skill_discovery_sync.py
+++ b/hooks/tests/test_skill_discovery_sync.py
@@ -1,0 +1,77 @@
+"""Private skill deployment must reach dispatch without changing the public index."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location("discovery_sync", ROOT / "hooks/sync-to-user-claude.py")
+sync = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sync)
+
+
+def skill(path, name):
+    path.mkdir(parents=True)
+    (path / "SKILL.md").write_text(f"---\nname: {name}\ndescription: Test skill.\n---\n")
+
+
+def test_deployed_private_skill_becomes_dispatchable(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    source = repo / "skills"
+    skill(source / "meta" / "public-skill", "public-skill")
+    private = tmp_path / "private" / "voice"
+    skill(private / "skills" / "private-editor", "private-editor")
+    (source / "voice").symlink_to(private, target_is_directory=True)
+    malformed = private / "skills" / "broken"
+    malformed.mkdir()
+    (malformed / "SKILL.md").write_text("---\nname: [broken\n---\n")
+    skill(private / "skills" / "retired", "retired")
+    (private / "skills" / "retired" / "SKILL.md").write_text("---\nname: retired\npromoted_to: public-skill\n---\n")
+    public = {"version": "2.0", "skills": {"public-skill": {"file": "skills/meta/public-skill/SKILL.md"}}}
+    public_bytes = json.dumps(public)
+    (source / "INDEX.json").write_text(public_bytes)
+    deployed = tmp_path / ".claude" / "skills"
+    skill(deployed / "private-editor", "private-editor")
+    skill(deployed / "custom", "custom")
+    custom = {"file": "skills/custom/SKILL.md", "description": "Keep local metadata"}
+    (source / "INDEX.local.json").write_text(
+        json.dumps({"skills": {"custom": custom, "removed": {"file": "skills/removed/SKILL.md"}}})
+    )
+
+    assert sync._refresh_local_skill_index(repo)
+    local = json.loads((source / "INDEX.local.json").read_text())
+    assert local["skills"]["custom"] == custom
+    assert local["skills"]["private-editor"]["file"] == "skills/private-editor/SKILL.md"
+    assert "public-skill" in local["skills"]
+    assert "broken" not in local["skills"]
+    assert "retired" not in local["skills"]
+    assert "missing" not in local["skills"]
+    assert "removed" not in local["skills"]
+    assert (source / "INDEX.json").read_text() == public_bytes
+    assert not sync._refresh_local_skill_index(repo)
+
+    runtime = tmp_path / ".codex" / "skills"
+    for name in ("private-editor", "public-skill"):
+        skill(runtime / name, name)
+    sync._sync_codex_runtime_skill_indexes(source, runtime)
+    published = json.loads((runtime / "INDEX.json").read_text())["skills"]
+    assert set(published) == {"private-editor", "public-skill"}
+    for entry in published.values():
+        assert (runtime.parent / entry["file"]).is_file()
+
+
+def test_discovery_failure_preserves_overlay(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    skills = repo / "skills"
+    skills.mkdir(parents=True)
+    local = skills / "INDEX.local.json"
+    local.write_text('{"skills": {"custom": {}}}')
+    before = local.read_bytes()
+    with pytest.raises(RuntimeError, match="Skill discovery failed"):
+        sync._refresh_local_skill_index(repo)
+    assert local.read_bytes() == before


### PR DESCRIPTION
## Summary

Sync now refreshes the local skill inventory after deploying private skills. This fixes installed skills being available to the harness but rejected by dispatch because the local index is stale.

## Changes

- Run the existing strict skill generator and fill missing local entries before publishing runtime indexes.
- Preserve live local metadata and the public index; remove entries whose declared file no longer resolves.
- Cover private symlinks, nested public skills, invalid and retired skills, repeated sync, and discovery failure.

## Notes

Routing selection and dispatch validation are unchanged. Private skill metadata stays in the gitignored local overlay. Relevant local tests: 110 passed, 1 skipped; Ruff passes.
