### PR TITLE
Inherit session models and keep handoffs proportional

### DIFF
--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -117,6 +117,7 @@ _STACK_RE = re.compile(r"\bstack=\{([a-z0-9:_,-]*)\}", re.IGNORECASE)
 # token, nothing read it, so evidence_route_decisions.pipeline stayed NULL.
 _PIPELINE_RE = re.compile(r"\bpipeline=([a-z0-9-]+)", re.IGNORECASE)
 
+# Requested selection, not an observed worker model. inherit means no override.
 # Model token on the marker line: `model=opus` or `model=-`. GPT-5.6 selections
 # carry an additional `effort=` token. Valid values match build-dispatch.py;
 # `model=-` or absent => null. Old markers remain readable.
@@ -124,6 +125,7 @@ _MODEL_RE = re.compile(r"\bmodel=([a-z0-9.-]+|-)", re.IGNORECASE)
 _EFFORT_RE = re.compile(r"\beffort=(low|medium|high|xhigh|max)", re.IGNORECASE)
 _VALID_MODELS = frozenset(
     {
+        "inherit",
         "sonnet",
         "opus",
         "codex",
@@ -360,7 +362,7 @@ def parse_model_effort(marker_text: str) -> str | None:
     """
     line = _marker_line(marker_text)
     model = parse_model(line)
-    if model is None:
+    if model is None or model == "inherit":
         return None
     match = _EFFORT_RE.search(line)
     return match.group(1).lower() if match else None

--- a/hooks/tests/test_pretool_dispatch_spec_gate.py
+++ b/hooks/tests/test_pretool_dispatch_spec_gate.py
@@ -223,3 +223,14 @@ def test_registered_in_pretooluse_agent_group() -> None:
     groups = [g for g in settings["hooks"]["PreToolUse"] if g.get("matcher") == "Agent"]
     commands = [h["command"] for g in groups for h in g["hooks"]]
     assert any("pretool-dispatch-spec-gate.py" in c for c in commands)
+
+
+@pytest.mark.parametrize("mode", ["summary", "files", "none"])
+@pytest.mark.parametrize("complexity", ["medium", "complex"])
+def test_inherited_model_context_modes_pass_strict_gate(mode, complexity):
+    build = _load_build_dispatch()
+    decision = {**_decision(complexity), "model": "inherit", "context_mode": mode}
+    prompt = build.build_preamble(decision, SETTINGS, repo_root=ROOT)
+    result = _run(_event(prompt), env={"DISPATCH_SPEC_GATE_MODE": "deny"})
+    assert result.returncode == 0
+    assert result.stdout == ""

--- a/scripts/build-dispatch.py
+++ b/scripts/build-dispatch.py
@@ -949,7 +949,11 @@ def build_gather_block(decision: dict, repo_root: Path | None = None) -> str:
     repo_root = repo_root or default_repo_root()
     mode = context_mode(decision)
     if mode == "none":
-        return ""
+        return (
+            "## Repo state\n\n"
+            "Gathering omitted by context_mode=none. No fresh repository state is asserted; "
+            "use supplied evidence only while its inputs remain valid, or inspect the relevant state. "
+        ).rstrip()
     spec = decision.get("task_spec") or {}
     tokens = _path_candidates(spec.get("files")) if isinstance(spec, dict) else []
     sections: list[str] = []

--- a/scripts/build-dispatch.py
+++ b/scripts/build-dispatch.py
@@ -26,7 +26,9 @@ truth for every one of them ("LLMs orchestrate, programs execute"):
   6. Repo state block (on by default; `--no-gather` skips): git status, diff
      stat, last 5 commits, and a head or def/class outline of each existing
      file in `task_spec.files`. Wrapped in <untrusted-content>, capped at
-     12000 chars, sensitive paths skipped. Fixed repo state => fixed bytes.
+     12000 chars, sensitive paths skipped. context_mode=summary omits file
+     excerpts; none omits gathered context. Neither bypasses path validation.
+     Fixed repo state => fixed bytes.
   7. The four MANDATORY verbatim injections: reference loading,
      completeness, Dense-Complete Writing, base instructions.
   8. Optional worktree rules and LOCAL-ONLY block, on flags.
@@ -41,11 +43,12 @@ Input schema (missing optional fields degrade gracefully — block omitted):
                                                    // complex; trivial => skill=-
       "complexity": "medium",                      // required enum, case-insensitive:
                                                    // trivial|simple|medium|complex
-      "model": "opus",                             // required for medium/complex;
+      "model": "inherit",                          // required for medium/complex;
                                                    // optional for trivial/simple
-      "model_policy": "standard",                  // optional GPT-5.6 auto lane
-      "model_effort": "high",                      // required for explicit GPT-5.6 picks
+      "model_policy": null,                        // optional policy, not with inherit
+      "model_effort": null,                        // explicit picks only, not with inherit
       "manual_model_override": false,               // required for non-default GPT picks
+      "context_mode": "summary",                   // summary|files|none; default files
       "health": {"confidence": 0.72, "n": 6,       // optional; absent/blank
                  "failure": 0, "action": "keep",   // confidence => health=-
                  "alts": ["a:b", "c:d"]},
@@ -132,7 +135,8 @@ THINKING_FAST = "Prioritize responding quickly rather than thinking deeply. When
 THINKING_SLOW = "Think carefully and step-by-step before responding; this problem is harder than it looks."
 
 WORKTREE_RULES = (
-    "Worktree rules: Verify CWD contains .claude/worktrees/. Create feature branch before edits. "
+    "Worktree rules: Use the assigned worktree; verify its Git registration, top-level, and feature branch before edits. "
+    "Follow skills/meta/do/references/worktree-rules.md. "
     "Skip task_plan.md. Stage specific files only."
 )
 
@@ -155,7 +159,7 @@ VALID_COMPLEXITY = ("trivial", "simple", "medium", "complex")
 GPT_56_MODELS = ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")
 GPT_56_EFFORTS = ("low", "medium", "high", "xhigh", "max")
 LEGACY_GPT_55 = "gpt-5.5"
-VALID_MODELS = ("sonnet", "opus", "codex", LEGACY_GPT_55, *GPT_56_MODELS)
+VALID_MODELS = ("inherit", "sonnet", "opus", "codex", LEGACY_GPT_55, *GPT_56_MODELS)
 VALID_PROVIDERS = ("anthropic", "openai", "other")
 ANTHROPIC_MODELS = ("opus", "sonnet")
 
@@ -184,9 +188,8 @@ AUTO_POLICIES_BY_PROVIDER = {
 # Backward compat: tests and the OpenAI-only path reference this name.
 AUTO_MODEL_POLICIES = OPENAI_AUTO_POLICIES
 VALID_MODEL_POLICIES = ("deterministic", *AUTO_MODEL_POLICIES)
-# Complexities that REQUIRE an explicit model pick (omission inherits the
-# session main-loop model — a silent cost leak when an expensive model
-# orchestrates). Trivial/simple may omit (inheritance risk is acceptable).
+# Medium/complex must choose a model or explicitly request inheritance.
+# Trivial/simple retain their existing optional-model behavior.
 _MODEL_REQUIRED_COMPLEXITY = frozenset({"medium", "complex"})
 VALID_ACTIONS = ("keep", "demote", "tiebreak")
 
@@ -235,6 +238,7 @@ _TASK_SPEC_FIELDS = (
     ("constraints", "Constraints"),
     ("acceptance", "Acceptance criteria"),
     ("files", "Relevant file locations"),
+    ("ownership", "File ownership"),
     ("decisions", "Decisions"),
     ("prior_results", "Prior results"),
     ("gaps", "Gaps"),
@@ -298,6 +302,11 @@ def resolve_model_selection(decision: dict, provider: str = "anthropic") -> tupl
     policy = str(policy_raw).strip().lower() if policy_raw is not None else ""
     model = _optional_model(decision.get("model"))
     effort = _optional_effort(decision.get("model_effort"))
+
+    if model == "inherit":
+        if policy or effort is not None or manual:
+            raise InputError("model='inherit' cannot include model_policy, model_effort, or manual_model_override=true")
+        return "inherit", None
 
     if policy:
         if policy not in VALID_MODEL_POLICIES:
@@ -611,7 +620,7 @@ def build_marker(decision: dict) -> str:
                 f"'model' is required for complexity={complexity} "
                 f"(allowed: {'/'.join(VALID_MODELS)}). "
                 f"Omitting model inherits the session main-loop model — "
-                f"set it explicitly per the Model Selection table."
+                f"set model=inherit deliberately or select a supported model/policy."
             )
         parts.append("model=-")
 
@@ -654,6 +663,19 @@ def build_marker(decision: dict) -> str:
         parts.append(f"fallback={fallback_reason}")
 
     return " ".join(parts)
+
+
+def build_model_instruction(decision: dict) -> str:
+    """Tell the dispatcher how to inherit; markers describe requests, not execution."""
+    model, _effort = resolve_model_selection(decision, _resolve_provider(decision))
+    if model != "inherit":
+        return ""
+    return (
+        "Model selection: inherit the current session model. Omit model and reasoning-effort "
+        "overrides from the agent tool call; do not pass the literal 'inherit' as a model name. "
+        "If the harness cannot inherit, report that limitation instead of choosing a substitute. "
+        "The route marker records this request; the actual worker model is unknown unless the harness reports it."
+    )
 
 
 def build_thinking(decision: dict) -> str:
@@ -910,6 +932,14 @@ def _cap_block(text: str, cap: int = _GATHER_BLOCK_CAP) -> str:
     return f"{body[: cap - len(note) - len(tail)]}{note}{tail}"
 
 
+def context_mode(decision: dict) -> str:
+    """Select optional repo context; legacy callers keep file excerpts."""
+    mode = decision.get("context_mode", "files")
+    if mode not in ("summary", "files", "none"):
+        raise InputError("'context_mode' must be summary/files/none")
+    return mode
+
+
 def build_gather_block(decision: dict, repo_root: Path | None = None) -> str:
     """Repo state block: git status, diff stat, recent log, then per-file outlines.
 
@@ -917,6 +947,9 @@ def build_gather_block(decision: dict, repo_root: Path | None = None) -> str:
     failure. Deterministic for a fixed repo state.
     """
     repo_root = repo_root or default_repo_root()
+    mode = context_mode(decision)
+    if mode == "none":
+        return ""
     spec = decision.get("task_spec") or {}
     tokens = _path_candidates(spec.get("files")) if isinstance(spec, dict) else []
     sections: list[str] = []
@@ -931,7 +964,7 @@ def build_gather_block(decision: dict, repo_root: Path | None = None) -> str:
         else:
             sections.append("\n".join([f"### {label}", *(lines or ["(empty)"])]))
     gathered = 0
-    for index, token in enumerate(tokens):
+    for index, token in enumerate(tokens if mode == "files" else []):
         if gathered >= _GATHER_MAX_FILES:
             sections.append(f"[{len(tokens) - index} more files not shown]")
             break
@@ -969,6 +1002,7 @@ def build_preamble(
     if not isinstance(flags, dict):
         raise InputError("'flags' must be an object")
 
+    context_mode(decision)
     marker = build_marker(decision)
     skill_calls = render_skill_calls(decision)
     thinking = build_thinking(decision)
@@ -977,6 +1011,7 @@ def build_preamble(
     validate_spec_paths(decision, repo_root)
     blocks = [
         marker,
+        build_model_instruction(decision),
         skill_calls,
         thinking,
         token_line,

--- a/scripts/tests/test_build_dispatch.py
+++ b/scripts/tests/test_build_dispatch.py
@@ -1241,6 +1241,8 @@ def test_none_context_does_not_gather_or_drop_task_spec(tmp_path):
     with patch.object(bd, "_run_git", side_effect=AssertionError("unexpected gather")):
         prompt = bd.build_preamble(decision, repo_root=tmp_path)
     assert bd._GATHER_HEADING not in prompt
+    assert "## Repo state" in prompt
+    assert "No fresh repository state is asserted" in prompt
     assert "Complete authorized task" in prompt
     assert bd.INJ_BASE_INSTRUCTIONS in prompt
 

--- a/scripts/tests/test_build_dispatch.py
+++ b/scripts/tests/test_build_dispatch.py
@@ -760,9 +760,9 @@ def _parse_cell(cell: str) -> tuple[int, float, int, int]:
 
 
 def _documented_claude_points() -> dict[tuple[str, str], tuple[int, float, int, int]]:
-    """Read the Anthropic-lane benchmark table out of skills/meta/do/SKILL.md."""
+    """Read the retained Anthropic benchmark table."""
     points: dict[tuple[str, str], tuple[int, float, int, int]] = {}
-    for line in _DO_SKILL_PATH.read_text(encoding="utf-8").splitlines():
+    for line in (_DO_SKILL_PATH.parent / "references" / "model-selection.md").read_text(encoding="utf-8").splitlines():
         cells = [c.strip() for c in line.strip().strip("|").split("|")]
         model = _DOCUMENTED_ROW_MODELS.get(cells[0]) if cells else None
         if model is None or len(cells) != len(_DOCUMENTED_EFFORTS) + 1:
@@ -824,14 +824,14 @@ def test_opus_max_requires_manual_override():
 
 
 def test_supplied_points_match_the_documented_benchmark_table():
-    """The table in skills/meta/do/SKILL.md is the source; this dict must track it.
+    """The table in the model-selection reference is the source; this dict must track it.
 
     Without this the dict is a private copy: an edit to the doc table (or a
     deleted row) leaves the Opus-5-has-no-benchmark-point check above asserting
     against numbers the toolkit no longer publishes.
     """
     assert _documented_claude_points() == SUPPLIED_CLAUDE_POINTS, (
-        "SUPPLIED_CLAUDE_POINTS drifted from the Anthropic-lane table in skills/meta/do/SKILL.md"
+        "SUPPLIED_CLAUDE_POINTS drifted from the model-selection reference"
     )
 
 
@@ -1175,3 +1175,77 @@ def test_decisions_prior_results_gaps_emit_in_order():
     block = bd.build_task_spec(_decision(task_spec=spec))
     labels = [line.split(":**")[0] for line in block.splitlines() if line.startswith("**")]
     assert labels == ["**Intent", "**Decisions", "**Prior results", "**Gaps", "**Operator context"]
+
+
+@pytest.mark.parametrize("complexity", bd.VALID_COMPLEXITY)
+@pytest.mark.parametrize("provider", bd.VALID_PROVIDERS)
+def test_inherit_requests_no_tool_override_and_round_trips(complexity, provider):
+    prompt = _preamble(_decision(model="inherit", complexity=complexity, provider=provider))
+    marker = prompt.splitlines()[0]
+    assert recorder.parse_model(marker) == "inherit"
+    assert recorder.parse_model_effort(marker) is None
+    assert "effort=" not in marker
+    assert "Omit model and reasoning-effort overrides from the agent tool call" in prompt
+    assert "actual worker model is unknown unless the harness reports it" in prompt
+    assert "do not pass the literal 'inherit' as a model name" in prompt
+
+
+@pytest.mark.parametrize(
+    "conflict",
+    [{"model_policy": "standard"}, {"model_effort": "high"}, {"manual_model_override": True}],
+)
+def test_inherit_rejects_conflicting_overrides(conflict):
+    with pytest.raises(bd.InputError, match="cannot include"):
+        _preamble(_decision(model="inherit", **conflict))
+
+
+def test_inherit_never_records_effort_even_from_malformed_external_marker():
+    marker = "[do-route] agent=claude skill=quick complexity=simple model=inherit effort=high health=-"
+    assert recorder.parse_model(marker) == "inherit"
+    assert recorder.parse_model_effort(marker) is None
+
+
+def test_summary_context_omits_file_reads_but_preserves_handoff(tmp_path):
+    source = tmp_path / "source.md"
+    source.write_text("File contents should only appear in files mode.\n")
+    spec = {
+        "request_verbatim": "Make the requested fix.",
+        "intent": "Fix this file.",
+        "constraints": "Do not publish.",
+        "acceptance": "The link resolves.",
+        "files": "source.md",
+        "ownership": "Only source.md",
+        "prior_results": "Evidence: report.md at the reviewed revision.",
+    }
+    decision = _decision(task_spec=spec, context_mode="summary")
+    with patch.object(bd, "_gather_file", side_effect=AssertionError("unneeded file read")):
+        prompt = bd.build_preamble(decision, repo_root=tmp_path)
+    assert "File contents should only appear" not in prompt
+    for value in spec.values():
+        assert value in prompt
+    assert bd._GATHER_SECURITY in prompt
+    assert "</untrusted-content>" in prompt
+    assert bd.INJ_REFERENCE_LOADING in prompt
+    files = bd.build_preamble({**decision, "context_mode": "files"}, repo_root=tmp_path)
+    assert "File contents should only appear" in files
+
+
+@pytest.mark.parametrize("mode", ["summary", "none"])
+def test_reduced_context_still_rejects_missing_paths(tmp_path, mode):
+    with pytest.raises(bd.InputError, match="does not exist"):
+        bd.build_preamble(_decision(context_mode=mode, task_spec={"files": "missing.py"}), repo_root=tmp_path)
+
+
+def test_none_context_does_not_gather_or_drop_task_spec(tmp_path):
+    decision = _decision(context_mode="none", task_spec={"intent": "Complete authorized task"})
+    with patch.object(bd, "_run_git", side_effect=AssertionError("unexpected gather")):
+        prompt = bd.build_preamble(decision, repo_root=tmp_path)
+    assert bd._GATHER_HEADING not in prompt
+    assert "Complete authorized task" in prompt
+    assert bd.INJ_BASE_INSTRUCTIONS in prompt
+
+
+@pytest.mark.parametrize("mode", ["", "everything", None, [], {}])
+def test_invalid_context_mode_fails_even_without_gather(mode):
+    with pytest.raises(bd.InputError, match="context_mode"):
+        _preamble(_decision(context_mode=mode))

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -287,7 +287,7 @@ anti-rationalization-core always + verification-checklist (code/debug) + anti-ra
 1. Keep `request_verbatim` unchanged. State this worker's `intent`, `constraints` (including authority), `files`, ownership, and `acceptance`.
 2. Include decisions, prior results, and gaps when they affect this assignment. Summarize findings and link durable evidence; quote exact text only when its wording matters. Do not copy the whole investigation into every handoff.
 3. Verify named paths. Add excerpts only when they explain a decision or let the worker act; the builder validates paths even when gathering is off.
-4. Use `context_mode: "summary"` for current git status, diff stat, and recent commits. Use `files` when initial excerpts help, or `none` when the worker already has valid context. The legacy default is `files`; `--no-gather` also suppresses gathered output. These options never omit the supplied Task Spec or required injections.
+4. Use `context_mode: "summary"` for current git status, diff stat, and recent commits. Use `files` when initial excerpts help, or `none` when the worker already has valid context. The legacy default is `files`. Mode `none` retains a notice that no fresh state was gathered, so the handoff envelope stays complete. Legacy `--no-gather` removes that envelope too; use `none` for Medium+ handoffs. Context modes never omit the supplied Task Spec or required injections.
 
 Reuse reads only while their source and task context remain unchanged; a fresh worker needs access to the relevant content or references. For worker transitions, use `session-handoff`. Verification evidence follows `verification-before-completion`; repeat checks when their inputs or relevant environment change, not just because a new phase starts.
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -348,8 +348,8 @@ Medium+ must provide `model: "inherit"`, a supported explicit model, or a policy
 
 | Verbs | Mode |
 |---|---|
-| list/count/extract/inventory/search/check/find/grep | Scripts when deterministic; otherwise harness-native low-risk readers → harness-native high-risk synth |
-| review/audit/assess/analyze/debug/investigate/evaluate | Single harness-native high-risk agent |
+| list/count/extract/inventory/search/check/find/grep | Scripts when deterministic; otherwise readers → synthesis, inheriting the session model |
+| review/audit/assess/analyze/debug/investigate/evaluate | Single agent, inheriting the session model |
 
 Simple/Medium: direct. Feature-branch; mods commit. `isolation:"worktree"`→`flags.worktree`. Non-org: 3 reviews→fix→PR. Org: confirm git.
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -70,7 +70,7 @@ Parallel FIRST: 2+ failures / 3+ subtasks → multiple Agent tools. Research→r
 
 The routing manifest (`scripts/routing-manifest.py`) is the runtime form; `docs/routing-map.md` is the human-readable committed form of the same data. Both are generated from frontmatter, so frontmatter is the single source of truth. CI checks staleness via `scripts/generate-routing-map.py --check`.
 
-Resolve SDIR (this probe also identifies the harness for Phase 4 Model Selection), then read the manifest (hash-gated cache or regenerate):
+Resolve SDIR to locate installed scripts, then read the manifest (hash-gated cache or regenerate). This probe does not identify the active session model or provider:
 
 ```bash
 SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
@@ -282,12 +282,14 @@ Check `pairs_with` before stacking. Skills with built-in verification gates may 
 
 anti-rationalization-core always + verification-checklist (code/debug) + anti-rationalization-review + anti-rationalization-security + anti-rationalization-testing; external: **untrusted-content-handling**. Max: load `verification-before-completion` references/anti-rationalization-enforcement.md.
 
-**Step G: GATHER (Simple+)** — fill the Task Spec before the Gate. Every thin handoff failure in the handoff context A/B (`scripts/routing-ab-results/handoff-context-v1/VERDICT.md`) was a fact the router knew and did not hand over.
+**Step G: GATHER (Simple+)** — fill the Task Spec before the Gate.
 
-1. `request_verbatim`: the user's message, unchanged.
-2. `constraints`: `git status -sb`, `git log -1 --format=%h`, and the CLAUDE.md rules that apply. Fill `decisions` (Phase 3 triage outcomes), `prior_results` (prior agent reports, verbatim), and `gaps` (what you could not find) as their own keys.
-3. `files`: Glob/Grep every named or implied file; record each as `path:lines — excerpt`.
-4. `acceptance`: commands with expected output, `command → expected`.
+1. Keep `request_verbatim` unchanged. State this worker's `intent`, `constraints` (including authority), `files`, ownership, and `acceptance`.
+2. Include decisions, prior results, and gaps when they affect this assignment. Summarize findings and link durable evidence; quote exact text only when its wording matters. Do not copy the whole investigation into every handoff.
+3. Verify named paths. Add excerpts only when they explain a decision or let the worker act; the builder validates paths even when gathering is off.
+4. Use `context_mode: "summary"` for current git status, diff stat, and recent commits. Use `files` when initial excerpts help, or `none` when the worker already has valid context. The legacy default is `files`; `--no-gather` also suppresses gathered output. These options never omit the supplied Task Spec or required injections.
+
+Reuse reads only while their source and task context remain unchanged; a fresh worker needs access to the relevant content or references. For worker transitions, use `session-handoff`. Verification evidence follows `verification-before-completion`; repeat checks when their inputs or relevant environment change, not just because a new phase starts.
 
 **Gate**: Enhancements applied, Task Spec filled. Phase 4.
 
@@ -312,84 +314,35 @@ python3 "$SDIR/build-dispatch.py" --json '{
   "agent": "<agent>", "skill": "<skill; omit when agent-only>",
   "pipeline": "<pipeline; omit when Phase 2 returned null>",
   "complexity": "<trivial|simple|medium|complex>",
-  "model": "<sonnet|opus|codex|gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna>",
-  "model_policy": "<low-risk|standard|high-risk|max-power>",
-  "model_effort": "<low|medium|high|xhigh|max>",
+  "model": "inherit",
+  "context_mode": "summary",
   "provider": "<anthropic|openai|other>",
   "manual_model_override": false,
   "health": "-",
   "fallback_reason": "<REQUIRED when agent=general-purpose; omit otherwise>",
   "stack": ["s1","s2"],
   "task_spec": {"request_verbatim": "<user message, unchanged>", "intent": "...",
-                "constraints": "<branch, HEAD, CLAUDE.md rules>",
+                "constraints": "<applicable rules, limits, and authorization>",
                 "decisions": "...", "prior_results": "...", "gaps": "...",
                 "acceptance": "<command> → <expected>",
-                "files": "<path:line-range — excerpt>", "operator_context": "..."},
+                "files": "<owned paths; optional line ranges>", "ownership": "<worker scope>",
+                "operator_context": "..."},
   "flags": {"worktree": false, "local_only": false, "thinking_override": null},
   "token_remaining": 480000
 }'
 ```
 
-`agent`/`skill`/`complexity`: Phase 2 (null→`-`). `pipeline`: the Phase 2 pick, passed so the marker carries it; omit when null. The builder validates each name against its index, then emits this exact action contract once per callable skill, primary first with ordered stack de-duplication: `Call the Skill tool with \`skill-name\`.` Shared-pattern stack entries remain prompt injections. Agents and pipelines stay out of Skill-tool calls. Fan-out: one call per agent, same `skill`/`pipeline`. `model`: **required Medium+** (`-` trivial/simple). Use `model_policy` for automatic selection — resolves via the harness-native provider lane. `model_effort` identifies the benchmark point; advisory for Claude lanes (Agent tool has no per-call effort). `provider`: harness detection (anthropic|openai|other, default anthropic). A manual model change must set both `manual_model_override=true` and `model_effort`; never inherit the policy effort silently. `health`: `-` (in-context weights read retired — `docs/route-loop-validation.md`). `fallback_reason`: **required when `agent=general-purpose`** — the one-line reason from the Agent-greediness gate, any prose; `build-dispatch.py` slugifies it and appends `fallback=<slug>` to the marker so every fallback is countable. Dispatch fails without it. `stack`: Phase 3. `task_spec`: mandatory Simple+ (Phase 3 Step G); the script rejects an empty spec at Medium+; creation+"match ADR". `thinking_override`: slow=security/arch/5+files; fast=lookups.
+`agent`/`skill`/`complexity`: Phase 2 (null→`-`). `pipeline`: the Phase 2 pick, passed so the marker carries it; omit when null. The builder validates each name against its index, then emits this exact action contract once per callable skill, primary first with ordered stack de-duplication: `Call the Skill tool with \`skill-name\`.` Shared-pattern stack entries remain prompt injections. Agents and pipelines stay out of Skill-tool calls. Fan-out: one call per agent, same `skill`/`pipeline`. `model`: **required Medium+**; use `inherit` by default. Explicit overrides follow `references/model-selection.md`. `provider` describes the active harness (anthropic|openai|other), not an installed directory. `health`: `-` (in-context weights read retired — `docs/route-loop-validation.md`). `fallback_reason`: **required when `agent=general-purpose`** — the one-line reason from the Agent-greediness gate, any prose; `build-dispatch.py` slugifies it and appends `fallback=<slug>` to the marker so every fallback is countable. Dispatch fails without it. `stack`: Phase 3. `task_spec`: mandatory Simple+ (Phase 3 Step G); the script rejects an empty spec at Medium+; creation+"match ADR". `thinking_override`: slow=security/arch/5+files; fast=lookups.
 
 `[do-route]` = SOLE signal for `routing-decision-recorder`. Sub-agents excluded.
 
 **Fallback:** `[do-route] agent={a} skill={s|-} complexity={c}[ pipeline={p}] health=- model={m|-}`, Task Spec inline, dispatch.
 
-**Model Selection (ADR `model-selection-policy`).**
+**Model selection.** Default to `model: "inherit"`. Omit `model_policy`, `model_effort`, and tool-level model/effort overrides. Do not pass the word `inherit` to an agent tool as a model name. This uses the current session model when the harness supports inheritance. If it cannot, report the limitation rather than silently selecting another model.
 
-**Harness-native routing.** The SDIR probe (Phase 2 pre-route) identifies the harness: `~/.claude` → provider `anthropic`, `~/.codex` → provider `openai`, `~/.hermes`/`.factory`/`.reasonix` → provider `other`. Default when absent: `anthropic` (Claude Code is primary). Each provider lane has its own automatic policy table; cross-provider dispatch is manual-only (explicit tool invocation, never a silent default).
+The marker records the requested selection, not an observed worker model. The actual model remains unknown unless the harness reports it. Do not infer session identity from installed script directories or historical model tables.
 
-Run deterministic work with scripts, not an LLM. Three decision axes: (1) the owner-directed default — Opus 5 (`opus`) for every Anthropic-lane task class. The dispatch model and the session model are separate choices: `build-dispatch.py` accepts only `opus`/`sonnet` for the Anthropic lane, so re-check this default when the session model changes. (2) DeepSWE Pass@1 / cost / tokens / steps — agentic task completion rate, the quantitative source for models that have been measured. (3) Owner-observed felt quality — opus > gpt-5.5 (marginal). Benchmark ties or near-ties resolve in favor of felt quality. Cells: `Pass@1 / cost / output tokens / steps`; cost = avg USD per task, written as a plain number — slash-command templating substitutes dollar-digit positional parameters in this injected body, so a literal dollar sign before a digit corrupts on every argful invocation. Higher Pass@1 better, other three lower-is-better. Opus 5 has no DeepSWE run yet, so its cells read `n/a — not yet benchmarked` and its pts/USD cannot be computed until it is measured; it is selected on the owner-directive grounds above, not on a benchmark figure.
-
-**Start low, escalate on miss.** Task-class tables are ceilings by risk class, not starting points. Default = lowest tier whose risk class matches; escalate one tier only when output misses the acceptance bar. High tiers cost 3-6x per Pass@1 point where measured (see the OpenAI lane's pts/$ column; the Anthropic lane's is pending an Opus 5 benchmark) — pre-paying for xhigh/max "to be safe" wastes the 200 USD/month plan budget. Fan-out rule: parallel readers use the lane's low-risk point; one synthesis agent may run one tier higher. User-facing output (docs, prose, reviews the owner reads, design) leans opus one tier up from the task class; bulk/mechanical/parse-heavy work is where the OpenAI lane's cheaper points earn their keep (under Codex harness or explicit cross-provider call).
-
-**Anthropic lane** (automatic under Claude Code). Effort is advisory — recorded in marker as model@effort for telemetry; the Agent tool has no per-call effort parameter.
-
-Current default: **Opus 5** (`opus`) at every task class, by owner directive.
-
-| Variant | max | xhigh | high | medium | low |
-|---|---|---|---|---|---|
-| Opus-5 (current default, unmeasured) | n/a — not yet benchmarked | n/a — not yet benchmarked | n/a — not yet benchmarked | n/a — not yet benchmarked | n/a — not yet benchmarked |
-| Opus-4.8 (prior measurement) | 59 / 13.22 / 135k / 120 | 54 / 8.01 / 86k / 95 | 52 / 4.28 / 50k / 73 | 49 / 3.44 / 41k / 66 | 41 / 2.29 / 29k / 54 |
-| Sonnet-5 (prior measurement) | 54 / 26.40 / 214k / 268 | 50 / 11.89 / 121k / 186 | 48 / 7.43 / 87k / 147 | 40 / 4.08 / 57k / 108 | 31 / 2.19 / 36k / 77 |
-
-| Task class | Selection | pts/$ | Why |
-|---|---|---|---|
-| deterministic | no LLM | — | Run the script directly. |
-| low-risk | `opus` / `low` | n/a | Current session model, owner-directed default; effort floor per start-low. |
-| standard | `opus` / `medium` | n/a | Current session model, owner-directed default; one tier up for standard work. |
-| high-risk | `opus` / `high` | n/a | Current session model, owner-directed default; high effort for risk-bearing work. |
-| max-power | `opus` / `xhigh` | n/a | Current session model, owner-directed default; `manual_model_override=true`; state justification in task_spec intent. |
-
-Effort selection still follows **start low, escalate on miss** — the effort column is a ceiling by risk class, and a miss against the acceptance bar is what buys the next tier. Opus 5 at `max` stays manual-only pending measurement. Sonnet-5 and Opus-4.8 points are the manual-only ones: they need `manual_model_override=true` plus `model_effort`, and stay available for cost, latency, context-window, and fan-out breadth constraints the benchmark does not measure. Haiku is retired.
-
-**OpenAI lane** (automatic under Codex CLI).
-
-| Variant | max | xhigh | high | medium | low |
-|---|---|---|---|---|---|
-| GPT-5.6 Sol | 73 / 8.39 / 60k / 61 | 71 / 4.70 / 41k / 44 | 69 / 3.47 / 28k / 37 | 61 / 1.86 / 18k / 31 | 45 / 1.07 / 11k / 23 |
-| GPT-5.6 Terra | 70 / 4.95 / 72k / 76 | 60 / 2.13 / 40k / 43 | 54 / 1.13 / 22k / 34 | 35 / 0.58 / 12k / 25 | 24 / 0.43 / 8.6k / 21 |
-| GPT-5.6 Luna | 67 / 3.03 / 73k / 102 | 57 / 1.54 / 45k / 71 | 44 / 0.78 / 26k / 49 | 11 / 0.22 / 8.2k / 24 | 2 / 0.07 / 3.1k / 12 |
-| GPT-5.5 legacy | n/a | 67 / 7.23 / 46k / 82 | 64 / 5.10 / 31k / 62 | 54 / 2.75 / 20k / 46 | 27 / 1.20 / 9.4k / 28 |
-
-| Task class | Selection | pts/$ | Why |
-|---|---|---|---|
-| deterministic | no LLM | — | Run the script directly. |
-| low-risk | `gpt-5.6-terra` / `high` | 47.8 | 54 Pass@1 at 1.13, 22k tokens, 34 steps. |
-| standard | `gpt-5.6-sol` / `high` | 19.9 | 69 Pass@1 at 3.47, 28k tokens, 37 steps. |
-| high-risk | `gpt-5.6-sol` / `xhigh` | 15.1 | 71 Pass@1 at 4.70, 41k tokens, 44 steps. |
-| max-power | `gpt-5.6-sol` / `max` | 8.7 | 73 Pass@1 at 8.39, 60k tokens, 61 steps; `manual_model_override=true`; state justification in task_spec intent. |
-
-All GPT-5.5 choices are manual-only. Off-policy GPT-5.6 points (Sol medium/low, Terra max/xhigh/medium/low, all Luna) are manual-only — some are cost trade-offs, not dominated; use with `manual_model_override=true` for a stated constraint.
-
-**Other harnesses** (provider=`other`): `model_policy` is unavailable — choose the highest non-dominated Pass@1 point among models the harness exposes, applying the same start-low-escalate-on-miss discipline. Set model explicitly.
-
-**Cross-provider escalation** — manual only, never automatic. Escalating anthropic → sol is a cost/limits lever or independent-second-opinion lever, not a quality upgrade. Under Claude Code, codex-wrapper dispatches (`codex` skill, pr-workflow codex second-opinion review) remain valid as EXPLICIT tools — deliberate cross-provider calls, not defaults. Escalation targets: anthropic max-power miss → sol/xhigh or sol/max (second opinion, cheaper per point); openai max-power miss → opus/xhigh (the Anthropic-lane default). Manual-pick ordering among legacy/manual points: opus-4.8 above gpt-5.5 where they otherwise tie.
-
-**Coordinator model.** The main-thread coordinator routes and evaluates but never executes; its cost is input-dominated (largest context, short outputs), and DeepSWE Pass@1 measures execution it never does. Picks: anthropic harness → `opus` (Opus 5, the session model — it replaces the prior sonnet pick); openai harness → `gpt-5.6-terra`/`high`. Safe because deterministic scripts (pre-route, manifest, build-dispatch, health weights) absorb routing complexity and the learning loop bounds misroute cost. Downgrade the anthropic coordinator to `sonnet` only as a deliberate plan-limit measure. Session model is set via harness config (`/model`), not per-turn.
-
-**Medium+ must set a model or policy.** Codex prompts stay read-only and public unless a task requires otherwise.
+Medium+ must provide `model: "inherit"`, a supported explicit model, or a policy. For a deliberate override, load `references/model-selection.md`; existing provider policies and explicit choices remain supported. Use scripts for deterministic work. Change model or effort only for a concrete task need or a missed acceptance criterion. Session configuration stays under the user's control. Codex prompts stay read-only and public unless the task requires otherwise.
 
 **Complex (3+ sources):**
 
@@ -400,7 +353,7 @@ All GPT-5.5 choices are manual-only. Off-policy GPT-5.6 points (Sol medium/low, 
 
 Simple/Medium: direct. Feature-branch; mods commit. `isolation:"worktree"`→`flags.worktree`. Non-org: 3 reviews→fix→PR. Org: confirm git.
 
-**Step 3: Multi-part / fan-out** — deps sequential; independent parallel (max 10). Phase 2 `agents` → ONE `build-dispatch.py` call and ONE Agent dispatch per agent: N agents = N calls = N markers, one marker each. Emit the parallel Agent calls in a single message. Each agent gets its own `files` and scope. Sequential stages pass the previous report verbatim as `prior_results`; the synthesis agent gets every stage report. Packing several markers into one Bash/Workflow script keeps them recorded but forfeits route-fit scoring, which reads a lone marker per event.
+**Step 3: Multi-part / fan-out** — deps sequential; independent parallel (max 10). Phase 2 `agents` → ONE `build-dispatch.py` call and ONE Agent dispatch per agent: N agents = N calls = N markers, one marker each. Emit the parallel Agent calls in a single message. Each agent gets its own `files` and scope. Sequential stages pass relevant prior results and evidence locations; synthesis receives the findings and access to evidence from every required stage. Packing several markers into one Bash/Workflow script keeps them recorded but forfeits route-fit scoring, which reads a lone marker per event.
 
 **Step 4: Auto-Pipeline Fallback** (no match, Simple+) — `auto-pipeline`. None → closest+`objective-loop`. Never empty skill.
 

--- a/skills/meta/do/references/model-selection.md
+++ b/skills/meta/do/references/model-selection.md
@@ -1,0 +1,49 @@
+# Explicit model selection
+
+Use this reference only when choosing a model override or a legacy policy. The normal `/do` dispatch uses `model: "inherit"` and omits model and effort overrides from the agent tool call. The builder produces a prompt; the dispatcher must apply that instruction.
+
+## Compatibility policies
+
+`scripts/build-dispatch.py` owns accepted model names, provider policies, effort validation, and override rules. Existing explicit selections remain supported. Set `provider` from the actual harness, not the first installed scripts directory. `model_policy` selects the provider's existing table below; provider `other` requires a supported explicit model instead. `deterministic` means run a script, not an LLM dispatch.
+
+- `max-power` requires `manual_model_override=true`.
+- A model different from a policy's choice requires `manual_model_override=true` and an explicit `model_effort`.
+- Explicit GPT-5.6 choices require effort and manual override. GPT-5.5 and Sonnet require manual override. Opus/max requires manual override.
+- Claude effort is advisory when the agent tool has no effort parameter. Only pass options the tool supports.
+- Cross-provider calls remain deliberate, explicit choices. Do not infer a cross-provider upgrade from historical scores.
+- A route marker records a requested selection. It does not establish which model ran. Report actual identity only from harness execution metadata.
+
+## Historical measurements and policy tables
+
+These are the previously recorded DeepSWE measurements and compatibility policy choices, retained for reference. They are not measurements of the current session or proof of current model quality. Opus 5 was an owner-directed default without a DeepSWE run. The builder's named policies retain those choices for existing callers; inheritance does not use them.
+
+Measurement cells: Pass@1 / average USD per task / output tokens / steps. Higher Pass@1 is better; the other values are lower-is-better. Policy tables show the historical rationale; “current session model” below refers to the original policy context, not the active session.
+
+| Variant | max | xhigh | high | medium | low |
+|---|---|---|---|---|---|
+| Opus-5 (current default, unmeasured) | n/a — not yet benchmarked | n/a — not yet benchmarked | n/a — not yet benchmarked | n/a — not yet benchmarked | n/a — not yet benchmarked |
+| Opus-4.8 (prior measurement) | 59 / 13.22 / 135k / 120 | 54 / 8.01 / 86k / 95 | 52 / 4.28 / 50k / 73 | 49 / 3.44 / 41k / 66 | 41 / 2.29 / 29k / 54 |
+| Sonnet-5 (prior measurement) | 54 / 26.40 / 214k / 268 | 50 / 11.89 / 121k / 186 | 48 / 7.43 / 87k / 147 | 40 / 4.08 / 57k / 108 | 31 / 2.19 / 36k / 77 |
+
+| Task class | Selection | pts/$ | Why |
+|---|---|---|---|
+| deterministic | no LLM | — | Run the script directly. |
+| low-risk | `opus` / `low` | n/a | Current session model, owner-directed default; effort floor per start-low. |
+| standard | `opus` / `medium` | n/a | Current session model, owner-directed default; one tier up for standard work. |
+| high-risk | `opus` / `high` | n/a | Current session model, owner-directed default; high effort for risk-bearing work. |
+| max-power | `opus` / `xhigh` | n/a | Current session model, owner-directed default; `manual_model_override=true`; state justification in task_spec intent. |
+
+| Variant | max | xhigh | high | medium | low |
+|---|---|---|---|---|---|
+| GPT-5.6 Sol | 73 / 8.39 / 60k / 61 | 71 / 4.70 / 41k / 44 | 69 / 3.47 / 28k / 37 | 61 / 1.86 / 18k / 31 | 45 / 1.07 / 11k / 23 |
+| GPT-5.6 Terra | 70 / 4.95 / 72k / 76 | 60 / 2.13 / 40k / 43 | 54 / 1.13 / 22k / 34 | 35 / 0.58 / 12k / 25 | 24 / 0.43 / 8.6k / 21 |
+| GPT-5.6 Luna | 67 / 3.03 / 73k / 102 | 57 / 1.54 / 45k / 71 | 44 / 0.78 / 26k / 49 | 11 / 0.22 / 8.2k / 24 | 2 / 0.07 / 3.1k / 12 |
+| GPT-5.5 legacy | n/a | 67 / 7.23 / 46k / 82 | 64 / 5.10 / 31k / 62 | 54 / 2.75 / 20k / 46 | 27 / 1.20 / 9.4k / 28 |
+
+| Task class | Selection | pts/$ | Why |
+|---|---|---|---|
+| deterministic | no LLM | — | Run the script directly. |
+| low-risk | `gpt-5.6-terra` / `high` | 47.8 | 54 Pass@1 at 1.13, 22k tokens, 34 steps. |
+| standard | `gpt-5.6-sol` / `high` | 19.9 | 69 Pass@1 at 3.47, 28k tokens, 37 steps. |
+| high-risk | `gpt-5.6-sol` / `xhigh` | 15.1 | 71 Pass@1 at 4.70, 41k tokens, 44 steps. |
+| max-power | `gpt-5.6-sol` / `max` | 8.7 | 73 Pass@1 at 8.39, 60k tokens, 61 steps; `manual_model_override=true`; state justification in task_spec intent. |


### PR DESCRIPTION
## Summary

Dispatches can now inherit the current session model without substituting an older named model. Handoffs can include a git summary or omit redundant gathered context with an explicit no-fresh-state notice while retaining the task, constraints, file ownership, acceptance criteria, and path validation.

## Changes

- Add explicit `model: "inherit"`, reject conflicting model settings, and direct the dispatcher to omit model and effort overrides. Existing explicit choices and policies remain supported.
- Record `inherit` as the requested selection in the existing route marker. It is not a claim about the actual worker model; actual identity requires harness evidence.
- Add `context_mode: summary|files|none`; `/do` uses summary, and legacy builder callers retain file excerpts. Keep validation, required injections, sensitive-path handling, and the gathered-content trust boundary.
- Replace mandatory copied reports/excerpts with relevant findings and evidence locations. Keep the original request, scope, constraints, and acceptance criteria.
- Move historical model tables into an on-demand reference. Preserve capability selection, routing metadata, phase banners, and reporting ceremony.
- Replace the worktree path-substring instruction with Git worktree/branch checks and the canonical worktree rules.

## Notes

The builder produces a dispatch prompt; the calling harness applies model inheritance. Unsupported inheritance must be reported rather than replaced silently. No model A/B runs or task-cost tracking were added. Local validation: 357 builder, skill-call, marker, reference, and strict handoff-gate tests passed; Ruff and changed-skill content checks passed. The worktree instruction aligns with the separately updated canonical worktree preflight.
