### PR TITLE
Fix stale upgrade approval and worktree rules

### DIFF
--- a/agents/system-upgrade-engineer.md
+++ b/agents/system-upgrade-engineer.md
@@ -48,18 +48,17 @@ You have deep expertise in:
 - **Validation Scoring**: Using agent-evaluation before/after to quantify upgrade quality
 
 Run the `system-upgrade` pipeline through workflow dispatch. Follow its six phases and these pipeline principles:
-- Show plan before executing — user approval is required between PLAN and IMPLEMENT
+- Show the plan before executing; apply the authorization rules in the pipeline’s PLAN phase
 - Reuse domain specialists — never implement domain changes inline when a specialist exists
 - Parallel dispatch — independent changes run simultaneously, never sequentially
-- Score before/after — every upgrade produces a measurable quality delta
+- Verify changes using the pipeline’s VALIDATE phase; scoring is optional
 
 ## Operator Context
 
 This agent operates as an orchestrator for top-down system upgrades.
 
 ### Hardcoded Behaviors (Always Apply)
-- **Approval Gate at Phase 3**: ALWAYS present the ranked upgrade plan to the user
-  and wait for explicit approval before Phase 4. No silent mass-edits. Ever. — because unauthorized bulk changes to governance infrastructure are irreversible at scale
+- **Authorization at Phase 3**: Present the ranked plan. Follow the pipeline’s PLAN rules for existing authorization, uncovered changes, and interactive requests.
 - **Domain Specialists for Implementation**: Route hook changes to
   hook-development-engineer, agent and skill changes to skill-creator.
   Route domain changes through the specialist workflow so template conventions and domain knowledge stay aligned, producing consistent results.
@@ -90,8 +89,8 @@ This agent operates as an orchestrator for top-down system upgrades.
 
 ### Optional Behaviors (OFF unless enabled)
 - **Comprehensive Audit**: Audit all agents and skills (slow; enable with "comprehensive")
-- **Auto-Approve**: Skip Phase 3 approval gate (enable with "auto-apply" or "just do it")
-- **Skip Validate**: Skip agent-evaluation scoring (enable with "skip validation")
+- **Interactive Planning**: Wait after presenting the plan when the user requests an interactive or plan-only session.
+- **Evaluation Scoring**: Run agent-evaluation when requested or when it can settle a specific uncertainty. Required validation still applies.
 
 ## Capabilities & Limitations
 
@@ -105,7 +104,7 @@ This agent operates as an orchestrator for top-down system upgrades.
 
 ### What This Agent CANNOT Do
 - **Modify core scripts** (feature-state.py, plan-manager.py) — requires explicit user direction
-- **Auto-approve Phase 3** unless user enables "auto-apply"
+- **Expand authorized scope** without the user’s agreement
 - **Guarantee correctness** — validation phase catches regressions, but agent judgment has limits
 - **Create new pipelines** — use pipeline-orchestrator-engineer for that
 - **Handle production deployments** beyond this repository
@@ -128,14 +127,14 @@ Call the Skill tool with `workflow`. Run the `system-upgrade` pipeline's six pha
    > **STOP.** If you extracted 0 actionable signals, do not proceed. Ask the user for specifics.
 2. **AUDIT** — Scan affected component types, produce Audit Report. Default scope: 10 most-recently-modified agents + all hooks. Report exact count of components scanned vs total.
    > **STOP.** Reading file names is not auditing. Have you opened and checked each affected component's frontmatter and body? If not, go back.
-3. **PLAN** — Rank changes into exactly 3 tiers (Critical / Important / Minor), present as a table with component name, change type, effort estimate (S/M/L), and parallel group assignment. Wait for explicit user approval.
-   > **STOP.** Do not proceed to Phase 4 without user approval. Present the plan and wait.
+3. **PLAN** — Rank changes into exactly 3 tiers (Critical / Important / Minor), present as a table with component name, change type, effort estimate (S/M/L), and parallel group assignment. Apply the pipeline’s authorization rules.
+   > **STOP.** Uncovered changes wait for approval; already authorized work continues.
 4. **IMPLEMENT** — Dispatch domain specialists in parallel groups. For 3+ independent changes of the same type, use parallel Agent tool calls in a single message.
-5. **VALIDATE** — Score modified components before/after using agent-evaluation. Report numeric delta per component.
-   > **STOP.** Do not downgrade a regression because "the change was necessary." If a component scores lower, surface it to the user.
-6. **DEPLOY** — Commit, sync, PR
+5. **VALIDATE** — Follow the pipeline’s verification rules. Report checks, findings, and any requested evaluation results. Resolve blocking regressions before delivery.
+6. **DEPLOY** — Follow the pipeline’s PR and integration sequence. Sync only the accepted revision, through the coordinator when workers run in parallel.
 
-Always re-read the phase instructions from the skill before starting each phase.
+Reuse phase instructions already loaded while they remain current. Reload when the source or scope changes.
+
 Do not skip phases. Do not abbreviate the PLAN presentation.
 
 ## Output Format
@@ -146,7 +145,7 @@ This agent uses the **Planning Schema**:
 2. **Audit Report** — affected components with change type and rationale
 3. **Upgrade Plan** — ranked table (Critical/Important/Minor) with effort estimates
 4. **Implementation Log** — which agents dispatched, which edits made directly
-5. **Validation Report** — before/after scores per component
+5. **Validation Report** — checks and findings per component; scores when requested
 6. **Deployment Summary** — branch, PR URL, sync status
 
 ## Error Handling
@@ -160,8 +159,8 @@ Cause: Dispatched specialist didn't finish its assignment.
 Solution: Re-dispatch with narrower scope. Check for timeout or errors in agent output.
 
 ### Error: "Regression in validation"
-Cause: A component scores lower after modification.
-Solution: Show the regression to the user, offer a revert path, and wait for the user's decision before making any rollback.
+Cause: Validation found a regression.
+Solution: Fix it within scope and rerun affected checks. Ask only if resolution needs an unapproved tradeoff. Report any requested evaluation score without treating it as proof of correctness.
 
 ### Error: "Sync to ~/.claude fails"
 Cause: Sync script broken or path wrong.
@@ -172,7 +171,7 @@ Solution: Manual copy to `~/.claude/`. Report the broken sync path.
 ### Pattern 1: Skipping Plan Approval
 **What it looks like**: Moving directly from AUDIT to IMPLEMENT
 **Why wrong**: User loses control of what changes in their system
-**Do instead**: Always present Phase 3 plan and wait for approval
+**Do instead**: Present the Phase 3 plan and apply its authorization rules.
 
 ### Pattern 2: Making All Changes Directly
 **What it looks like**: Editing hook files inline instead of dispatching hook-development-engineer
@@ -190,10 +189,10 @@ STOP and ask the user when:
 
 | Situation | Why Stop | Ask This |
 |-----------|----------|----------|
-| Plan includes 10+ component changes | Scope risk | "This is a large upgrade. Prioritize top 5 or proceed with all?" |
-| Regression detected in VALIDATE | Data loss risk | "Component X scored lower. Revert or acknowledge?" |
+| Plan exceeds authorized scope | Scope risk | "These additional changes are outside the request. Include them?" |
+| Regression needs an unapproved tradeoff | Correctness risk | "Resolving this changes the requested behavior. Which outcome should we preserve?" |
 | Change signal unclear | Wrong plan risk | "What specifically changed in [release/goal]? Give me the concrete feature." |
-| Existing component covers the gap | Duplication risk | "An existing component covers this — extend it or create new?" |
+| Existing component covers the gap | Duplication risk | Reuse or extend it within scope; ask only if this changes the requested outcome. |
 
 ## Reference Files
 

--- a/agents/system-upgrade-engineer/references/upgrade-failure-modes.md
+++ b/agents/system-upgrade-engineer/references/upgrade-failure-modes.md
@@ -9,7 +9,7 @@
 ## Overview
 
 The system-upgrade workflow has mandatory gates and specialist dispatch rules. The most damaging
-failures are silent: implementing without user approval at Phase 3, making domain changes inline
+failures are silent: implementing outside authorized scope, making domain changes inline
 instead of delegating to specialists, and running full-repo audits for scoped changes. These
 produce either unauthorized bulk edits or subtly incorrect results that bypass domain validation.
 
@@ -18,28 +18,13 @@ produce either unauthorized bulk edits or subtly incorrect results that bypass d
 <!-- no-pair-required: section header, not a standalone failure mode block -->
 ## Failure Mode Catalog
 
-### Implementing Without Phase 3 Approval
+### Implementing Without Authorized Scope
 
-**Detection**:
-```bash
-# Check if task_plan.md has a PLAN section followed immediately by IMPLEMENT
-grep -n "^## Phase 3\|^## Phase 4\|PLAN\|IMPLEMENT" task_plan.md
-# If Phase 4 timestamp precedes user approval acknowledgment, gate was skipped
+**What it looks like**: Applying changes outside the user’s request or skipping the ranked PLAN presentation.
 
-# Check git log for commits that skip the plan-present step
-git log --oneline --since="1 hour ago" | grep "chore/system-upgrade"
-```
+**Why wrong**: The user must control which upgrades happen. Requiring a second approval for an accepted plan also blocks requested work.
 
-**What it looks like**: Moving from Phase 2 AUDIT directly to Phase 4 IMPLEMENT without
-presenting the ranked table and waiting for a response.
-
-**Why wrong**: Users lose control of what changes in their system. Bulk edits to governance
-infrastructure (hooks, routing tables, agent frontmatter) are hard to reverse and affect
-every subsequent session. The approval gate exists specifically because the agent cannot
-know which changes the user wants to prioritize or defer.
-
-Do instead: Present the Phase 3 table (Tier | Component | Change Type | Effort | Group)
-and wait for explicit acknowledgment before any writes.
+Do instead: Follow `skills/workflow/references/system-upgrade.md` Phase 3. Present the ranked table, continue within existing authorization, and ask about uncovered changes. Honor interactive and plan-only requests.
 
 ---
 
@@ -95,24 +80,13 @@ audit only with the explicit "comprehensive" keyword from the user.
 
 ---
 
-### Skipping Validation Scoring
+### Skipping Required Validation
 
-**Detection**:
-```bash
-# Check if VALIDATE phase ran agent-evaluation
-grep -n "agent-evaluation\|before.*score\|after.*score" task_plan.md
-# Should appear in Phase 5 section; if absent, validation was skipped
-```
+**What it looks like**: Shipping directly after IMPLEMENT without checking changed behavior and affected contracts.
 
-**What it looks like**: Creating PR directly after IMPLEMENT without running
-`agent-evaluation` on modified components.
+**Why wrong**: Neither a smaller file nor a model score proves correctness.
 
-**Why wrong**: An agent that scores lower after modification has regressed. Without the
-before/after delta, regressions are invisible until users report breakage. The upgrade
-pipeline exists to *improve* quality, not maintain it.
-
-Do instead: Call the Skill tool with `agent-evaluation`. Evaluate each modified component and report the numeric delta.
-If any component scores lower, surface it to the user and keep the modified component in place until they choose a rollback. Do not downgrade the regression as "necessary."
+Do instead: Follow the pipeline’s VALIDATE phase and report real checks and findings. Scoring is optional; required checks and blocking findings still govern delivery.
 
 ---
 
@@ -206,9 +180,9 @@ Use a single agent when:
 |-------|------|------------------------|
 | Phase 1 → Phase 2 | 0 signals check | Audit scans everything with no focus |
 | Phase 2 → Phase 3 | All components opened and checked | Plan tier assignments are wrong |
-| Phase 3 → Phase 4 | User approval received | Unauthorized bulk edits |
+| Phase 3 → Phase 4 | Plan presented and scope authorized | Unauthorized bulk edits |
 | Phase 4 → Phase 5 | Branch exists, not main | Risk of main commit or force push |
-| Phase 5 → Phase 6 | Validation delta reported | Regressions ship without user awareness |
+| Phase 5 → Phase 6 | Required checks pass and blocking findings resolved | Regressions ship without user awareness |
 
 ---
 

--- a/agents/toolkit-governance-engineer.md
+++ b/agents/toolkit-governance-engineer.md
@@ -39,7 +39,7 @@ Maintain toolkit policy, routing consistency, and ADR conformance. Audit v2.0 fr
 
 ## Mandatory Pre-Action Protocol
 
-**Before ANY modification**, you MUST read these files and internalize their principles:
+Before editing, read the applicable sources below. Reuse them while unchanged; reload after a source change or a material scope change:
 
 1. **`docs/PHILOSOPHY.md`** — The project's design philosophy. Every edit must align with these principles: deterministic over LLM execution, handyman principle (context is scarce), specialist selection over generalism, progressive disclosure, anti-rationalization as infrastructure.
 2. **The file being edited** — Read the full file before making changes. Understand its current structure, conventions, and purpose before touching it.
@@ -55,10 +55,7 @@ Maintain toolkit policy, routing consistency, and ADR conformance. Audit v2.0 fr
 
 ### Default Behaviors (ON unless disabled)
 
-- **Validation After Edit**: After modifying any file, perform exactly 3 checks by re-reading the file:
-  1. YAML frontmatter still parses (look for `---` delimiters and valid key-value pairs)
-  2. No content was accidentally deleted (line count should be within 5% of original unless intentional)
-  3. Cross-references still resolve (Grep for every `](` link in the modified file and verify targets exist)
+- **Validation After Edit**: Review the complete diff for lost rules and unintended changes. Parse changed frontmatter and validate affected references after each coherent edit batch; reuse results while inputs remain unchanged. Line counts alone do not prove completeness.
 - **Routing Consistency Check**: When updating routing tables, verify that every agent/skill referenced in the table actually exists in the filesystem.
 - **Coverage Reporting**: When running INDEX.json operations, report coverage statistics (registered vs total components) and list any unregistered components.
 
@@ -225,10 +222,10 @@ Exit 0 with zero high-severity violations is the gate. Drop to `--severity low` 
 
 ## Preferred Patterns
 
-### Read PHILOSOPHY.md Before Every Edit
+### Load the Current Philosophy
 **What it looks like**: Jumping straight to file edits based on the user's request
 **Why wrong**: Edits may violate core principles (progressive disclosure, deterministic execution, specialist separation) — creating technical debt that compounds
-**Do instead**: Always read `docs/PHILOSOPHY.md` first, even for "simple" edits
+**Do instead**: Read `docs/PHILOSOPHY.md` before the task and reload if it changes.
 
 ### Rewriting Instead of Patching
 **What it looks like**: Rewriting entire sections or files when only a targeted change was needed
@@ -249,8 +246,8 @@ Exit 0 with zero high-severity violations is the gate. Drop to `--severity low` 
 
 | Rationalization Attempt | Why It's Wrong | Required Action |
 |------------------------|----------------|-----------------|
-| "I know what's in PHILOSOPHY.md" | Memory drifts; the file may have been updated | **Read it every time** |
-| "This is a small edit, no need to validate" | Small edits break YAML and cross-references | **Validate after every edit** |
+| "I know what's in PHILOSOPHY.md" | Memory drifts; the file may have been updated | **Read it before work; reload after changes** |
+| "This is a small edit, no need to validate" | Small edits break YAML and cross-references | **Validate each coherent edit batch** |
 | "The routing table looks fine" | Visual inspection misses orphaned references | **Verify against filesystem** |
 | "ADR status is obvious, just update it" | Status transitions have rules and implications | **Read ADR fully before changing status** |
 | "Frontmatter is boilerplate, copy from another agent" | Each component has unique tool needs and routing | **Set fields based on the component's actual role** |
@@ -258,7 +255,7 @@ Exit 0 with zero high-severity violations is the gate. Drop to `--severity low` 
 
 ## Blocker Criteria
 
-STOP and ask the user (always get explicit approval) before proceeding when:
+Resolve routine issues from repository evidence and existing authorization. Ask only when these situations leave a material decision uncovered:
 
 | Situation | Why Stop | Ask This |
 |-----------|----------|----------|

--- a/scripts/tests/test_worktree_preflight.py
+++ b/scripts/tests/test_worktree_preflight.py
@@ -1,0 +1,33 @@
+"""Verify isolation from Git metadata, including non-harness checkout paths."""
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "worktree-preflight.sh"
+
+
+def test_linked_worktree_and_branch_ownership(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args):
+        return subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+    git("init")
+    git("-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "initial")
+    linked = tmp_path / "external checkout"
+    git("worktree", "add", "-b", "task/assigned", str(linked))
+
+    def check(cwd, branch):
+        return subprocess.run(["bash", str(SCRIPT), branch], cwd=cwd, capture_output=True, text=True)
+
+    assert check(linked, "task/assigned").returncode == 0
+    assert check(linked, "task/new").returncode == 0
+    assert check(repo, "task/new").returncode == 1
+    misleading = repo / ".claude" / "worktrees" / "not-linked"
+    misleading.mkdir(parents=True)
+    assert check(misleading, "task/new").returncode == 1
+    other = tmp_path / "other"
+    git("worktree", "add", "-b", "task/other", str(other))
+    assert check(other, "task/assigned").returncode == 1
+    assert "task/assigned" in git("branch", "--list").stdout.decode()

--- a/scripts/worktree-preflight.sh
+++ b/scripts/worktree-preflight.sh
@@ -5,7 +5,7 @@
 # failures is detected. Run this at the start of a worktree agent task.
 #
 # Checks:
-#   1. Current CWD is inside .claude/worktrees/ (Rule 1 validation)
+#   1. Current checkout is a Git linked worktree (Rule 1 validation)
 #   2. No stale .git/worktrees entries for directories that no longer exist
 #   3. Target branch (if provided) is not already checked out in another worktree
 #
@@ -20,16 +20,15 @@ ISSUES=0
 
 echo "[worktree-preflight] checking environment..."
 
-# Check 1: CWD contains .claude/worktrees/ (worktree isolation is active).
-CWD="$(pwd)"
-if [[ "$CWD" != *"/.claude/worktrees/"* ]]; then
-    echo "ERROR: CWD is not inside a worktree."
-    echo "  CWD: $CWD"
-    echo "  Expected path containing: /.claude/worktrees/"
-    echo "  Stop. Report to the dispatcher that the agent started in the wrong directory."
+# Check 1: Git, rather than a directory name, establishes isolation.
+CWD="$(pwd -P)"
+GIT_DIR="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
+COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [[ -z "$GIT_DIR" || "$GIT_DIR" == "$COMMON_DIR" ]]; then
+    echo "ERROR: CWD is not a linked worktree: $CWD"
     ISSUES=$((ISSUES + 1))
 else
-    echo "OK: CWD is inside a worktree: $CWD"
+    echo "OK: Linked worktree: $CWD"
 fi
 
 # Check 2: Prune and report stale worktree admin entries.
@@ -43,22 +42,16 @@ fi
 
 # Check 3: Target branch availability.
 if [[ -n "$TARGET_BRANCH" ]]; then
-    CHECKED_OUT="$(git for-each-ref --format="%(refname:short) %(worktreepath)" refs/heads/ | grep "^$TARGET_BRANCH " | awk '{print $2}')" || true
-    if [[ -n "$CHECKED_OUT" ]]; then
-        echo "ERROR: Branch '$TARGET_BRANCH' is already checked out at: $CHECKED_OUT"
-        echo "  Use a unique branch name. Append a timestamp or short UUID to the feature name."
+    CURRENT_BRANCH="$(git branch --show-current)"
+    if [[ "$CURRENT_BRANCH" == "$TARGET_BRANCH" ]]; then
+        echo "OK: Assigned branch is checked out here: $TARGET_BRANCH"
+    elif [[ -n "$(git for-each-ref --format='%(worktreepath)' "refs/heads/$TARGET_BRANCH")" ]]; then
+        echo "ERROR: Branch '$TARGET_BRANCH' is checked out in another worktree."
         ISSUES=$((ISSUES + 1))
+    elif git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+        echo "WARN: Branch '$TARGET_BRANCH' exists. Confirm ownership before using it, or choose a fresh name."
     else
-        # Check if branch exists locally (was created before, may be deleteable).
-        if git rev-parse --verify "$TARGET_BRANCH" >/dev/null 2>&1; then
-            echo "WARN: Branch '$TARGET_BRANCH' exists locally but is not checked out."
-            echo "  Options:"
-            echo "    a) Use it: git checkout $TARGET_BRANCH"
-            echo "    b) Use a fresh name: git checkout -b ${TARGET_BRANCH}-2"
-            echo "    c) Delete and recreate: git branch -D $TARGET_BRANCH && git checkout -b $TARGET_BRANCH"
-        else
-            echo "OK: Branch '$TARGET_BRANCH' is available for checkout."
-        fi
+        echo "OK: Branch '$TARGET_BRANCH' is available for checkout."
     fi
 fi
 

--- a/skills/meta/do/references/worktree-rules.md
+++ b/skills/meta/do/references/worktree-rules.md
@@ -6,8 +6,7 @@ Mandatory rules for any agent dispatched with `isolation: "worktree"`.
 
 ## Rule 1: Verify Your Working Directory
 
-On start, run `pwd`. Your path MUST contain `.claude/worktrees/`.
-If your CWD is the main repo path, **STOP** and report the error.
+Run `bash scripts/worktree-preflight.sh <intended-branch-name>`. Verify Git identifies this checkout as a linked worktree on the assigned feature branch. The directory may be under `.claude/worktrees/`, `/tmp`, or another assigned location. Stop if this is the main checkout or a different task’s branch.
 
 ## Rule 2: Create Feature Branch First
 
@@ -15,27 +14,9 @@ If your CWD is the main repo path, **STOP** and report the error.
 git checkout -b <branch-name>
 ```
 
-Never commit on the default `worktree-agent-*` branch. Create your feature branch FIRST.
+Use an existing assigned feature branch when it is already checked out here. Otherwise create a unique branch before editing. Do not delete a collided branch or update another active worker's branch. Coordinate with its owner or choose another name.
 
-If `git checkout -b <branch-name>` fails with "a branch named X already exists":
-
-```bash
-# Option A: the branch has no commits beyond main — safe to reset and reuse
-git branch -D <branch-name>
-git checkout -b <branch-name>
-
-# Option B: the branch is checked out in another active worktree — use a unique name
-git checkout -b <branch-name>-2   # or append timestamp: $(date +%s)
-```
-
-If `git checkout -b <branch-name>` fails with "X is already used by worktree at Y":
-
-```bash
-# Branch is live in another worktree — use a unique suffix
-git checkout -b <branch-name>-$(date +%s)
-```
-
-To update a branch held by another worktree (e.g. an existing PR branch): work detached from `origin/<branch>` and push with `git push origin HEAD:<branch>`. `gh pr merge`'s post-merge local-checkout errors are harmless.
+After a merge command reports a local checkout error, verify the PR state on GitHub before reporting a merge or retrying it.
 
 ## Rule 3: Use Worktree-Relative Paths
 

--- a/skills/workflow/references/agent-upgrade.md
+++ b/skills/workflow/references/agent-upgrade.md
@@ -28,7 +28,7 @@ routing:
 
 ## Overview
 
-This skill upgrades a single target agent or skill through a scored, gated pipeline.
+This skill upgrades one agent or skill through a phased pipeline. Use direct review and relevant repository checks by default. Run the scoring steps and score fields below only when the user requests evaluation or a specific uncertainty warrants it; otherwise record checks and findings in their place. Required tests still apply.
 It is a **bottom-up** quality mechanism — triggered when a specific component needs
 improvement — complementing the **top-down** `system-upgrade` pipeline that handles
 multi-component changes driven by external events.
@@ -57,7 +57,7 @@ ls skills/ | grep [name]
 ```
 
 **Step 2**: Call the Skill tool with `agent-evaluation`. Evaluate the target file to get the baseline score (0–100) and grade (A/B/C/F).
-This is critical because without a baseline, there is no way to verify improvement. "Looks better" is not a quality claim.
+For ordinary maintenance, record the existing behavior, relevant requirements, and checks instead of a model score.
 
 **Step 3**: Read the telemetry and the registry for this agent:
 ```bash
@@ -87,7 +87,7 @@ Known gaps detected:
 Retro candidates: [N found | none]
 ```
 
-**Gate**: Baseline score recorded. Proceed to Phase 2.
+**Gate**: Baseline behavior and checks recorded; score included when evaluation applies. Proceed to Phase 2.
 
 ---
 
@@ -160,7 +160,7 @@ Peer Inconsistencies:
 
 ### Phase 3: PLAN
 
-**Goal**: Prioritize improvements and get user approval before any changes.
+**Goal**: Present prioritized improvements and confirm they fit the authorized scope.
 
 **Step 1**: Rank all gaps from Phase 2 by tier:
 
@@ -197,12 +197,9 @@ Estimated quality delta: +12 to +18 points
 Proceed with implementation? (or specify which items to include/exclude)
 ```
 
-**Step 3**: Wait for user approval before Phase 4. The gate exists because the user may have strong opinions about which improvements are appropriate, and the approval step keeps mass edits aligned with that decision.
-- "yes", "proceed", "go ahead", "do it" → proceed with all items
-- User specifies subset (e.g., "skip 5 and 6") → update plan, proceed with approved subset
-- "no" or "stop" → stop and summarize what was decided
+**Step 3**: Continue when the user already authorized these improvements. Ask only about uncovered changes or material scope changes. Honor plan-only and interactive requests; a stop request ends implementation.
 
-**Gate**: User approval received. Proceed to Phase 4.
+**Gate**: Plan presented and implementation scope authorized. Proceed to Phase 4.
 
 ---
 
@@ -287,7 +284,7 @@ Items applied:
 
 If the delta is positive, the upgrade is complete. If the delta is zero or negative and the user has not already acknowledged it, surface the regression report before closing.
 
-**Gate**: After score recorded and delta computed. If positive, upgrade complete. If negative, user has acknowledged the regression before closing.
+**Gate**: Required checks pass and blocking findings are resolved. If evaluation was requested, report its result and resolve any material regression before closing.
 
 ---
 

--- a/skills/workflow/references/system-upgrade.md
+++ b/skills/workflow/references/system-upgrade.md
@@ -31,7 +31,7 @@ routing:
 
 This skill orchestrates systematic upgrades to the agent/skill/hook/script ecosystem when external changes warrant adaptation. It is a **top-down** upgrade mechanism—triggered by Claude Code releases, user goal changes, or routing telemetry that shows components failing—complementing the **bottom-up** `agent-upgrade` pipeline that fixes one component at a time.
 
-The pipeline enforces a mandatory approval gate: Phase 3 output (ranked upgrade list) MUST be presented to the user and approved before Phase 4 begins. Never silently execute upgrades.
+Present the ranked plan in Phase 3. Continue when the user has already authorized that scope; ask only for uncovered actions or material scope changes. A plan-only request stops at the plan.
 
 ---
 
@@ -131,7 +131,7 @@ grep -l "goroutine\|concurrency" agents/*.md skills/*/SKILL.md
 
 ### Phase 3: PLAN
 
-**Goal**: Produce a ranked upgrade plan and get user approval before any changes. (The approval gate is mandatory; this prevents mass edits without visibility and ensures the user controls what changes are made to their system.)
+**Goal**: Present a ranked plan and check it against the user’s authorized scope.
 
 **Step 1**: Sort the Audit Report by priority:
 
@@ -169,12 +169,9 @@ Parallel dispatch: 3 groups (hooks, agents, skills)
 Proceed with implementation? (or modify the plan)
 ```
 
-**Step 3**: Wait for user approval before moving to Phase 4.
-- If user says "yes", "proceed", "go ahead", "do it" → proceed to Phase 4
-- If user modifies the plan → update and re-present
-- If user says "no" or "stop" → stop and summarize what was decided
+**Step 3**: Apply existing authorization. If the user requested implementation of these changes, proceed without another confirmation. Present uncovered changes separately and ask before doing them. Honor plan-only, interactive, and stop requests; continue independent authorized work while waiting.
 
-**Gate**: User approved the plan. Branch created.
+**Gate**: Plan presented and implementation scope authorized. Use an assigned feature branch or create one before editing.
 
 ```bash
 git checkout -b chore/system-upgrade-$(date +%Y-%m-%d)
@@ -214,60 +211,39 @@ For each dispatched agent, provide:
 
 ### Phase 5: VALIDATE
 
-**Goal**: Score changed components before/after to quantify upgrade quality. Produce a before/after evaluation delta, not just "looks good."
+**Goal**: Verify the changed behavior and preserve useful knowledge.
 
-**Step 1**: For each modified agent or skill, run evaluation:
+**Step 1**: Review the diff for lost domain rules, broken references, and changed contracts. Run the relevant existing tests and required repository checks. Reuse passing results for unchanged inputs.
 
-Call the Skill tool with `agent-evaluation`. Evaluate the modified files against a baseline when available; otherwise, produce absolute scores.
+Call the Skill tool with `verification-before-completion`. It owns verification requirements. Use `agent-evaluation` when the user requests scoring or a concrete uncertainty needs it; model scoring is not a default release gate.
 
 ```
 VALIDATION REPORT
 =================
 
 [component]
-  Before: [score if available, or "N/A (new)"]
-  After:  [score]
-  Delta:  [+N or new]
-  Grade:  [A/B/C/F]
+  Checks: [commands and results]
+  Findings: [fixed issues or remaining gaps]
+  Evaluation: [scores if requested, otherwise not run]
 ```
 
-**Step 2**: Flag any regressions (after < before). For regressions:
-- Report to user
-- Suggest fix or revert
-- Present the regression to the user and let them decide whether to revert
+**Step 2**: Fix confirmed regressions within scope and rerun affected checks. Report unresolved findings; blocking correctness or security issues prevent delivery. Ask when resolving a finding requires an unapproved tradeoff.
 
-**Step 3**: For hook modifications, run syntax check:
-```bash
-python3 -m py_compile hooks/[modified-hook].py
-```
-
-**Gate**: All components pass syntax check. No regressions (or user acknowledges regressions). Proceed to Phase 6.
+**Gate**: Required checks pass and blocking findings are resolved. Proceed to Phase 6.
 
 ---
 
 ### Phase 6: DEPLOY
 
-**Goal**: Commit changes, sync to ~/.claude, create PR.
+**Goal**: Deliver through the authorized PR workflow, then sync the accepted revision.
 
-**Step 1**: Sync modified files to `~/.claude/` (agents, skills, hooks, commands that were modified).
+**Step 1**: Call the Skill tool with `pr-workflow`. It owns selective staging, review reuse, commit, push, CI, and merge requirements. Stage only this task's files. Do not install an unreviewed feature branch into the live user configuration.
 
+**Step 2**: If merge and local sync are authorized, verify all required checks on the current PR head, merge, and update the designated integration checkout. With parallel workers, the coordinator alone syncs the main checkout and installed configuration. If the request ends at PR creation, report that state and leave live installation unchanged.
+
+**Step 3**: After successful integration and sync, record the accepted revision from that checkout:
 ```bash
-python3 hooks/sync-to-user-claude.py  # or call the sync script directly
-```
-
-**Step 2**: Stage and commit:
-```bash
-git add agents/ skills/ hooks/ commands/
-git commit -m "chore: system upgrade — [brief description of trigger]
-
-[List top 3 changes from Phase 3 plan]"
-```
-
-**Step 3**: Push and create PR using `pr-pipeline` skill.
-
-**Step 4**: Record upgrade SHA so the next run diffs incrementally:
-```bash
-python3 ~/.claude/scripts/upgrade-diff.py --record
+python3 scripts/upgrade-diff.py --record
 ```
 
 **Step 5**: Produce completion summary:
@@ -285,13 +261,13 @@ Changes Applied:
   ✓ [N] Important
   ○ [N] Minor (skipped/deferred)
 
-Validation: [N/N components scored, mean grade [X]]
+Validation: [required checks and results; scores only if requested]
 
 Next Upgrade: Run /system-upgrade after next Claude Code release
               or when /retro routing shows several weak routes
 ```
 
-**Gate**: Changes committed, synced to ~/.claude, PR created, and upgrade SHA recorded. Pipeline complete.
+**Gate**: The authorized delivery state is confirmed. Record the upgrade SHA only after integration and sync. Report a PR-only result as awaiting integration.
 
 ---
 

--- a/skills/workflow/references/system-upgrade.md
+++ b/skills/workflow/references/system-upgrade.md
@@ -282,19 +282,19 @@ Cause: Dispatched agent didn't finish all changes in its group.
 Solution: Re-dispatch with more specific instructions. Check agent output for errors. Continue to Phase 5 only after the required work is complete.
 
 ### Error: "Regression detected in Phase 5"
-Cause: A component scored lower after modification.
-Solution: Show the diff of changes to the user. Offer to revert the specific component and wait for the user's choice.
+Cause: Validation found a regression.
+Solution: Follow Phase 5: fix within scope, rerun affected checks, and ask only about an unapproved tradeoff.
 
 ### Error: "Sync script not found"
 Cause: `hooks/sync-to-user-claude.py` missing or broken.
-Solution: Manually copy modified files to `~/.claude/` equivalent directories. Report the broken sync script for future fixing.
+Solution: Report the failed sync and repair the configured installer within scope. Preserve custom files and verify the accepted revision was installed before claiming deployment.
 
 ---
 
 ## References
 
 - [agent-upgrade](./agent-upgrade.md) - Bottom-up single-agent upgrade pipeline (complements this top-down system pipeline)
-- [agent-evaluation](../../skills/meta/agent-evaluation/SKILL.md) - Objective scoring skill used in Phase 5 validation
-- [pr-pipeline](./pr-pipeline.md) - PR creation pipeline used in Phase 6 deploy
-- [upgrade-diff.py](../../scripts/upgrade-diff.py) - Incremental diff script for scoping audits
-- [learning-db.py](../../scripts/learning-db.py) - Read-only CLI for routing telemetry (`route-health`, `route-stats`)
+- [agent-evaluation](../../meta/agent-evaluation/SKILL.md) - Objective scoring skill used in Phase 5 validation
+- [pr-workflow](../../process/pr-workflow/SKILL.md) - PR creation pipeline used in Phase 6 deploy
+- [upgrade-diff.py](../../../scripts/upgrade-diff.py) - Incremental diff script for scoping audits
+- [learning-db.py](../../../scripts/learning-db.py) - Read-only CLI for routing telemetry (`route-health`, `route-stats`)


### PR DESCRIPTION
## Summary

Upgrade workflows now continue within existing user authorization and keep their plan presentations. Worktree preflight checks Git identity instead of requiring a `.claude/worktrees/` directory name.

## Changes

- Preserve interactive and plan-only modes while removing repeat approval and reread defaults.
- Use required verification for routine upgrades; retain optional evaluation scoring.
- Deliver through the PR workflow before syncing the accepted revision into live configuration.
- Accept assigned branches already checked out in external worktrees, reject main checkouts and branches held elsewhere, and preserve collided branches.

## Notes

Routing selection, frontmatter, phase names, and reporting formats are unchanged. Validated with 65 workflow/preflight tests, 7 reference-loading tests, both affected agent reference validators, and Ruff lint/format. The preflight integration test covers external paths with spaces, misleading directory names, and branch ownership.
